### PR TITLE
fix: add missing intent parameter to improveTopic test (#10)

### DIFF
--- a/tests/unit/llm/service.spec.ts
+++ b/tests/unit/llm/service.spec.ts
@@ -320,7 +320,15 @@ describe('LangChainLlmService', () => {
         falseNegativePatterns: [],
         suggestions: [],
       };
-      const result = await service.improveTopic(validTopic, metrics, emptyAnalysis, [], 2, 0.9);
+      const result = await service.improveTopic(
+        validTopic,
+        metrics,
+        emptyAnalysis,
+        [],
+        2,
+        0.9,
+        'block',
+      );
       expect(result.name).toBe('Weapons');
     });
 


### PR DESCRIPTION
## Summary
- Added missing `'block'` intent parameter to `improveTopic` call in the "uses 'None' when FP/FN patterns are empty" test case (line 323)

## Changes
- `tests/unit/llm/service.spec.ts`: Added 7th argument `'block'` to `service.improveTopic()` call that was missing the required `intent` parameter

## Testing
- `pnpm test -- tests/unit/llm/service.spec.ts` — 34/34 pass
- `pnpm test` — 526/526 pass
- `pnpm run lint` — clean (only pre-existing warning)
- `pnpm tsc --noEmit` — clean

Closes #10