### PR TITLE
docs: complete profiles get documentation coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,6 +488,18 @@ airs runtime profiles list --output json
 
 Returns JSON array of `{ id, name, state }` objects.
 
+### Workflow 2b: Get a specific profile's full configuration
+
+```bash
+# By name
+airs runtime profiles get AI-Firewall-High-Security-Profile --output json
+
+# By UUID
+airs runtime profiles get 03e9d2aa-64e0-4734-a21e-de85c7d0d728 --output json
+```
+
+Returns full profile detail including the complete `policy` JSON (topic guardrails, DLP, app protection, etc.). Auto-detects UUID vs name.
+
 ### Workflow 3: Create a custom topic, then scan against it
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ airs model-security scans create --config scan-config.json
 | `runtime scan` | Single prompt scanning against AIRS profiles |
 | `runtime bulk-scan` | Batch prompt scanning with CSV output |
 | `runtime topics` | Custom topic CRUD + guardrail generation (`generate`, `resume`, `report`, `runs`) |
-| `runtime profiles` | Security profile CRUD + multi-topic `audit` |
+| `runtime profiles` | Security profile CRUD (`list`, `get`, `create`, `update`, `delete`) + multi-topic `audit` |
 | `runtime api-keys` | API key management |
 | `runtime customer-apps` | Customer app CRUD |
 | `runtime deployment-profiles` | Deployment profile listing |

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -94,6 +94,19 @@ airs model-security scans list
 
 ---
 
+## Profile Management
+
+View and inspect your security profiles.
+
+```bash
+# List all profiles
+airs runtime profiles list --output json
+
+# Get full configuration of a specific profile (by name or UUID)
+airs runtime profiles get AI-Firewall-High-Security-Profile
+airs runtime profiles get AI-Firewall-High-Security-Profile --output json
+```
+
 ## Profile Audits
 
 Evaluate all topics in a security profile at once, with conflict detection.


### PR DESCRIPTION
## Summary

Fill documentation gaps for the `profiles get` command added in #23.

## Changes

- **README.md** — expand `runtime profiles` row to list subcommands including `get`
- **AGENTS.md** — add Workflow 2b for retrieving a profile's full configuration
- **docs/getting-started/quick-start.md** — add Profile Management section with `list` and `get` examples before the audit section