### PR TITLE
docs: improve installation for all user journeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@
 
 ```bash
 npm install -g @cdot65/prisma-airs-cli
+airs --version
 ```
 
-Requires **Node.js >= 20**. Also available as a [Docker image](https://github.com/cdot65/prisma-airs-cli/pkgs/container/prisma-airs-cli).
+Requires **Node.js >= 20**. Also available via `pnpm add -g`, `npx`, or as a [Docker image](https://github.com/cdot65/prisma-airs-cli/pkgs/container/prisma-airs-cli). See the [installation guide](https://cdot65.github.io/prisma-airs-cli/getting-started/installation/) for details.
 
 ## Quick Start
 

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -36,11 +36,23 @@ Edit `.env` with your credentials:
 !!! note "Tests run without credentials"
     Unit and integration tests use MSW mocks — you only need real credentials for E2E tests and actual AIRS operations.
 
+## Register `airs` command
+
+To make the `airs` binary available globally from your source checkout:
+
+```bash
+pnpm run build
+pnpm link --global
+airs --version   # 1.0.1
+```
+
+After making code changes, re-run `pnpm run build` for the linked `airs` command to reflect them. `pnpm run dev` doesn't require a build step.
+
 ## Development Commands
 
 | Command | What it does |
 |---------|-------------|
-| `pnpm run dev` | Run CLI via tsx (any subcommand) |
+| `pnpm run dev` | Run CLI via tsx — no build needed (e.g. `pnpm run dev runtime scan ...`) |
 | `pnpm run build` | Compile TypeScript to `dist/` |
 | `pnpm test` | Run all tests |
 | `pnpm run test:watch` | Watch mode |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,15 +16,46 @@ Before you begin, make sure you have:
 
 ## Install from npm
 
-```bash
-npm install -g @cdot65/prisma-airs-cli
-```
+=== "npm (recommended)"
+
+    ```bash
+    npm install -g @cdot65/prisma-airs-cli
+    ```
+
+=== "pnpm"
+
+    ```bash
+    pnpm add -g @cdot65/prisma-airs-cli
+    ```
+
+    !!! warning "pnpm global bin PATH"
+        pnpm's global bin directory is often not in your `PATH` by default. If `airs` is not found after install, run:
+        ```bash
+        pnpm setup
+        ```
+        Then restart your terminal. This adds pnpm's global bin to your shell profile.
 
 Verify the installation:
 
 ```bash
-airs --version
-airs --help
+$ airs --version
+1.0.1
+
+$ airs --help
+Usage: airs [options] [command]
+
+CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red
+teaming, model security scanning, profile audits
+
+Options:
+  -V, --version   output the version number
+  -h, --help      display help for command
+
+Commands:
+  runtime         Runtime prompt scanning against AIRS profiles
+  redteam         AI Red Team scan operations
+  model-security  AI Model Security operations — groups, rules, scans
+  help [command]  display help for command
 ```
 
 !!! tip "Try without installing"
@@ -142,24 +173,33 @@ cp .env.example .env
 
 Requires **pnpm >= 8** (`corepack enable` to install).
 
-=== "Development"
+### Running from source
 
-    Run directly via `tsx` — no build step needed:
+=== "Development (tsx, no build)"
 
     ```bash
     pnpm run dev runtime topics generate
     ```
 
-=== "Production"
-
-    Compile TypeScript, then run the output:
+=== "Production (compiled)"
 
     ```bash
     pnpm run build
     node dist/cli/index.js runtime topics generate
     ```
 
-Verify everything works:
+### Register the `airs` command locally
+
+To make the `airs` command available in your terminal from a source checkout:
+
+```bash
+pnpm run build
+pnpm link --global
+```
+
+Then `airs --version`, `airs runtime scan`, etc. work anywhere. Changes require re-running `pnpm run build` to take effect.
+
+### Verify setup
 
 ```bash
 pnpm test          # All tests (no AIRS creds needed)


### PR DESCRIPTION
## Summary
- Add pnpm global install tab with PATH warning and `pnpm setup` fix
- Show real `--version` and `--help` output so users can verify installation
- Add `pnpm link --global` instructions for source installs
- Update local-setup.md with `airs` command registration section
- Update README with verification step and link to full install guide

## Test plan
- [x] `pnpm run build` clean
- [x] 537 tests pass
- [ ] Verify mkdocs renders tabbed install sections correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)