### PR TITLE
feat: --output flag on all list commands

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## v1.0.6
+
+### New
+
+- **`--output` flag on all list commands** — unified structured output across all 3 command groups
+    - Formats: `pretty` (default), `table`, `csv`, `json`, `yaml`
+    - Supported on: `runtime profiles list`, `runtime topics list`, `runtime api-keys list`, `runtime customer-apps list`, `runtime deployment-profiles list`, `runtime dlp-profiles list`, `runtime scan-logs query`, `redteam list`, `redteam targets list`, `redteam prompt-sets list`, `redteam properties list`, `model-security groups list`, `model-security rules list`, `model-security scans list`
+
 ## v1.0.5
 
 ### New

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -43,7 +43,7 @@ To make the `airs` binary available globally from your source checkout:
 ```bash
 pnpm run build
 pnpm link --global
-airs --version   # 1.0.5
+airs --version   # 1.0.6
 ```
 
 After making code changes, re-run `pnpm run build` for the linked `airs` command to reflect them. `pnpm run dev` doesn't require a build step.

--- a/docs/features/model-security.md
+++ b/docs/features/model-security.md
@@ -50,6 +50,9 @@ airs model-security install --extras aws
 
 ```bash
 airs model-security groups list
+
+# Structured output (table, csv, json, yaml)
+airs model-security groups list --output table
 ```
 
 ### 2. Browse security rules

--- a/docs/features/red-team.md
+++ b/docs/features/red-team.md
@@ -154,6 +154,10 @@ airs redteam list --status COMPLETED --type CUSTOM
 
 # Filter by target
 airs redteam list --target <uuid> --limit 20
+
+# Structured output (table, csv, json, yaml)
+airs redteam list --output json
+airs redteam targets list --output csv
 ```
 
 ### 7. Abort a running scan

--- a/docs/features/runtime-security.md
+++ b/docs/features/runtime-security.md
@@ -153,6 +153,28 @@ prompt,action,category,triggered,scan_id,report_id
 
 ---
 
+## Structured Output
+
+All list commands support `--output <format>` for machine-readable output:
+
+```bash
+# Table with box-drawing characters
+airs runtime profiles list --output table
+
+# CSV (pipe to file or other tools)
+airs runtime api-keys list --output csv
+
+# JSON (pretty-printed)
+airs runtime topics list --output json
+
+# YAML
+airs runtime scan-logs query --interval 24 --unit hours --output yaml
+```
+
+Supported formats: `pretty` (default), `table`, `csv`, `json`, `yaml`.
+
+---
+
 ## Configuration Management
 
 Prisma AIRS CLI exposes full CRUD over AIRS runtime configuration resources via `airs runtime` subcommand groups. All config management commands require Management API credentials (`PANW_MGMT_CLIENT_ID`, `PANW_MGMT_CLIENT_SECRET`, `PANW_MGMT_TSG_ID`).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,7 +39,7 @@ Verify the installation:
 
 ```bash
 $ airs --version
-1.0.5
+1.0.6
 
 $ airs --help
 Usage: airs [options] [command]

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -4,6 +4,8 @@ Binary: `airs` (or `pnpm run dev` during development).
 
 Three top-level command groups: `runtime`, `redteam`, `model-security`.
 
+All list commands support `--output <format>` for structured output: `pretty` (default), `table`, `csv`, `json`, `yaml`.
+
 ```
 $ airs --help
 Usage: airs [options] [command]
@@ -182,7 +184,7 @@ airs runtime profiles audit <profileName> [options]
 
 | Subcommand | Flags |
 |------------|-------|
-| `list` | `--limit <n>` (default 100), `--offset <n>` (default 0) |
+| `list` | `--limit <n>` (default 100), `--offset <n>` (default 0), `--output <format>` |
 | `create` | `--config <path>` (required) |
 | `update <profileId>` | `--config <path>` (required) |
 | `delete <profileId>` | `--force`, `--updated-by <email>` |
@@ -224,7 +226,7 @@ airs runtime topics runs
 
 | Subcommand | Flags |
 |------------|-------|
-| `list` | `--limit <n>` (default 100), `--offset <n>` (default 0) |
+| `list` | `--limit <n>` (default 100), `--offset <n>` (default 0), `--output <format>` |
 | `create` | `--config <path>` (required) |
 | `update <topicId>` | `--config <path>` (required) |
 | `delete <topicId>` | `--force`, `--updated-by <email>` |
@@ -330,7 +332,7 @@ airs runtime api-keys delete <apiKeyName> --updated-by <email>
 
 | Subcommand | Flags |
 |------------|-------|
-| `list` | `--limit <n>` (default 100) |
+| `list` | `--limit <n>` (default 100), `--output <format>` |
 | `create` | `--config <path>` (required) |
 | `regenerate <apiKeyId>` | `--interval <n>`, `--unit <unit>` (e.g. `hours`, `days`, `months`), `--updated-by <email>` |
 | `delete <apiKeyName>` | `--updated-by <email>` |
@@ -348,7 +350,7 @@ airs runtime customer-apps delete <appName> --updated-by <email>
 
 | Subcommand | Flags |
 |------------|-------|
-| `list` | `--limit <n>` (default 100) |
+| `list` | `--limit <n>` (default 100), `--output <format>` |
 | `get <appName>` | — |
 | `update <appId>` | `--config <path>` (required) |
 | `delete <appName>` | `--updated-by <email>` |
@@ -364,7 +366,7 @@ airs runtime deployment-profiles list --unactivated
 
 | Subcommand | Flags |
 |------------|-------|
-| `list` | `--unactivated` |
+| `list` | `--unactivated`, `--output <format>` |
 
 ### runtime dlp-profiles
 
@@ -372,7 +374,12 @@ DLP profile listing (read-only).
 
 ```bash
 airs runtime dlp-profiles list
