### PR TITLE
fix: remove unused OUTPUT_FORMATS import (#9)

### DIFF
--- a/src/cli/commands/redteam.ts
+++ b/src/cli/commands/redteam.ts
@@ -4,7 +4,6 @@ import { SdkPromptSetService } from '../../airs/promptsets.js';
 import { SdkRedTeamService } from '../../airs/redteam.js';
 import { loadConfig } from '../../config/loader.js';
 import {
-  OUTPUT_FORMATS,
   type OutputFormat,
   renderAttackList,
   renderCategories,


### PR DESCRIPTION
## Summary

- Remove unused `OUTPUT_FORMATS` import from `src/cli/commands/redteam.ts`

## Changes

- Removed `OUTPUT_FORMATS` from the named imports in `redteam.ts` line 7; only `OutputFormat` type and renderer functions remain

## Testing

- `pnpm run lint` passes clean
- `pnpm run format:check` passes clean
- `pnpm tsc --noEmit` passes clean
- All 526 tests pass

Closes #9