### PR TITLE
fix: use File instead of Blob for CSV upload

### DIFF
--- a/.changeset/0015-fix-csv-upload-filename.md
+++ b/.changeset/0015-fix-csv-upload-filename.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Fix `airs redteam prompt-sets upload` failing with `File must be a CSV` (400). The upload now sends a `File` (with filename) instead of a bare `Blob`, so the server can identify the content type from the multipart header.

--- a/src/cli/commands/redteam.ts
+++ b/src/cli/commands/redteam.ts
@@ -503,7 +503,8 @@ export function registerRedteamCommand(program: Command): void {
         renderRedteamHeader();
         const service = await createPromptSetService();
         const content = fs.readFileSync(file);
-        const blob = new Blob([content], { type: 'text/csv' });
+        const filename = path.basename(file);
+        const blob = new File([content], filename, { type: 'text/csv' });
         const result = await service.uploadPromptsCsv(uuid, blob);
         console.log(`  ${result.message}\n`);
       } catch (err) {


### PR DESCRIPTION
`airs redteam prompt-sets upload <uuid> file.csv` fails with:

```
Error: AISEC_SERVER_SIDE_ERROR: Upload failed (400): {"code":"validation_error","message":"File must be a CSV"}
```

The upload handler constructs a `Blob` without a filename, so the server can't identify the file type from the multipart content-disposition header. Switching to `File` (which extends `Blob` but includes the filename) fixes the issue.

One-line change: `new Blob([content], { type: 'text/csv' })` -> `new File([content], filename, { type: 'text/csv' })`.