+airs runtime dlp-profiles list --output json
 ```
+
+| Subcommand | Flags |
+|------------|-------|
+| `list` | `--output <format>` |
 
 ### runtime scan-logs
 
@@ -384,7 +391,7 @@ airs runtime scan-logs query --interval <n> --unit <unit> [options]
 
 | Subcommand | Flags |
 |------------|-------|
-| `query` | `--interval <n>` (required), `--unit <unit>` (required, e.g. `hours`), `--filter <filter>` (all, benign, threat; default: all), `--page <n>` (default: 1), `--page-size <n>` (default: 50) |
+| `query` | `--interval <n>` (required), `--unit <unit>` (required, e.g. `hours`), `--filter <filter>` (all, benign, threat; default: all), `--page <n>` (default: 1), `--page-size <n>` (default: 50), `--output <format>` |
 
 ---
 
@@ -469,6 +476,7 @@ airs redteam list [options]
 | `--type <type>` | all | Filter: STATIC, DYNAMIC, CUSTOM |
 | `--target <uuid>` | all | Filter by target UUID |
 | `--limit <n>` | `10` | Max results |
+| `--output <format>` | `pretty` | Output format: pretty, table, csv, json, yaml |
 
 #### Example Output — `redteam list`
 
@@ -520,7 +528,7 @@ airs redteam targets update-profile <uuid> --config p.json
 
 | Subcommand | Flags |
 |------------|-------|
-| `list` | — |
+| `list` | `--output <format>` |
 | `get <uuid>` | — |
 | `create` | `--config <path>` (required), `--validate` |
 | `update <uuid>` | `--config <path>` (required), `--validate` |
@@ -559,7 +567,7 @@ airs redteam prompt-sets upload <uuid> prompts.csv     # Upload CSV
 
 | Subcommand | Flags |
 |------------|-------|
-| `list` | — |
+| `list` | `--output <format>` |
 | `get <uuid>` | — |
 | `create` | `--name` (required), `--description` |
 | `update <uuid>` | `--name`, `--description` |
@@ -681,7 +689,7 @@ airs model-security groups delete <uuid>
 
 | Subcommand | Flags |
 |------------|-------|
-| `list` | `--source-types <types>`, `--search <query>`, `--sort-field <field>`, `--sort-dir <dir>`, `--enabled-rules <uuids>`, `--limit <n>` (default 20) |
+| `list` | `--source-types <types>`, `--search <query>`, `--sort-field <field>`, `--sort-dir <dir>`, `--enabled-rules <uuids>`, `--limit <n>` (default 20), `--output <format>` |
 | `get <uuid>` | — |
 | `create` | `--config <path>` (required) |
 | `update <uuid>` | `--name <name>`, `--description <desc>` |
@@ -759,7 +767,7 @@ airs model-security rules get <uuid>
 
 | Subcommand | Flags |
 |------------|-------|
-| `list` | `--source-type <type>`, `--search <query>`, `--limit <n>` (default 20) |
+| `list` | `--source-type <type>`, `--search <query>`, `--limit <n>` (default 20), `--output <format>` |
 | `get <uuid>` | — |
 
 #### Example Output — `rules list`
@@ -840,7 +848,7 @@ airs model-security scans files <scanUuid> [--type <type>] [--result <result>] [
 
 | Subcommand | Flags |
 |------------|-------|
-| `list` | `--eval-outcome <outcome>`, `--source-type <type>`, `--scan-origin <origin>`, `--search <query>`, `--limit <n>` (default 20) |
+| `list` | `--eval-outcome <outcome>`, `--source-type <type>`, `--scan-origin <origin>`, `--search <query>`, `--limit <n>` (default 20), `--output <format>` |
 | `get <uuid>` | — |
 | `create` | `--config <path>` (required) |
 | `evaluations <scanUuid>` | `--limit <n>` (default 20) |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/prisma-airs-cli",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/commands/modelsecurity.ts
+++ b/src/cli/commands/modelsecurity.ts
@@ -5,6 +5,7 @@ import type { Command } from 'commander';
 import { SdkModelSecurityService } from '../../airs/modelsecurity.js';
 import { loadConfig } from '../../config/loader.js';
 import {
+  type OutputFormat,
   renderError,
   renderEvaluationDetail,
   renderEvaluationList,
@@ -79,9 +80,11 @@ export function registerModelSecurityCommand(program: Command): void {
     .option('--sort-dir <dir>', 'Sort direction (asc, desc)')
     .option('--enabled-rules <uuids>', 'Filter by enabled rule UUIDs (comma-separated)')
     .option('--limit <n>', 'Max results', '20')
+    .option('--output <format>', 'Output format: pretty, table, csv, json, yaml', 'pretty')
     .action(async (opts) => {
       try {
-        renderModelSecurityHeader();
+        const fmt = opts.output as OutputFormat;
+        if (fmt === 'pretty') renderModelSecurityHeader();
         const service = await createService();
         const result = await service.listGroups({
           sourceTypes: opts.sourceTypes
@@ -95,7 +98,7 @@ export function registerModelSecurityCommand(program: Command): void {
             : undefined,
           limit: Number.parseInt(opts.limit, 10),
         });
-        renderGroupList(result.groups);
+        renderGroupList(result.groups, fmt);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);
@@ -448,16 +451,18 @@ export function registerModelSecurityCommand(program: Command): void {
     .option('--source-type <type>', 'Filter by source type')
     .option('--search <query>', 'Search by name or UUID')
     .option('--limit <n>', 'Max results', '20')
+    .option('--output <format>', 'Output format: pretty, table, csv, json, yaml', 'pretty')
     .action(async (opts) => {
       try {
-        renderModelSecurityHeader();
+        const fmt = opts.output as OutputFormat;
+        if (fmt === 'pretty') renderModelSecurityHeader();
         const service = await createService();
         const result = await service.listRules({
           sourceType: opts.sourceType,
           searchQuery: opts.search,
           limit: Number.parseInt(opts.limit, 10),
         });
-        renderRuleList(result.rules);
+        renderRuleList(result.rules, fmt);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);
@@ -492,9 +497,11 @@ export function registerModelSecurityCommand(program: Command): void {
     .option('--scan-origin <origin>', 'Filter by scan origin')
     .option('--search <query>', 'Search scans')
     .option('--limit <n>', 'Max results', '20')
+    .option('--output <format>', 'Output format: pretty, table, csv, json, yaml', 'pretty')
     .action(async (opts) => {
       try {
-        renderModelSecurityHeader();
+        const fmt = opts.output as OutputFormat;
+        if (fmt === 'pretty') renderModelSecurityHeader();
         const service = await createService();
         const result = await service.listScans({
           evalOutcome: opts.evalOutcome,
@@ -503,7 +510,7 @@ export function registerModelSecurityCommand(program: Command): void {
           search: opts.search,
           limit: Number.parseInt(opts.limit, 10),
         });
-        renderMsScanList(result.scans);
+        renderMsScanList(result.scans, fmt);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);

--- a/src/cli/commands/redteam.ts
+++ b/src/cli/commands/redteam.ts
@@ -4,6 +4,8 @@ import { SdkPromptSetService } from '../../airs/promptsets.js';
 import { SdkRedTeamService } from '../../airs/redteam.js';
 import { loadConfig } from '../../config/loader.js';
 import {
+  OUTPUT_FORMATS,
+  type OutputFormat,
   renderAttackList,
   renderCategories,
   renderCustomAttackList,
@@ -97,9 +99,11 @@ export function registerRedteamCommand(program: Command): void {
     .option('--type <type>', 'Filter by job type (STATIC, DYNAMIC, CUSTOM)')
     .option('--target <uuid>', 'Filter by target UUID')
     .option('--limit <n>', 'Max results', '10')
+    .option('--output <format>', 'Output format: pretty, table, csv, json, yaml', 'pretty')
     .action(async (opts) => {
       try {
-        renderRedteamHeader();
+        const fmt = opts.output as OutputFormat;
+        if (fmt === 'pretty') renderRedteamHeader();
         const service = await createService();
         const scans = await service.listScans({
           status: opts.status,
@@ -107,7 +111,7 @@ export function registerRedteamCommand(program: Command): void {
           targetId: opts.target,
           limit: Number.parseInt(opts.limit, 10),
         });
-        renderScanList(scans);
+        renderScanList(scans, fmt);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);
@@ -122,12 +126,14 @@ export function registerRedteamCommand(program: Command): void {
   promptSets
     .command('list')
     .description('List custom prompt sets')
-    .action(async () => {
+    .option('--output <format>', 'Output format: pretty, table, csv, json, yaml', 'pretty')
+    .action(async (opts) => {
       try {
-        renderRedteamHeader();
+        const fmt = opts.output as OutputFormat;
+        if (fmt === 'pretty') renderRedteamHeader();
         const service = await createPromptSetService();
         const sets = await service.listPromptSets();
-        renderPromptSetList(sets);
+        renderPromptSetList(sets, fmt);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);
@@ -339,12 +345,14 @@ export function registerRedteamCommand(program: Command): void {
   properties
     .command('list')
     .description('List property names')
-    .action(async () => {
+    .option('--output <format>', 'Output format: pretty, table, csv, json, yaml', 'pretty')
+    .action(async (opts) => {
       try {
-        renderRedteamHeader();
+        const fmt = opts.output as OutputFormat;
+        if (fmt === 'pretty') renderRedteamHeader();
         const service = await createPromptSetService();
         const names = await service.getPropertyNames();
-        renderPropertyNames(names);
+        renderPropertyNames(names, fmt);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);
@@ -525,12 +533,14 @@ export function registerRedteamCommand(program: Command): void {
   targets
     .command('list')
     .description('List configured red team targets')
-    .action(async () => {
+    .option('--output <format>', 'Output format: pretty, table, csv, json, yaml', 'pretty')
+    .action(async (opts) => {
       try {
-        renderRedteamHeader();
+        const fmt = opts.output as OutputFormat;
+        if (fmt === 'pretty') renderRedteamHeader();
         const service = await createService();
         const list = await service.listTargets();
-        renderTargetList(list);
+        renderTargetList(list, fmt);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -9,6 +9,8 @@ import { loadConfig } from '../../config/loader.js';
 import { loadBulkScanState, saveBulkScanState } from '../bulk-scan-state.js';
 import { parseInputFile } from '../parse-input.js';
 import {
+  OUTPUT_FORMATS,
+  type OutputFormat,
   renderApiKeyDetail,
   renderApiKeyList,
   renderCustomerAppDetail,
@@ -74,14 +76,16 @@ export function registerRuntimeCommand(program: Command): void {
     .command('list')
     .description('List API keys')
     .option('--limit <n>', 'Max results', '100')
+    .option('--output <format>', 'Output format: pretty, table, csv, json, yaml', 'pretty')
     .action(async (opts) => {
       try {
-        renderRuntimeConfigHeader();
+        const fmt = opts.output as OutputFormat;
+        if (fmt === 'pretty') renderRuntimeConfigHeader();
         const service = await createMgmtService();
         const result = await service.listApiKeys({
           limit: Number.parseInt(opts.limit, 10),
         });
-        renderApiKeyList(result.apiKeys);
+        renderApiKeyList(result.apiKeys, fmt);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);
@@ -238,14 +242,16 @@ export function registerRuntimeCommand(program: Command): void {
     .command('list')
     .description('List customer apps')
     .option('--limit <n>', 'Max results', '100')
+    .option('--output <format>', 'Output format: pretty, table, csv, json, yaml', 'pretty')
     .action(async (opts) => {
       try {
-        renderRuntimeConfigHeader();
+        const fmt = opts.output as OutputFormat;
+        if (fmt === 'pretty') renderRuntimeConfigHeader();
         const service = await createMgmtService();
         const result = await service.listCustomerApps({
           limit: Number.parseInt(opts.limit, 10),
         });
-        renderCustomerAppList(result.apps);
+        renderCustomerAppList(result.apps, fmt);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);
@@ -312,14 +318,16 @@ export function registerRuntimeCommand(program: Command): void {
     .command('list')
     .description('List deployment profiles')
     .option('--unactivated', 'Include unactivated profiles')
+    .option('--output <format>', 'Output format: pretty, table, csv, json, yaml', 'pretty')
     .action(async (opts) => {
       try {
-        renderRuntimeConfigHeader();
+        const fmt = opts.output as OutputFormat;
+        if (fmt === 'pretty') renderRuntimeConfigHeader();
         const service = await createMgmtService();
         const profiles = await service.listDeploymentProfiles({
           unactivated: opts.unactivated,
         });
-        renderDeploymentProfileList(profiles);
+        renderDeploymentProfileList(profiles, fmt);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);
@@ -334,12 +342,14 @@ export function registerRuntimeCommand(program: Command): void {
   dlpProfiles
     .command('list')
     .description('List DLP profiles')
-    .action(async () => {
+    .option('--output <format>', 'Output format: pretty, table, csv, json, yaml', 'pretty')
+    .action(async (opts) => {
       try {
-        renderRuntimeConfigHeader();
+        const fmt = opts.output as OutputFormat;
+        if (fmt === 'pretty') renderRuntimeConfigHeader();
         const service = await createMgmtService();
         const profiles = await service.listDlpProfiles();
-        renderDlpProfileList(profiles);
+        renderDlpProfileList(profiles, fmt);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);
@@ -356,16 +366,22 @@ export function registerRuntimeCommand(program: Command): void {
     .description('List security profiles')
     .option('--limit <n>', 'Max results', '100')
     .option('--offset <n>', 'Starting offset', '0')
+    .option('--output <format>', 'Output format: pretty, table, csv, json, yaml', 'pretty')
     .action(async (opts) => {
       try {
-        renderRuntimeConfigHeader();
+        const fmt = opts.output as OutputFormat;
+        if (!OUTPUT_FORMATS.includes(fmt)) {
+          renderError(`Invalid output format "${fmt}". Valid: ${OUTPUT_FORMATS.join(', ')}`);
+          process.exit(1);
+        }
+        if (fmt === 'pretty') renderRuntimeConfigHeader();
         const service = await createMgmtService();
         const result = await service.listProfiles({
           limit: Number.parseInt(opts.limit, 10),
           offset: Number.parseInt(opts.offset, 10),
         });
-        renderProfileList(result.profiles);
-        if (result.nextOffset != null) {
+        renderProfileList(result.profiles, fmt);
+        if (fmt === 'pretty' && result.nextOffset != null) {
           console.log(chalk.dim(`  Next offset: ${result.nextOffset}\n`));
         }
       } catch (err) {
@@ -536,9 +552,11 @@ export function registerRuntimeCommand(program: Command): void {
     .option('--filter <filter>', 'Filter: all, benign, threat', 'all')
     .option('--page <n>', 'Page number', '1')
     .option('--page-size <n>', 'Page size', '50')
+    .option('--output <format>', 'Output format: pretty, table, csv, json, yaml', 'pretty')
     .action(async (opts) => {
       try {
-        renderRuntimeConfigHeader();
+        const fmt = opts.output as OutputFormat;
+        if (fmt === 'pretty') renderRuntimeConfigHeader();
         const service = await createMgmtService();
         const result = await service.queryScanLogs({
           timeInterval: Number.parseInt(opts.interval, 10),
@@ -547,7 +565,7 @@ export function registerRuntimeCommand(program: Command): void {
           pageSize: Number.parseInt(opts.pageSize, 10),
           filter: opts.filter,
         });
-        renderScanLogList(result.results, result.pageToken);
+        renderScanLogList(result.results, result.pageToken, fmt);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);
@@ -566,17 +584,19 @@ export function registerRuntimeCommand(program: Command): void {
     .description('List custom topics')
     .option('--limit <n>', 'Max results', '100')
     .option('--offset <n>', 'Starting offset', '0')
+    .option('--output <format>', 'Output format: pretty, table, csv, json, yaml', 'pretty')
     .action(async (opts) => {
       try {
-        renderRuntimeConfigHeader();
+        const fmt = opts.output as OutputFormat;
+        if (fmt === 'pretty') renderRuntimeConfigHeader();
         const service = await createMgmtService();
         const allTopics = await service.listTopics();
         // Client-side pagination since SDK returns all
         const offset = Number.parseInt(opts.offset, 10);
         const limit = Number.parseInt(opts.limit, 10);
         const page = allTopics.slice(offset, offset + limit);
-        renderTopicList(page);
-        if (offset + limit < allTopics.length) {
+        renderTopicList(page, fmt);
+        if (fmt === 'pretty' && offset + limit < allTopics.length) {
           console.log(chalk.dim(`  Showing ${page.length} of ${allTopics.length} topics\n`));
         }
       } catch (err) {

--- a/src/cli/renderer/common.ts
+++ b/src/cli/renderer/common.ts
@@ -4,3 +4,69 @@ import chalk from 'chalk';
 export function renderError(message: string): void {
   console.error(chalk.red(`\n  Error: ${message}\n`));
 }
+
+export type OutputFormat = 'pretty' | 'table' | 'csv' | 'json' | 'yaml';
+
+export const OUTPUT_FORMATS: OutputFormat[] = ['pretty', 'table', 'csv', 'json', 'yaml'];
+
+/**
+ * Generic structured output for list commands.
+ * `rows` is an array of flat key-value objects.
+ * `columns` defines which keys to show and their header labels.
+ */
+export function formatOutput(
+  rows: Record<string, unknown>[],
+  columns: { key: string; label: string }[],
+  format: OutputFormat,
+): string {
+  if (rows.length === 0) return '';
+
+  const vals = (row: Record<string, unknown>, key: string) => String(row[key] ?? '');
+
+  switch (format) {
+    case 'json':
+      return JSON.stringify(
+        rows.map((r) => {
+          const obj: Record<string, unknown> = {};
+          for (const c of columns) obj[c.key] = r[c.key];
+          return obj;
+        }),
+        null,
+        2,
+      );
+
+    case 'csv': {
+      const header = columns.map((c) => c.label).join(',');
+      const lines = rows.map((r) =>
+        columns
+          .map((c) => {
+            const v = vals(r, c.key);
+            return v.includes(',') || v.includes('"') ? `"${v.replace(/"/g, '""')}"` : v;
+          })
+          .join(','),
+      );
+      return [header, ...lines].join('\n');
+    }
+
+    case 'yaml': {
+      return rows
+        .map((r) => columns.map((c) => `${c.key}: ${vals(r, c.key)}`).join('\n'))
+        .join('\n---\n');
+    }
+
+    case 'table': {
+      const widths = columns.map((c) =>
+        Math.max(c.label.length, ...rows.map((r) => vals(r, c.key).length)),
+      );
+      const sep = widths.map((w) => '─'.repeat(w + 2)).join('┼');
+      const header = columns.map((c, i) => ` ${c.label.padEnd(widths[i])} `).join('│');
+      const body = rows.map((r) =>
+        columns.map((c, i) => ` ${vals(r, c.key).padEnd(widths[i])} `).join('│'),
+      );
+      return [header, sep, ...body].join('\n');
+    }
+
+    default:
+      return '';
+  }
+}

