### PR TITLE
docs: link DLP Detection Testing from home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,14 @@ Prisma AIRS CLI is a CLI tool that provides full operational coverage over **Pal
 
     [:octicons-arrow-right-24: Profile Audits](runtime/profile-audits.md)
 
+-   :material-magnify-scan:{ .lg .middle } **DLP Detection Testing**
+
+    ---
+
+    A synthetic, multi-modality corpus (PDF, JPEG, PNG, DOCX, ZIP) for evaluating how well a scanner detects sensitive data hidden via invisible text layers, metadata, container padding, OCR-only pixels, and steganography.
+
+    [:octicons-arrow-right-24: DLP Detection Testing](dlp-detection/index.md)
+
 </div>
 
 ---


### PR DESCRIPTION
Follow-up to #71. The squash merge of #71 landed just before this home-page commit was pushed, so the deployed site is missing the landing-page link to the new section.

Adds a **DLP Detection Testing** card to the home-page Capabilities grid linking to `dlp-detection/`.

## Test plan
- [x] `mkdocs build` clean locally; card renders and link resolves to `dlp-detection/`