### PR TITLE
chore: bump to v2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/prisma-airs-cli",
   "packageManager": "pnpm@10.6.5",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Version bump for the v2.6.1 release.

## What's in this release

Consolidates 7 changesets (0008–0014) merged since v2.6.0:

### Bug fix (the headline)

- **Fixes `airs runtime profiles list` against tenants with empty topic-list action buckets** (via SDK 0.8.1). SDK 0.8.0 tightened response Zod validation but had `TopicArraySchema.topic` as non-nullable; the AIRS API legitimately returns \`null\` when an allow or block bucket is empty. SDK 0.8.1 made the field \`.nullable()\` to match the wire shape. Without this, profile list would error with \`RESPONSE_VALIDATION\` on most real tenants.

### Dependency upgrades

- \`@cdot65/prisma-airs-sdk\` \`^0.7.1\` → \`^0.8.1\`
  - 0.8.0: runtime Zod validation now ON for every response; \`ScanResponse.{timeout,error,errors}\` and \`CustomTopic.{revision,description,examples}\` tightened from optional → required; \`tool_detected\` reshape (not used in this CLI). New \`ErrorType.RESPONSE_VALIDATION\` enum value.
  - 0.8.1: \`TopicArraySchema.topic\` \`.nullable()\` (the bug fix above).
- Removed unused \`msw\` devDependency (peer dep of vitest only — never imported anywhere in src/tests).

### Documentation

- New: [Live Smoke Tests](docs/development/smoke-tests.md) — 16-command checklist for catching wire-format drift after CLI/SDK releases.
- New: [Full CLI Command Sweep](docs/development/full-cli-sweep.md) — comprehensive deep-audit walkthrough of every command, with cleanup order.
- Fixed: \`docs/development/testing.md\` — corrected stale claims about MSW handlers and a wrong test-directory tree.
- Fixed: rule-instances command in smoke-tests.md (required \`<groupUuid>\` arg) and ~20 signature errors in full-cli-sweep.md (verified against \`src/cli/commands/*.ts\`).

### Internal

- Test mocks updated to satisfy the now-required CustomTopic fields.
- Added a \`Known Issues\` section to full-cli-sweep.md noting:
  - \`runtime scan-logs query\` may RESPONSE_VALIDATION on some tenants — SDK schema follow-up tracked
  - \`redteam prompt-sets get\` second-call 500 from \`getPromptSetVersionInfo\` — CLI soft-fail follow-up tracked
  - \`runtime customer-apps get\` 403 is a permission boundary, not a bug

## PRs in this release

- #52 chore(deps): upgrade @cdot65/prisma-airs-sdk to ^0.8.0
- #54 docs: add live AIRS smoke test reference
- #56 docs: fix stale testing.md, drop unused msw dep
- #58 chore(deps): upgrade @cdot65/prisma-airs-sdk to ^0.8.1
- #60 docs: fix rule-instances command in smoke test reference
- #62 docs: add full CLI command sweep reference
- #64 docs: fix wrong command signatures in full-cli-sweep.md

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm test\` — 512/512
- [x] \`pnpm lint\` clean
- [x] \`pnpm run build\` clean
- [x] \`mkdocs build --strict\` clean
- [x] Live verified: \`airs runtime profiles list\` succeeds on a real tenant (24 profiles, no \`RESPONSE_VALIDATION\`)
- [ ] CI green
- [ ] After merge: tag v2.6.1 + GitHub release → publish.yml ships to npm