### PR TITLE
docs: fix rule-instances command in smoke test reference

### DIFF
--- a/.changeset/0012-fix-smoke-rule-instances.md
+++ b/.changeset/0012-fix-smoke-rule-instances.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Fix `airs model-security rule-instances list` entry in the live smoke test reference. The CLI requires a positional `<groupUuid>` argument (rule instances are scoped to a security group); the doc was missing it. Discovered during the first live run of the smoke checklist on a real tenant.

--- a/docs/development/smoke-tests.md
+++ b/docs/development/smoke-tests.md
@@ -92,8 +92,10 @@ airs model-security groups list
 # 2. List rules — exercises rule shape (snake_case → camelCase normalization path)
 airs model-security rules list
 
-# 3. List rule instances — exercises state enum (BLOCKING | ALLOWING | DISABLED)
-airs model-security rule-instances list
+# 3. List rule instances for one of the groups from command 1 — exercises state enum
+#    (BLOCKING | ALLOWING | DISABLED). Replace <groupUuid> with the UUID of any
+#    group from the previous command's output.
+airs model-security rule-instances list <groupUuid>
 
 # 4. List recent scans — exercises scan summary shape (evaluations/violations/files counts)
 airs model-security scans list


### PR DESCRIPTION
## Summary

Fix one entry in `docs/development/smoke-tests.md` Step 4 — `airs model-security rule-instances list` requires a positional `<groupUuid>`.

Discovered during the first live run of the smoke checklist on a real tenant: the other 10 commands worked, this one errored with `error: missing required argument 'groupUuid'`.

## Root cause

The CLI's [src/cli/commands/modelsecurity.ts:386](src/cli/commands/modelsecurity.ts:386) declares the command as `command('list <groupUuid>')` — rule instances are scoped to a security group, there's no flat list endpoint. Doc was wrong.

## Fix

Substitute `<groupUuid>` placeholder and chain instructions to use a UUID from Step 4 command 1's `groups list` output.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 512/512
- [x] `mkdocs build --strict` clean
- [ ] CI green

Closes #59