--- a/src/cli/renderer/modelsecurity.ts
+++ b/src/cli/renderer/modelsecurity.ts
@@ -8,6 +8,7 @@ import type {
   ModelSecurityScan,
   ModelSecurityViolation,
 } from '../../airs/types.js';
+import { formatOutput, type OutputFormat } from './common.js';
 
 /** Render the model security banner. */
 export function renderModelSecurityHeader(): void {
@@ -16,9 +17,33 @@ export function renderModelSecurityHeader(): void {
 }
 
 /** Render security group list. */
-export function renderGroupList(groups: ModelSecurityGroup[]): void {
+export function renderGroupList(
+  groups: ModelSecurityGroup[],
+  format: OutputFormat = 'pretty',
+): void {
   if (groups.length === 0) {
     console.log(chalk.dim('  No security groups found.\n'));
+    return;
+  }
+  if (format !== 'pretty') {
+    const rows = groups.map((g) => ({
+      id: g.uuid,
+      name: g.name,
+      state: g.state,
+      sourceType: g.sourceType,
+    }));
+    console.log(
+      formatOutput(
+        rows,
+        [
+          { key: 'id', label: 'ID' },
+          { key: 'name', label: 'Name' },
+          { key: 'state', label: 'State' },
+          { key: 'sourceType', label: 'Source Type' },
+        ],
+        format,
+      ),
+    );
     return;
   }
   console.log(chalk.bold('\n  Security Groups:\n'));
@@ -45,9 +70,32 @@ export function renderGroupDetail(group: ModelSecurityGroup): void {
 }
 
 /** Render security rule list. */
-export function renderRuleList(rules: ModelSecurityRule[]): void {
+export function renderRuleList(rules: ModelSecurityRule[], format: OutputFormat = 'pretty'): void {
   if (rules.length === 0) {
     console.log(chalk.dim('  No security rules found.\n'));
+    return;
+  }
+  if (format !== 'pretty') {
+    const rows = rules.map((r) => ({
+      id: r.uuid,
+      name: r.name,
+      type: r.ruleType,
+      defaultState: r.defaultState,
+      sources: r.compatibleSources.join(', '),
+    }));
+    console.log(
+      formatOutput(
+        rows,
+        [
+          { key: 'id', label: 'ID' },
+          { key: 'name', label: 'Name' },
+          { key: 'type', label: 'Type' },
+          { key: 'defaultState', label: 'Default State' },
+          { key: 'sources', label: 'Sources' },
+        ],
+        format,
+      ),
+    );
     return;
   }
   console.log(chalk.bold('\n  Security Rules:\n'));
@@ -145,9 +193,39 @@ export function renderRuleInstanceDetail(instance: ModelSecurityRuleInstance): v
 // ---------------------------------------------------------------------------
 
 /** Render a list of model security scans. */
-export function renderMsScanList(scans: ModelSecurityScan[]): void {
+export function renderMsScanList(
+  scans: ModelSecurityScan[],
+  format: OutputFormat = 'pretty',
+): void {
   if (scans.length === 0) {
     console.log(chalk.dim('  No scans found.\n'));
+    return;
+  }
+  if (format !== 'pretty') {
+    const rows = scans.map((s) => ({
+      id: s.uuid,
+      outcome: s.evalOutcome,
+      origin: s.scanOrigin,
+      modelUri: s.modelUri ?? '',
+      createdAt: s.createdAt,
+      passed: s.evalSummary?.rulesPassed ?? '',
+      failed: s.evalSummary?.rulesFailed ?? '',
+    }));
+    console.log(
+      formatOutput(
+        rows,
+        [
+          { key: 'id', label: 'ID' },
+          { key: 'outcome', label: 'Outcome' },
+          { key: 'origin', label: 'Origin' },
+          { key: 'modelUri', label: 'Model URI' },
+          { key: 'passed', label: 'Passed' },
+          { key: 'failed', label: 'Failed' },
+          { key: 'createdAt', label: 'Created' },
+        ],
+        format,
+      ),
+    );
     return;
   }
   console.log(chalk.bold('\n  Model Security Scans:\n'));

--- a/src/cli/renderer/redteam.ts
+++ b/src/cli/renderer/redteam.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { formatOutput, type OutputFormat } from './common.js';
 
 /** Render the red team banner. */
 export function renderRedteamHeader(): void {
@@ -80,9 +81,35 @@ export function renderScanList(
     score?: number | null;
     createdAt?: string | null;
   }>,
+  format: OutputFormat = 'pretty',
 ): void {
   if (jobs.length === 0) {
     console.log(chalk.dim('  No scans found.\n'));
+    return;
+  }
+  if (format !== 'pretty') {
+    const rows = jobs.map((j) => ({
+      id: j.uuid,
+      name: j.name,
+      status: j.status,
+      type: j.jobType,
+      score: j.score ?? '',
+      createdAt: j.createdAt ?? '',
+    }));
+    console.log(
+      formatOutput(
+        rows,
+        [
+          { key: 'id', label: 'ID' },
+          { key: 'name', label: 'Name' },
+          { key: 'status', label: 'Status' },
+          { key: 'type', label: 'Type' },
+          { key: 'score', label: 'Score' },
+          { key: 'createdAt', label: 'Created' },
+        ],
+        format,
+      ),
+    );
     return;
   }
   console.log(chalk.bold('\n  Recent Scans:\n'));
@@ -231,9 +258,31 @@ export function renderTargetList(
     targetType?: string;
     active: boolean;
   }>,
+  format: OutputFormat = 'pretty',
 ): void {
   if (targets.length === 0) {
     console.log(chalk.dim('  No targets found.\n'));
+    return;
+  }
+  if (format !== 'pretty') {
+    const rows = targets.map((t) => ({
+      id: t.uuid,
+      name: t.name,
+      status: t.active ? 'active' : 'inactive',
+      type: t.targetType ?? '',
+    }));
+    console.log(
+      formatOutput(
+        rows,
+        [
+          { key: 'id', label: 'ID' },
+          { key: 'name', label: 'Name' },
+          { key: 'status', label: 'Status' },
+          { key: 'type', label: 'Type' },
+        ],
+        format,
+      ),
+    );
     return;
   }
   console.log(chalk.bold('\n  Targets:\n'));
@@ -276,9 +325,29 @@ export function renderCategories(
 /** Render prompt set list. */
 export function renderPromptSetList(
   promptSets: Array<{ uuid: string; name: string; active: boolean }>,
+  format: OutputFormat = 'pretty',
 ): void {
   if (promptSets.length === 0) {
     console.log(chalk.dim('  No prompt sets found.\n'));
+    return;
+  }
+  if (format !== 'pretty') {
+    const rows = promptSets.map((ps) => ({
+      id: ps.uuid,
+      name: ps.name,
+      status: ps.active ? 'active' : 'inactive',
+    }));
+    console.log(
+      formatOutput(
+        rows,
+        [
+          { key: 'id', label: 'ID' },
+          { key: 'name', label: 'Name' },
+          { key: 'status', label: 'Status' },
+        ],
+        format,
+      ),
+    );
     return;
   }
   console.log(chalk.bold('\n  Prompt Sets:\n'));
@@ -409,9 +478,17 @@ export function renderPromptDetail(p: {
 }
 
 /** Render property names list. */
-export function renderPropertyNames(names: Array<{ name: string }>): void {
+export function renderPropertyNames(
+  names: Array<{ name: string }>,
+  format: OutputFormat = 'pretty',
+): void {
   if (names.length === 0) {
     console.log(chalk.dim('  No property names found.\n'));
+    return;
+  }
+  if (format !== 'pretty') {
+    const rows = names.map((n) => ({ name: n.name }));
+    console.log(formatOutput(rows, [{ key: 'name', label: 'Name' }], format));
     return;
   }
   console.log(chalk.bold('\n  Property Names:\n'));

--- a/src/cli/renderer/runtime.ts
+++ b/src/cli/renderer/runtime.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { formatOutput, type OutputFormat } from './common.js';
 
 /** Render polling progress inline. */
 export function renderScanProgress(job: {
@@ -85,11 +86,30 @@ export function renderProfileList(
     active?: boolean;
     lastModifiedTs?: string;
   }>,
+  format: OutputFormat = 'pretty',
 ): void {
   if (profiles.length === 0) {
     console.log(chalk.dim('  No profiles found.\n'));
     return;
   }
+
+  if (format !== 'pretty') {
+    const rows = profiles.map((p) => ({
+      id: p.profileId,
+      name: p.profileName,
+      status: p.active ? 'active' : 'inactive',
+      revision: p.revision ?? '',
+    }));
+    const columns = [
+      { key: 'id', label: 'ID' },
+      { key: 'name', label: 'Name' },
+      { key: 'status', label: 'Status' },
+      { key: 'revision', label: 'Revision' },
+    ];
+    console.log(formatOutput(rows, columns, format));
+    return;
+  }
+
   console.log(chalk.bold('\n  Security Profiles:\n'));
   for (const p of profiles) {
     console.log(`  ${chalk.dim(p.profileId)}`);
@@ -135,9 +155,31 @@ export function renderTopicList(
     description?: string;
     revision?: number;
   }>,
+  format: OutputFormat = 'pretty',
 ): void {
   if (topics.length === 0) {
     console.log(chalk.dim('  No topics found.\n'));
+    return;
+  }
+  if (format !== 'pretty') {
+    const rows = topics.map((t) => ({
+      id: t.topic_id ?? '',
+      name: t.topic_name,
+      revision: t.revision ?? '',
+      description: t.description ?? '',
+    }));
+    console.log(
+      formatOutput(
+        rows,
+        [
+          { key: 'id', label: 'ID' },
+          { key: 'name', label: 'Name' },
+          { key: 'revision', label: 'Revision' },
+          { key: 'description', label: 'Description' },
+        ],
+        format,
+      ),
+    );
     return;
   }
   console.log(chalk.bold('\n  Custom Topics:\n'));
@@ -181,9 +223,31 @@ export function renderTopicDetail(topic: {
 /** Render API key list. */
 export function renderApiKeyList(
   keys: Array<{ id: string; name: string; createdAt?: string; expiresAt?: string }>,
+  format: OutputFormat = 'pretty',
 ): void {
   if (keys.length === 0) {
     console.log(chalk.dim('  No API keys found.\n'));
+    return;
+  }
+  if (format !== 'pretty') {
+    const rows = keys.map((k) => ({
+      id: k.id,
+      name: k.name,
+      createdAt: k.createdAt ?? '',
+      expiresAt: k.expiresAt ?? '',
+    }));
+    console.log(
+      formatOutput(
+        rows,
+        [
+          { key: 'id', label: 'ID' },
+          { key: 'name', label: 'Name' },
+          { key: 'createdAt', label: 'Created' },
+          { key: 'expiresAt', label: 'Expires' },
+        ],
+        format,
+      ),
+    );
     return;
   }
   console.log(chalk.bold('\n  API Keys:\n'));
@@ -213,9 +277,29 @@ export function renderApiKeyDetail(key: {
 /** Render customer app list. */
 export function renderCustomerAppList(
   apps: Array<{ id?: string; name: string; description?: string }>,
+  format: OutputFormat = 'pretty',
 ): void {
   if (apps.length === 0) {
     console.log(chalk.dim('  No customer apps found.\n'));
+    return;
+  }
+  if (format !== 'pretty') {
+    const rows = apps.map((a) => ({
+      id: a.id ?? '',
+      name: a.name,
+      description: a.description ?? '',
+    }));
+    console.log(
+      formatOutput(
+        rows,
+        [
+          { key: 'id', label: 'ID' },
+          { key: 'name', label: 'Name' },
+          { key: 'description', label: 'Description' },
+        ],
+        format,
+      ),
+    );
     return;
   }
   console.log(chalk.bold('\n  Customer Apps:\n'));
@@ -245,9 +329,29 @@ export function renderCustomerAppDetail(app: {
 /** Render deployment profile list. */
 export function renderDeploymentProfileList(
   profiles: Array<{ raw: Record<string, unknown> }>,
+  format: OutputFormat = 'pretty',
 ): void {
   if (profiles.length === 0) {
     console.log(chalk.dim('  No deployment profiles found.\n'));
+    return;
+  }
+  if (format !== 'pretty') {
+    const rows = profiles.map((p) => ({
+      name: (p.raw.dp_name ?? p.raw.profile_name ?? p.raw.name ?? '') as string,
+      status: (p.raw.status ?? '') as string,
+      authCode: (p.raw.auth_code ?? '') as string,
+    }));
+    console.log(
+      formatOutput(
+        rows,
+        [
+          { key: 'name', label: 'Name' },
+          { key: 'status', label: 'Status' },
+          { key: 'authCode', label: 'Auth Code' },
+        ],
+        format,
+      ),
+    );
     return;
   }
   console.log(chalk.bold('\n  Deployment Profiles:\n'));
@@ -264,9 +368,29 @@ export function renderDeploymentProfileList(
 }
 
 /** Render DLP profile list. */
-export function renderDlpProfileList(profiles: Array<{ raw: Record<string, unknown> }>): void {
+export function renderDlpProfileList(
+  profiles: Array<{ raw: Record<string, unknown> }>,
+  format: OutputFormat = 'pretty',
+): void {
   if (profiles.length === 0) {
     console.log(chalk.dim('  No DLP profiles found.\n'));
+    return;
+  }
+  if (format !== 'pretty') {
+    const rows = profiles.map((p) => ({
+      id: (p.raw.uuid ?? '') as string,
+      name: (p.raw.name ?? p.raw.profile_name ?? '') as string,
+    }));
+    console.log(
+      formatOutput(
+        rows,
+        [
+          { key: 'id', label: 'ID' },
+          { key: 'name', label: 'Name' },
+        ],
+        format,
+      ),
+    );
     return;
   }
   console.log(chalk.bold('\n  DLP Profiles:\n'));
@@ -280,9 +404,36 @@ export function renderDlpProfileList(profiles: Array<{ raw: Record<string, unkno
 }
 
 /** Render scan log results. */
-export function renderScanLogList(results: Record<string, unknown>[], pageToken?: string): void {
+export function renderScanLogList(
+  results: Record<string, unknown>[],
+  pageToken?: string,
+  format: OutputFormat = 'pretty',
+): void {
   if (results.length === 0) {
     console.log(chalk.dim('  No scan logs found.\n'));
+    return;
+  }
+  if (format !== 'pretty') {
+    const rows = results.map((r) => ({
+      scanId: (r.scan_id ?? '') as string,
+      timestamp: (r.received_ts ?? r.timestamp ?? '') as string,
+      action: (r.action ?? r.verdict ?? '') as string,
+      profile: (r.profile_name ?? '') as string,
+      app: (r.app_name ?? '') as string,
+    }));
+    console.log(
+      formatOutput(
+        rows,
+        [
+          { key: 'scanId', label: 'Scan ID' },
+          { key: 'timestamp', label: 'Timestamp' },
+          { key: 'action', label: 'Action' },
+          { key: 'profile', label: 'Profile' },
+          { key: 'app', label: 'App' },
+        ],
+        format,
+      ),
+    );
     return;
   }
   console.log(chalk.bold(`\n  Scan Logs (${results.length} results):\n`));


### PR DESCRIPTION
## Summary
- Add `--output <format>` flag to all 14 list commands across runtime, redteam, and model-security groups
- Formats: `pretty` (default), `table` (box-drawing), `csv`, `json`, `yaml`
- Shared `formatOutput()` utility in `src/cli/renderer/common.ts`
- Bump version to 1.0.6
- Update docs: CLI reference, feature pages, release notes, version refs

## Test plan
- [x] 526 tests pass
- [x] tsc clean
- [x] Biome lint/format clean
- [x] MkDocs strict build passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)