### PR TITLE
feat: add model-security install command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,8 @@ tests/
 ### Model Security (`src/airs/modelsecurity.ts`)
 - `SdkModelSecurityService` wraps `ModelSecurityClient` for security groups, rules, scans, labels, PyPI auth
 - snake_case (SDK) → camelCase normalization via `normalizeGroup()`, `normalizeRule()`, etc.
-- CLI: `airs model-security {groups,rules,rule-instances,scans,labels,pypi-auth}`
+- CLI: `airs model-security {groups,install,labels,pypi-auth,rule-instances,rules,scans}`
+- `install` auto-detects uv (uses `uv init` + `uv add`) or falls back to `python3 -m venv` + `pip install`
 - Groups: CRUD per source type (LOCAL, S3, GCS, AZURE, HUGGING_FACE)
 - Rule instances: state = BLOCKING | ALLOWING | DISABLED
 - Scans: create/list/get with evaluations, violations, files sub-queries

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,19 @@
 # Release Notes
 
+## v1.0.5
+
+### New
+
+- **`airs model-security install`** — one-command setup of the `model-security-client` Python package from AIRS private PyPI
+    - Auto-detects `uv` (uses `uv init` + `uv add`) or falls back to `python3 -m venv` + `pip install`
+    - `--extras` for source type selection: `all`, `aws`, `gcp`, `azure`, `artifactory`, `gitlab`
+    - `--dir` to specify project directory
+    - `--dry-run` to preview commands
+
+### Fixed
+
+- CLI help menus now display subcommands in alphabetical order across all command groups
+
 ## v1.0.0
 
 First release of Prisma AIRS CLI (renamed from `daystrom`). See [MIGRATION.md](https://github.com/cdot65/prisma-airs-cli/blob/main/MIGRATION.md) for upgrade steps.
@@ -37,10 +51,11 @@ airs redteam targets ...     # Target CRUD
 airs redteam prompt-sets ... # Prompt set CRUD
 airs redteam prompts ...     # Individual prompt CRUD
 airs redteam properties ...  # Property management
-airs model-security groups   # Security group CRUD
-airs model-security rules    # Rule browsing
-airs model-security scans    # Scan operations
-airs model-security labels   # Label management
+airs model-security groups    # Security group CRUD
+airs model-security install   # Install model-security-client Python package
+airs model-security labels    # Label management
+airs model-security rules     # Rule browsing
+airs model-security scans     # Scan operations
 ```
 
 ### Breaking Changes (from daystrom)

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -43,7 +43,7 @@ To make the `airs` binary available globally from your source checkout:
 ```bash
 pnpm run build
 pnpm link --global
-airs --version   # 1.0.2
+airs --version   # 1.0.5
 ```
 
 After making code changes, re-run `pnpm run build` for the linked `airs` command to reflect them. `pnpm run dev` doesn't require a build step.

--- a/docs/examples/model-security.md
+++ b/docs/examples/model-security.md
@@ -446,9 +446,26 @@ airs model-security labels delete <scanUuid> --keys env,team
 
 ---
 
+## Install Model Security Client
+
+Install the `model-security-client` Python package with a single command. Authenticates via your management credentials and handles project/venv setup automatically.
+
+```bash
+# Install with all extras — auto-detects uv or falls back to python3 venv + pip
+airs model-security install
+
+# Install with only GCP extras into a custom directory
+airs model-security install --extras gcp --dir my-scanner
+
+# Preview what would run without executing
+airs model-security install --dry-run
+```
+
+If `uv` is on PATH, the command runs `uv init` + `uv add`. Otherwise, it creates a `python3 -m venv` and uses `pip install`.
+
 ## PyPI Authentication
 
-Get authentication URL for Google Artifact Registry (used for model scanning tools).
+Get the raw authentication URL for Google Artifact Registry. For a fully automated setup, use `airs model-security install` instead.
 
 ```bash
 airs model-security pypi-auth

--- a/docs/features/model-security.md
+++ b/docs/features/model-security.md
@@ -10,8 +10,9 @@ The `airs model-security` command group provides access to Model Security operat
 - **Rules** — browse available security rules (read-only, managed by AIRS)
 - **Rule Instances** — configure rule enforcement within groups (BLOCKING, ALLOWING, DISABLED)
 - **Scans** — create, list, and inspect model security scans with evaluations, violations, and file results
+- **Install** — one-command setup of the `model-security-client` Python package (auto-detects uv/pip, creates venv)
 - **Labels** — organize scans with key-value labels
-- **PyPI Auth** — get authentication for Google Artifact Registry
+- **PyPI Auth** — get raw authentication URL for Google Artifact Registry
 
 ## Concepts
 
@@ -34,6 +35,16 @@ When a group is created, AIRS automatically provisions rule instances for all co
 | `DISABLED` | Rule is skipped entirely |
 
 ## Workflow
+
+### 0. Install the Python SDK
+
+```bash
+# Auto-detects uv or pip, creates a project/venv, installs the package
+airs model-security install
+
+# Or install with only AWS extras
+airs model-security install --extras aws
+```
 
 ### 1. List available groups
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,7 +39,7 @@ Verify the installation:
 
 ```bash
 $ airs --version
-1.0.2
+1.0.5
 
 $ airs --help
 Usage: airs [options] [command]

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -74,6 +74,9 @@ airs redteam categories
 Manage ML model supply chain security — scan model artifacts for threats.
 
 ```bash
+# Install the model-security-client Python package
+airs model-security install
+
 # List security groups
 airs model-security groups list
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -657,13 +657,14 @@ Usage: airs model-security [options] [command]
 AI Model Security operations — groups, rules, scans
 
 Commands:
-  groups          Manage security groups
-  rules           Browse security rules
-  rule-instances  Manage rule instances in groups
-  scans           Model security scan operations
-  labels          Manage scan labels
-  pypi-auth       Get PyPI authentication URL for Google Artifact Registry
-  help [command]  display help for command
+  groups             Manage security groups
+  install [options]  Install the model-security-client Python package from AIRS PyPI
+  labels             Manage scan labels
+  pypi-auth          Get PyPI authentication URL for Google Artifact Registry
+  rule-instances     Manage rule instances in groups
+  rules              Browse security rules
+  scans              Model security scan operations
+  help [command]     display help for command
 ```
 
 ### model-security groups
@@ -712,6 +713,39 @@ airs model-security groups delete <uuid>
   "description": "Scans local model files",
   "rule_configurations": {}
 }
+```
+
+### model-security install
+
+Install the `model-security-client` Python package from AIRS private PyPI. Authenticates via your management credentials, fetches a time-limited PyPI URL, and runs the install end-to-end.
+
+- If `uv` is found: creates a project with `uv init` and installs via `uv add`
+- If `uv` is not found: creates a venv with `python3 -m venv` and installs via `pip`
+
+```bash
+airs model-security install [options]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--extras <type>` | Source type extras: `all`, `aws`, `gcp`, `azure`, `artifactory`, `gitlab` (default: `all`) |
+| `--dir <path>` | Directory to create the project in (default: `model-security`) |
+| `--dry-run` | Print the commands without executing |
+
+#### Examples
+
+```bash
+# Install with all extras (auto-detects uv or pip)
+airs model-security install
+
+# Install with AWS support only
+airs model-security install --extras aws
+
+# Preview commands without executing
+airs model-security install --dry-run
+
+# Install into a custom directory
+airs model-security install --dir my-scanner
 ```
 
 ### model-security rules
@@ -852,7 +886,8 @@ airs model-security labels values <key> [--limit <n>]
 
 ### model-security pypi-auth
 
-Get PyPI authentication URL for Google Artifact Registry.
+Get PyPI authentication URL for Google Artifact Registry. For a fully automated install, use [`model-security install`](#model-security-install) instead.
 
 ```bash
 airs model-security pypi-auth
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/prisma-airs-cli",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Add `airs model-security install` — one-command setup of `model-security-client` Python package from AIRS private PyPI
- Auto-detects `uv` (uses `uv init` + `uv add`) or falls back to `python3 -m venv` + `pip install`
- Supports `--extras` (all/aws/gcp/azure/artifactory/gitlab), `--dir`, `--dry-run`
- Update all docs: CLI reference, features, examples, quick-start, release notes, CLAUDE.md
- Bump version to 1.0.5

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] 526 tests pass
- [x] `mkdocs build --strict` passes
- [x] `airs model-security install --help` shows correct options
- [ ] Manual: `airs model-security install --dry-run` previews correct commands
- [ ] Manual: `airs model-security install` completes end-to-end with valid creds

🤖 Generated with [Claude Code](https://claude.com/claude-code)