### PR TITLE
chore(deps): upgrade @cdot65/prisma-airs-sdk to ^0.8.0

### DIFF
--- a/.changeset/0008-sdk-080-upgrade.md
+++ b/.changeset/0008-sdk-080-upgrade.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Upgrade `@cdot65/prisma-airs-sdk` from `0.7.1` to `0.8.0`. SDK adds runtime Zod validation on every response and tightens `ScanResponse`/`CustomTopic` field requiredness. No CLI behavior changes — public surface is unchanged. Test fixtures updated to match the now-required `revision`/`description`/`examples` fields on `CustomTopic` responses.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 dist/
 *.tsbuildinfo
 
+# Worktrees
+.worktrees/
+
 # Test
 coverage/
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/vertex-sdk": "^0.14.4",
-    "@cdot65/prisma-airs-sdk": "^0.7.1",
+    "@cdot65/prisma-airs-sdk": "^0.8.0",
     "@inquirer/prompts": "^8.3.0",
     "@langchain/anthropic": "^1.3.25",
     "@langchain/aws": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.14.4
         version: 0.14.4(zod@3.25.76)
       '@cdot65/prisma-airs-sdk':
-        specifier: ^0.7.1
-        version: 0.7.1
+        specifier: ^0.8.0
+        version: 0.8.0
       '@inquirer/prompts':
         specifier: ^8.3.0
         version: 8.3.0(@types/node@22.19.13)
@@ -316,8 +316,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cdot65/prisma-airs-sdk@0.7.1':
-    resolution: {integrity: sha512-kiUrTBV84krDKOgBkYOXdsjfBBSQUBMKTRaAR9GN8VCSmCA+AIQBJ1aWzF748Zx9phLmCk4V89ezoYiQqVkSKA==}
+  '@cdot65/prisma-airs-sdk@0.8.0':
+    resolution: {integrity: sha512-xYSf+Wb0qsMfw8pGTCJe6GaCGcYq0dOX2h9ewS3c1Elun0ggOgtQKAPpxWih5EiR4iAslmtqmJFMavVPgZARcQ==}
     engines: {node: '>=18'}
 
   '@cfworker/json-schema@4.1.1':
@@ -2442,7 +2442,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.5':
     optional: true
 
-  '@cdot65/prisma-airs-sdk@0.7.1':
+  '@cdot65/prisma-airs-sdk@0.8.0':
     dependencies:
       zod: 3.25.76
 

--- a/tests/helpers/mocks.ts
+++ b/tests/helpers/mocks.ts
@@ -46,8 +46,9 @@ export function createMockManagementService(): ManagementService {
     createTopic: async (request: CreateCustomTopicRequest): Promise<SdkCustomTopic> => ({
       topic_id: `topic-${++topicCounter}`,
       topic_name: request.topic_name,
-      description: request.description,
-      examples: request.examples,
+      revision: 1,
+      description: request.description ?? '',
+      examples: request.examples ?? [],
       active: true,
     }),
     updateTopic: async (
@@ -56,8 +57,9 @@ export function createMockManagementService(): ManagementService {
     ): Promise<SdkCustomTopic> => ({
       topic_id: id,
       topic_name: request.topic_name,
-      description: request.description,
-      examples: request.examples,
+      revision: (request.revision ?? 1) + 1,
+      description: request.description ?? '',
+      examples: request.examples ?? [],
       active: true,
     }),
     deleteTopic: async () => {},


### PR DESCRIPTION
## Summary

Upgrade `@cdot65/prisma-airs-sdk` from `^0.7.1` to `^0.8.0`. Public CLI surface unchanged.

## What changed in SDK 0.8.0 (and why this PR is small)

SDK 0.8.0 introduces:
1. Runtime Zod validation on every response (new `ErrorType.RESPONSE_VALIDATION`)
2. `ScanResponse.{timeout,error,errors}` and `CustomTopic.{revision,description,examples}` tightened from optional → required
3. `tool_detected` reshape (`detection_entries[]` and `summary.{detections,threats}`)
4. New exports: `ToolDetectionFlags`, `ToolDetectionEntry`, `ToolDetectionDetails`, `ListingOptions`

Audit of this repo against those changes:

| Migration item | Refs in repo | Touched in this PR? |
|---|---|---|
| `tool_detected.*` access | 0 | no |
| `AISecSDKException`/`ErrorType` handlers | 0 | no |
| `ScanResponse` literal construction | 0 | no |
| `SdkCustomTopic` literal construction | 2 (`tests/helpers/mocks.ts`) | yes — added `revision` + defaults |
| msw handler fixtures | 0 | no |

## Files changed

- `package.json` — bump SDK to `^0.8.0`
- `pnpm-lock.yaml` — regenerated
- `tests/helpers/mocks.ts` — added `revision` to mock `createTopic`/`updateTopic` returns; defaulted `description` and `examples` to satisfy required fields
- `.changeset/0008-sdk-080-upgrade.md` — patch changeset
- `.gitignore` — added `.worktrees/`

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` — 512/512 pass
- [x] `pnpm lint` clean
- [x] `pnpm run build` clean
- [x] `rg "tool_detected\.input_detected|tool_detected\.output_detected|tool_detected\.summary\.(verdict|action)" src tests` — zero hits
- [x] `rg "AISecSDKException|ErrorType\." src tests` — zero hits (no catch-block updates needed)
- [ ] CI green
- [ ] E2E sanity-check against real AIRS instance (optional, opt-in `pnpm test:e2e`)

Closes #51
