### PR TITLE
chore: release v1.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/prisma-airs-cli",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Hotfix release — fix memory extraction crash on neutral-outcome learnings.

## Changes since v1.0.8
- fix: make changeType optional in learning extraction schema (#19, #20)

## Version
1.0.8 → 1.0.9