### PR TITLE
docs: fix stale testing.md and drop unused msw dep

### DIFF
--- a/.changeset/0010-fix-testing-doc.md
+++ b/.changeset/0010-fix-testing-doc.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Rewrite `docs/development/testing.md` to accurately describe the test suite. The page previously claimed MSW intercepted HTTP requests and listed test directories that don't exist (`memory/`, `persistence/`, `integration/`, `report/`). The unit suite actually injects in-memory service mocks from `tests/helpers/mocks.ts` — the SDK and its HTTP layer are never instantiated. Also removes the unused `msw` devDependency and links the page to the new live AIRS smoke test reference for API coverage that the unit suite intentionally does not provide.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -3,42 +3,52 @@
 ## Running Tests
 
 ```bash
-pnpm test              # All unit/integration tests
+pnpm test              # All unit tests (vitest run)
 pnpm run test:watch    # Watch mode
-pnpm run test:coverage # Coverage report (v8 provider)
-pnpm run test:e2e      # E2E tests (requires real creds)
-pnpm tsc --noEmit      # Type-check (strict mode)
+pnpm run test:coverage # Coverage report (V8 provider)
+pnpm run test:e2e      # E2E tests (opt-in, requires real Vertex AI creds)
+pnpm tsc --noEmit      # Type-check (strict mode, src/ only)
 ```
+
+!!! info "No AIRS credentials needed for the unit suite"
+    Unit tests never instantiate the `@cdot65/prisma-airs-sdk` clients. They inject mock service implementations directly into the code paths under test, so the SDK and its HTTP layer are bypassed entirely. You can run `pnpm test` with no AIRS env vars set.
 
 ## Test Structure
 
-Tests live in `tests/`, mirroring the `src/` layout:
-
 ```
 tests/
-├── unit/                  28 spec files
-│   ├── airs/              scanner.spec.ts, management.spec.ts, modelsecurity.spec.ts, promptsets.spec.ts, redteam.spec.ts, runtime.spec.ts
-│   ├── audit/             evaluator.spec.ts, runner.spec.ts, report.spec.ts
-│   ├── cli/               parse-input.spec.ts, bulk-scan-state.spec.ts
-│   ├── config/            schema.spec.ts, loader.spec.ts
-│   ├── core/              loop.spec.ts, metrics.spec.ts, constraints.spec.ts
-│   ├── llm/               provider.spec.ts, schemas.spec.ts, service.spec.ts, prompts.spec.ts
-│   ├── memory/            store.spec.ts, extractor.spec.ts, injector.spec.ts, diff.spec.ts, prompts.spec.ts
-│   ├── persistence/       store.spec.ts
-│   └── report/            json.spec.ts, html.spec.ts
-├── integration/           loop.integration.spec.ts
-├── e2e/                   vertex-provider.e2e.spec.ts (opt-in)
+├── unit/                  34 spec files
+│   ├── airs/              management.spec.ts, modelsecurity.spec.ts, promptsets.spec.ts,
+│   │                      redteam.spec.ts, runtime.spec.ts, scanner.spec.ts
+│   ├── audit/             evaluator.spec.ts, report.spec.ts, runner.spec.ts
+│   ├── backup/            io.spec.ts
+│   ├── cli/               backup-renderer.spec.ts, backup.spec.ts, bulk-scan-state.spec.ts,
+│   │                      parse-input.spec.ts, profile-builder.spec.ts, profiles-cleanup.spec.ts,
+│   │                      redteam-init.spec.ts, restore.spec.ts, topics-apply.spec.ts,
+│   │                      topics-create.spec.ts, topics-eval.spec.ts, topics-revert.spec.ts,
+│   │                      topics-sample.spec.ts
+│   ├── config/            loader.spec.ts, schema.spec.ts
+│   ├── core/              constraints.spec.ts, metrics.spec.ts, prompt-loader.spec.ts
+│   └── llm/               prompts.spec.ts, provider.spec.ts, schemas.spec.ts, service.spec.ts
+├── e2e/                   vertex-provider.e2e.spec.ts (opt-in, real Vertex AI creds)
 └── helpers/               mocks.ts
 ```
 
 ## Mocking
 
