### PR TITLE
feat: display API key value and last 8 chars

### DIFF
--- a/.changeset/0000-api-key-value.md
+++ b/.changeset/0000-api-key-value.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Display API key value on create/regenerate and last 8 characters in list views.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/prisma-airs-cli",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",

--- a/src/airs/management.ts
+++ b/src/airs/management.ts
@@ -269,6 +269,8 @@ export class SdkManagementService implements ManagementService {
     return {
       id: (k.id ?? k.api_key_id ?? '') as string,
       name: (k.name ?? k.api_key_name ?? '') as string,
+      apiKey: k.api_key as string | undefined,
+      last8: k.api_key_last8 as string | undefined,
       createdAt: k.created_at as string | undefined,
       expiresAt: k.expires_at as string | undefined,
     };

--- a/src/airs/types.ts
+++ b/src/airs/types.ts
@@ -687,6 +687,8 @@ export interface PaginationOptions {
 export interface ApiKeyInfo {
   id: string;
   name: string;
+  apiKey?: string;
+  last8?: string;
   createdAt?: string;
   expiresAt?: string;
 }

--- a/src/cli/renderer/runtime.ts
+++ b/src/cli/renderer/runtime.ts
@@ -222,7 +222,13 @@ export function renderTopicDetail(topic: {
 
 /** Render API key list. */
 export function renderApiKeyList(
-  keys: Array<{ id: string; name: string; createdAt?: string; expiresAt?: string }>,
+  keys: Array<{
+    id: string;
+    name: string;
+    last8?: string;
+    createdAt?: string;
+    expiresAt?: string;
+  }>,
   format: OutputFormat = 'pretty',
 ): void {
   if (keys.length === 0) {
@@ -233,6 +239,7 @@ export function renderApiKeyList(
     const rows = keys.map((k) => ({
       id: k.id,
       name: k.name,
+      last8: k.last8 ?? '',
       createdAt: k.createdAt ?? '',
       expiresAt: k.expiresAt ?? '',
     }));
@@ -242,6 +249,7 @@ export function renderApiKeyList(
         [
           { key: 'id', label: 'ID' },
           { key: 'name', label: 'Name' },
+          { key: 'last8', label: 'Key (last 8)' },
           { key: 'createdAt', label: 'Created' },
           { key: 'expiresAt', label: 'Expires' },
         ],
@@ -253,8 +261,9 @@ export function renderApiKeyList(
   console.log(chalk.bold('\n  API Keys:\n'));
   for (const k of keys) {
     console.log(`  ${chalk.dim(k.id)}`);
+    const last8 = k.last8 ? chalk.dim(` key: …${k.last8}`) : '';
     const expires = k.expiresAt ? chalk.dim(` expires: ${k.expiresAt}`) : '';
-    console.log(`    ${k.name}${expires}`);
+    console.log(`    ${k.name}${last8}${expires}`);
   }
   console.log();
 }
@@ -263,12 +272,16 @@ export function renderApiKeyList(
 export function renderApiKeyDetail(key: {
   id: string;
   name: string;
+  apiKey?: string;
+  last8?: string;
   createdAt?: string;
   expiresAt?: string;
 }): void {
   console.log(chalk.bold('\n  API Key Detail:\n'));
   console.log(`    ID:      ${chalk.dim(key.id)}`);
   console.log(`    Name:    ${key.name}`);
+  if (key.apiKey) console.log(`    Key:     ${key.apiKey}`);
+  else if (key.last8) console.log(`    Key:     ${chalk.dim('…')}${key.last8}`);
   if (key.createdAt) console.log(`    Created: ${chalk.dim(key.createdAt)}`);
   if (key.expiresAt) console.log(`    Expires: ${chalk.dim(key.expiresAt)}`);
   console.log();


### PR DESCRIPTION
## Summary
- Show full API key value on create/regenerate responses
- Show last 8 characters of API key in list and detail views
- Add `apiKey` and `last8` fields to `ApiKeyInfo` type and management service normalizer

## Test plan
- [x] All 526 tests pass
- [x] Type-check clean
- [ ] Manual: `airs runtime api-keys list` shows last 8 chars column
- [ ] Manual: `airs runtime api-keys create` shows full key value

🤖 Generated with [Claude Code](https://claude.com/claude-code)