### PR TITLE
chore: bump to v2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/prisma-airs-cli",
   "packageManager": "pnpm@10.6.5",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- feat: `--goals`/`--depth`/`--breadth` flags for redteam DYNAMIC scans (#66)
- fix: CSV upload sends `File` w/ filename instead of bare `Blob` (#67)
- fix: download template — bump SDK to 0.8.3 + drop 30-line OAuth workaround (#68)

Changesets: 0015–0017.

## Test plan

- [x] `pnpm run lint`, `pnpm tsc --noEmit`, `pnpm test` clean on each contributing PR
- [ ] CI passes on this bump
- [ ] After merge: tag v2.7.0, GitHub release fires `publish.yml` → npm