-**MSW** (Mock Service Worker) intercepts all HTTP requests — no real AIRS credentials needed for unit or integration tests.
+Mocks are defined in [`tests/helpers/mocks.ts`](https://github.com/cdot65/prisma-airs-cli/blob/main/tests/helpers/mocks.ts) as **service-level factories**, not HTTP-level interceptors. Each factory returns an in-memory implementation of one of the project's service interfaces from [`src/airs/types.ts`](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/types.ts):
 
-!!! info "No credentials needed"
-    All HTTP calls to AIRS and LLM APIs are intercepted by MSW handlers in `tests/helpers/mocks.ts`. You can run the full unit/integration suite without any API keys.
+| Factory | Returns | Used to test |
+|---|---|---|
+| `createMockManagementService()` | `ManagementService` | Topic and profile CRUD code paths |
+| `createMockScanService()` | `ScanService` | Synchronous scanning, with optional regex `triggerPatterns` |
+| `createMockAllowScanService()` | `ScanService` | Allow-intent scanner behavior (matching prompts → `topic_violation: true`) |
+| `createMockRedTeamService()` | `RedTeamService` | Red team scan and target operations |
+| `createMockModelSecurityService()` | `ModelSecurityService` | Model security groups, rules, scans |
 
-E2E tests require real Vertex AI credentials and are opt-in via separate config.
+The unit suite injects these mocks directly into the code under test via constructor or function arguments — the SDK and its `Scanner` / `ManagementClient` / `RedTeamClient` / `ModelSecurityClient` are never instantiated. Because no HTTP requests ever leave the process, no AIRS credentials are required.
+
+E2E tests under `tests/e2e/` are different: they exercise the LangChain Vertex AI provider for the `audit` command's LLM path against real Google Cloud, gated by `pnpm test:e2e`. They do **not** cover the AIRS Scanner, Management, RedTeam, or ModelSecurity APIs. For live AIRS coverage, run the manual checklist in [Live Smoke Tests](smoke-tests.md) — that's the authoritative way to catch backend wire-format drift, especially under SDK 0.8.0's now-on runtime Zod validation.
 
 ## Coverage
 
@@ -49,6 +59,8 @@ Coverage is collected via **V8** and excludes files that aren't meaningfully tes
 | `src/cli/**` | Interactive UI (prompts, rendering) |
 | `src/index.ts` | Re-exports only |
 | `**/types.ts` | Type-only files, no runtime code |
+
+Thresholds (from `vitest.config.ts`): **90% lines, 95% functions, 80% branches, 90% statements.**
 
 ```bash
 pnpm run test:coverage

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.0.0",
-    "msw": "^2.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,9 +66,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.0.0
         version: 3.2.4(vitest@3.2.4(@types/node@22.19.13)(msw@2.12.10(@types/node@22.19.13)(typescript@5.9.3))(tsx@4.21.0))
-      msw:
-        specifier: ^2.0.0
-        version: 2.12.10(@types/node@22.19.13)(typescript@5.9.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -2528,7 +2525,8 @@ snapshots:
 
   '@google/generative-ai@0.24.1': {}
 
-  '@inquirer/ansi@1.0.2': {}
+  '@inquirer/ansi@1.0.2':
+    optional: true
 
   '@inquirer/ansi@2.0.3': {}
 
@@ -2547,6 +2545,7 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@22.19.13)
     optionalDependencies:
       '@types/node': 22.19.13
+    optional: true
 
   '@inquirer/confirm@6.0.8(@types/node@22.19.13)':
     dependencies:
@@ -2567,6 +2566,7 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 22.19.13
+    optional: true
 
   '@inquirer/core@11.1.5(@types/node@22.19.13)':
     dependencies:
@@ -2602,7 +2602,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.13
 
-  '@inquirer/figures@1.0.15': {}
+  '@inquirer/figures@1.0.15':
+    optional: true
 
   '@inquirer/figures@2.0.3': {}
 
@@ -2670,6 +2671,7 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@22.19.13)':
     optionalDependencies:
       '@types/node': 22.19.13
+    optional: true
 
   '@inquirer/type@4.0.3(@types/node@22.19.13)':
     optionalDependencies:
@@ -2769,15 +2771,19 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
+    optional: true
 
-  '@open-draft/deferred-promise@2.2.0': {}
+  '@open-draft/deferred-promise@2.2.0':
+    optional: true
 
   '@open-draft/logger@0.3.0':
     dependencies:
       is-node-process: 1.2.0
       outvariant: 1.4.3
+    optional: true
 
-  '@open-draft/until@2.1.0': {}
+  '@open-draft/until@2.1.0':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -3179,7 +3185,8 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/statuses@2.0.6': {}
+  '@types/statuses@2.0.6':
+    optional: true
 
   '@types/uuid@10.0.0': {}
 
@@ -3314,6 +3321,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+    optional: true
 
   color-convert@2.0.1:
     dependencies:
@@ -3327,7 +3335,8 @@ snapshots:
     dependencies:
       simple-wcswidth: 1.1.2
 
-  cookie@1.1.1: {}
+  cookie@1.1.1:
+    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3388,7 +3397,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
-  escalade@3.2.0: {}
+  escalade@3.2.0:
+    optional: true
 
   estree-walker@3.0.3:
     dependencies:
@@ -3477,7 +3487,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  get-caller-file@2.0.5: {}
+  get-caller-file@2.0.5:
+    optional: true
 
   get-tsconfig@4.13.6:
     dependencies:
@@ -3519,7 +3530,8 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
-  graphql@16.13.0: {}
+  graphql@16.13.0:
+    optional: true
 
   gtoken@7.1.0:
     dependencies:
@@ -3531,7 +3543,8 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  headers-polyfill@4.0.3: {}
+  headers-polyfill@4.0.3:
+    optional: true
 
   html-escaper@2.0.2: {}
 
@@ -3548,7 +3561,8 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-node-process@1.2.0: {}
+  is-node-process@1.2.0:
+    optional: true
 
   is-stream@2.0.1: {}
 
@@ -3676,10 +3690,12 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
   mustache@4.2.0: {}
 
-  mute-stream@2.0.0: {}
+  mute-stream@2.0.0:
+    optional: true
 
   mute-stream@3.0.0: {}
 
@@ -3699,7 +3715,8 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  outvariant@1.4.3: {}
+  outvariant@1.4.3:
+    optional: true
 
   p-finally@1.0.0: {}
 
@@ -3727,7 +3744,8 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
-  path-to-regexp@6.3.0: {}
+  path-to-regexp@6.3.0:
+    optional: true
 
   pathe@2.0.3: {}
 
@@ -3743,11 +3761,13 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  require-directory@2.1.1: {}
+  require-directory@2.1.1:
+    optional: true
 
   resolve-pkg-maps@1.0.0: {}
 
-  rettime@0.10.1: {}
+  rettime@0.10.1:
+    optional: true
 
   rollup@4.59.0:
     dependencies:
@@ -3802,11 +3822,13 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  statuses@2.0.2: {}
+  statuses@2.0.2:
+    optional: true
 
   std-env@3.10.0: {}
 
-  strict-event-emitter@0.5.1: {}
+  strict-event-emitter@0.5.1:
+    optional: true
 
   string-width@4.2.3:
     dependencies:
@@ -3838,7 +3860,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  tagged-tag@1.0.0: {}
+  tagged-tag@1.0.0:
+    optional: true
 
   test-exclude@7.0.2:
     dependencies:
@@ -3861,15 +3884,18 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
-  tldts-core@7.0.24: {}
+  tldts-core@7.0.24:
+    optional: true
 
   tldts@7.0.24:
     dependencies:
       tldts-core: 7.0.24
+    optional: true
 
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.24
+    optional: true
 
   tr46@0.0.3: {}
 
@@ -3887,12 +3913,14 @@ snapshots:
   type-fest@5.4.4:
     dependencies:
       tagged-tag: 1.0.0
+    optional: true
 
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
 
-  until-async@3.0.2: {}
+  until-async@3.0.2:
+    optional: true
 
   uuid@10.0.0: {}
 
@@ -3998,6 +4026,7 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+    optional: true
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -4011,9 +4040,11 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
-  y18n@5.0.8: {}
+  y18n@5.0.8:
+    optional: true
 
-  yargs-parser@21.1.1: {}
+  yargs-parser@21.1.1:
+    optional: true
 
   yargs@17.7.2:
     dependencies:
@@ -4024,9 +4055,11 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    optional: true
 
   yocto-queue@1.2.2: {}
 
-  yoctocolors-cjs@2.1.3: {}
+  yoctocolors-cjs@2.1.3:
+    optional: true
 
   zod@3.25.76: {}


### PR DESCRIPTION
## Summary

Fix stale claims in `docs/development/testing.md` and drop the unused `msw` devDependency.

## What was wrong

The page claimed:
- *"MSW (Mock Service Worker) intercepts all HTTP requests — no real AIRS credentials needed"* — false. `rg "msw|setupServer|http\.\b" src tests` returns zero hits. No handlers, no `setupServer`, no `http.*` calls.
- A `Test Structure` tree listing `tests/integration/`, `tests/unit/memory/`, `tests/unit/persistence/`, `tests/unit/report/`, `tests/unit/core/loop.spec.ts` — none of which exist on disk.

The actual mocks in `tests/helpers/mocks.ts` are service-level factories (`createMockManagementService`, `createMockScanService`, `createMockAllowScanService`, `createMockRedTeamService`, `createMockModelSecurityService`) returning in-memory implementations of the project's service interfaces. The SDK and its HTTP layer are never instantiated.

## What changed

- Rewrote **Mocking** section to describe the real service-level mocks honestly, with a table mapping each factory to its purpose
- Rewrote **Test Structure** tree to match `find tests -name "*.spec.ts" -o -name "mocks.ts" | sort` output
- Added a cross-link to `docs/development/smoke-tests.md` for live AIRS coverage (the `RESPONSE_VALIDATION` finding from yesterday's smoke-test run is exactly the kind of drift that page is designed to catch)
- Surfaced the actual coverage thresholds (90% lines, 95% functions, 80% branches, 90% statements) inline in the Coverage section
- Tightened "Running Tests" admonition to make explicit that no AIRS env vars are needed for `pnpm test`
- Removed `msw ^2.0.0` from `package.json` devDependencies; `pnpm-lock.yaml` regenerated

## Files changed

- `docs/development/testing.md` — rewrite
- `package.json` — `msw` removed
- `pnpm-lock.yaml` — regenerated
- `.changeset/0010-fix-testing-doc.md` — patch changeset

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` — 512/512 pass (no msw refs to break)
- [x] `pnpm lint` clean
- [x] `mkdocs build --strict` succeeds locally; cross-link to `smoke-tests.md` resolves
- [x] `rg "msw|setupServer|http\.\b" src tests` — zero hits (confirmed `msw` was truly unused before removal)
- [ ] CI green (lint, test, typecheck, docs-build)

## Notable observations (out of scope, follow-up)

- `src/report/json.ts` and `src/report/html.ts` have **0% coverage**. The overall `pnpm run test:coverage` still passes because the rest of the codebase carries the average (91.62% lines), but those two modules are real test debt.
- `CLAUDE.md`'s test-tree section lives outside `docs/` and is also stale (lists the same nonexistent `report/` test dir). Worth a separate cleanup.

Closes #55
