### PR TITLE
chore(deps): upgrade @cdot65/prisma-airs-sdk to ^0.8.1

### DIFF
--- a/.changeset/0011-sdk-081-upgrade.md
+++ b/.changeset/0011-sdk-081-upgrade.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Upgrade `@cdot65/prisma-airs-sdk` from `0.8.0` to `0.8.1`. Picks up a fix to the `TopicArraySchema.topic` field, which was strict-array in 0.8.0 but the AIRS API legitimately returns `null` for empty action buckets. SDK 0.8.0 + live tenants would fail `airs runtime profiles list` with `RESPONSE_VALIDATION` for any profile that had an empty allow or block bucket; 0.8.1 fixes this. No CLI behavior changes.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/vertex-sdk": "^0.14.4",
-    "@cdot65/prisma-airs-sdk": "^0.8.0",
+    "@cdot65/prisma-airs-sdk": "^0.8.1",
     "@inquirer/prompts": "^8.3.0",
     "@langchain/anthropic": "^1.3.25",
     "@langchain/aws": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.14.4
         version: 0.14.4(zod@3.25.76)
       '@cdot65/prisma-airs-sdk':
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.8.1
+        version: 0.8.1
       '@inquirer/prompts':
         specifier: ^8.3.0
         version: 8.3.0(@types/node@22.19.13)
@@ -313,8 +313,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cdot65/prisma-airs-sdk@0.8.0':
-    resolution: {integrity: sha512-xYSf+Wb0qsMfw8pGTCJe6GaCGcYq0dOX2h9ewS3c1Elun0ggOgtQKAPpxWih5EiR4iAslmtqmJFMavVPgZARcQ==}
+  '@cdot65/prisma-airs-sdk@0.8.1':
+    resolution: {integrity: sha512-14I2+6Vy1ARLTEripdFUVsfNvll6zu8CkIeru42UzeJQnysEHYFp7+W5j+4cU4YjUFFooxQoGqs1/GYfTEoXAQ==}
     engines: {node: '>=18'}
 
   '@cfworker/json-schema@4.1.1':
@@ -2439,7 +2439,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.5':
     optional: true
 
-  '@cdot65/prisma-airs-sdk@0.8.0':
+  '@cdot65/prisma-airs-sdk@0.8.1':
     dependencies:
       zod: 3.25.76
 


### PR DESCRIPTION
## Summary

Bump `@cdot65/prisma-airs-sdk` from `^0.8.0` to `^0.8.1`.

## Why

SDK 0.8.0 was strict on `TopicArraySchema.topic` — declared as `z.array(TopicObjectSchema)` (non-nullable). The AIRS production API legitimately returns `"topic": null` when an action bucket (allow or block) has no topics, so 0.8.0's now-on Zod runtime validation rejected real-world responses. Yesterday's first run of the live smoke test reference (`airs runtime profiles list`) hit `AISEC_RESPONSE_VALIDATION` on 4 distinct profiles in a real tenant.

SDK 0.8.1 makes that field `.nullable()`. CLI public surface unchanged.

## Files changed

- `package.json` — SDK to `^0.8.1`
- `pnpm-lock.yaml` — regenerated
- `.changeset/0011-sdk-081-upgrade.md` — patch changeset

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` — 512/512 pass
- [x] `pnpm lint` clean
- [x] `pnpm run build` clean
- [ ] CI green (lint, test, typecheck, docs-build)
- [ ] **Live verification:** `airs runtime profiles list` against the real tenant that previously hit `RESPONSE_VALIDATION` succeeds with 0.8.1

Closes #57
