### PR TITLE
feat(runtime): dlp-gen — generate DLP test corpora + dlp-test-files skill

### DIFF
--- a/.changeset/0018-runtime-dlp-gen.md
+++ b/.changeset/0018-runtime-dlp-gen.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": minor
+---
+
+Add `airs runtime dlp-gen` to generate DLP test corpora: clean carrier files plus "dirty" copies with synthetic sensitive data embedded across PDF, PNG, JPEG, SVG, and DOCX via multiple hiding techniques (metadata, hidden text, container trailers, PNG chunks, LSB steganography, EXIF/COM, DOCX core-props/hidden-run). Writes `clean/`, `dirty/`, and a `manifest.json` mapping each dirty file to its technique and embedded values for scanner scoring. All values are synthetic / reserved-for-testing. Adds a companion `dlp-test-files` skill.

--- a/.claude/skills/dlp-test-files/SKILL.md
+++ b/.claude/skills/dlp-test-files/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: dlp-test-files
+description: Generate DLP test files for scanner-efficacy testing — clean carrier files plus "dirty" copies with synthetic sensitive data embedded via multiple hiding techniques. Use when asked to create DLP/data-loss test corpora, embed synthetic sensitive data in PDF/PNG/JPEG/SVG/DOCX, produce clean/dirty test pairs, or build files to exercise a content scanner's DLP detection. Drives the `airs runtime dlp-gen` CLI command.
+---
+
+# DLP Test-File Generation
+
+Generate paired **clean** and **dirty** files to measure how well a content scanner (e.g.
+Prisma AIRS) detects sensitive data hidden across file formats and embedding channels. All
+embedded data is **synthetic** (reserved/test ranges only — never real PII).
+
+This skill drives the `airs runtime dlp-gen` command. Do not hand-roll generators; use the CLI.
+
+## When to use
+
+- "Generate DLP test files / a DLP test corpus"
+- "Embed (synthetic) sensitive data in a PDF / PNG / JPEG / SVG / DOCX"
+- "Create clean and dirty test files for the scanner"
+- Building a batch to score a DLP/guardrail scanner's detection rate
+
+## Command
+
+```bash
+airs runtime dlp-gen [options]
+```
+
+| Option | Default | Meaning |
+|--------|---------|---------|
+| `--types <list>` | `all` | Comma list of `pdf,png,jpeg,svg,docx` (or `all`) |
+| `--count <n>` | `1` | Clean files to generate per type |
+| `--out <dir>` | `./temp` | Base output directory |
+| `--techniques <list>` | `all` | `all` or comma list of technique ids (below) |
+| `--seed <n>` | random | Seed the synthetic-payload RNG for reproducible runs |
+| `--output <fmt>` | `pretty` | `pretty` or `json` summary |
+
+### Examples
+
+```bash
+# Full corpus, all formats + techniques, into ./temp
+airs runtime dlp-gen
+
+# Only images, 3 each, reproducible
+airs runtime dlp-gen --types png,jpeg,svg --count 3 --seed 42
+
+# Just the PNG steganography variant, JSON summary
+airs runtime dlp-gen --types png --techniques stego-lsb --output json
+```
+
+## Output layout
+
+```
+<out>/
+  clean/<type>/<base>.<ext>                 # benign carriers (controls)
+  dirty/<type>/<base>__<technique>.<ext>    # one per (clean file × technique)
+  manifest.json                             # dirty file -> technique + embedded values
+```
+
+`manifest.json` records, for every dirty file, the technique used and the exact synthetic
+values embedded — use it to score scanner hits/misses.
+
+## Techniques per format
+
+| Format | Technique ids |
+|--------|---------------|
+| PDF | `meta`, `hidden-text`, `trailer` |
+| PNG | `text-chunks`, `trailer`, `stego-lsb` |
+| JPEG | `exif`, `com`, `trailer` |
+| SVG | `meta`, `hidden-text`, `comment` |
+| DOCX | `core-props`, `hidden-run`, `visible` |
+
+## Scoring against a scanner
+
+After generating, scan each dirty file's content and compare against the manifest. Example
+loop with `airs runtime scan` (text channels; images may need base64 submission per your
+gateway):
+
+```bash
+airs runtime dlp-gen --types svg --out ./temp --seed 1 --output json
+# for each dirty file, submit its content and check whether DLP fired,
+# then reconcile with manifest.json entries[].values
+```
+
+Clean files in `clean/` are true-negative controls: a correctly-configured DLP profile should
+**allow** them and **block** the matching dirty files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,19 @@ airs runtime resume-poll <stateFile> [--output <csv>]
 
 Resumes polling from saved bulk scan state file after a crash or rate limit failure.
 
+#### Generate DLP test files
+
+```bash
+airs runtime dlp-gen [--types pdf,png,jpeg,svg,docx] [--count <n>] [--out <dir>] [--techniques all|<ids>] [--seed <n>] [--output pretty|json]
+```
+
+Generates clean carrier files and "dirty" copies with **synthetic** sensitive data embedded
+via multiple techniques (per format). Writes `<out>/clean/`, `<out>/dirty/`, and
+`<out>/manifest.json` (dirty file → technique + embedded values, for scoring). No auth required
+(local file generation). Technique ids: PDF `meta|hidden-text|trailer`; PNG
+`text-chunks|trailer|stego-lsb`; JPEG `exif|com|trailer`; SVG `meta|hidden-text|comment`; DOCX
+`core-props|hidden-run|visible`. All values are synthetic / reserved-for-testing.
+
 ---
 
 ### Runtime — Configuration Management

--- a/docs/development/full-cli-sweep.md
+++ b/docs/development/full-cli-sweep.md
@@ -126,6 +126,42 @@ airs model-security labels values <labelKey>
 airs model-security pypi-auth
 ```
 
+### B.4 — Runtime DLP test-file generation (local, no API)
+
+Generates clean carrier files plus "dirty" copies with synthetic sensitive data embedded via
+multiple techniques. Local only — no AIRS API calls, safe to run anywhere.
+
+```bash
+# Full corpus (all formats + techniques) into ./temp, reproducible with a seed
+airs runtime dlp-gen --types all --count 1 --out ./temp --seed 1
+
+# Images only, JSON summary
+airs runtime dlp-gen --types png,jpeg,svg --techniques all --output json
+
+# Just the PNG steganography variant
+airs runtime dlp-gen --types png --techniques stego-lsb --out ./temp
+```
+
+Expected output (pretty):
+
+```
+  DLP Test-File Generation
+  Output:   ./temp
+  Seed:     1
+  Clean:    5    Dirty: 15
+  Manifest: ./temp/manifest.json
+
+    svg   clean=1 dirty=3
+    png   clean=1 dirty=3
+    pdf   clean=1 dirty=3
+    jpeg  clean=1 dirty=3
+    docx  clean=1 dirty=3
+```
+
+Produces `temp/clean/<type>/`, `temp/dirty/<type>/<base>__<technique>.<ext>`, and
+`temp/manifest.json` (each dirty file → technique + embedded synthetic values). All values are
+synthetic / reserved-for-testing.
+
 ## Section C — Synchronous scan
 
 Smallest possible write — single sync scan returns immediately, no state to clean up.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -198,6 +198,63 @@ airs runtime resume-poll <stateFile> [--output <file>]
 | `<stateFile>` | Yes | Path to saved `.bulk-scan.json` state file |
 | `--output <file>` | No | Output CSV path |
 
+### runtime dlp-gen
+
+Generate DLP test files — clean carriers plus "dirty" copies with synthetic sensitive data
+embedded via multiple techniques across PDF/PNG/JPEG/SVG/DOCX. Local only; no AIRS API calls.
+
+```bash
+airs runtime dlp-gen [--types <list>] [--count <n>] [--out <dir>] [--techniques <list>] [--seed <n>] [--output <fmt>]
+```
+
+#### Options
+
+| Flag | Required | Description |
+|------|:--------:|-------------|
+| `--types <list>` | No | Comma list of `pdf,png,jpeg,svg,docx` or `all` (default: `all`) |
+| `--count <n>` | No | Clean files per type (default: `1`) |
+| `--out <dir>` | No | Output base directory (default: `./temp`) |
+| `--techniques <list>` | No | `all` or comma list of technique ids (default: `all`) |
+| `--seed <n>` | No | Seed the synthetic-payload RNG for reproducible runs |
+| `--output <fmt>` | No | Summary format: `pretty` (default) or `json` |
+
+Technique ids: PDF `meta`, `hidden-text`, `trailer`; PNG `text-chunks`, `trailer`, `stego-lsb`;
+JPEG `exif`, `com`, `trailer`; SVG `meta`, `hidden-text`, `comment`; DOCX `core-props`,
+`hidden-run`, `visible`.
+
+#### Examples
+
+```bash
+# Full corpus into ./temp, reproducible
+airs runtime dlp-gen --types all --seed 1
+
+# Images only, 3 each
+airs runtime dlp-gen --types png,jpeg,svg --count 3
+
+# Just PNG LSB steganography, JSON summary
+airs runtime dlp-gen --types png --techniques stego-lsb --output json
+```
+
+#### Example Output
+
+```
+  DLP Test-File Generation
+  Output:   ./temp
+  Seed:     1
+  Clean:    5    Dirty: 15
+  Manifest: ./temp/manifest.json
+
+    svg   clean=1 dirty=3
+    png   clean=1 dirty=3
+    pdf   clean=1 dirty=3
+    jpeg  clean=1 dirty=3
+    docx  clean=1 dirty=3
+```
+
+Output layout: `<out>/clean/<type>/`, `<out>/dirty/<type>/<base>__<technique>.<ext>`, and
+`<out>/manifest.json` (dirty file → technique + embedded synthetic values, for scanner
+scoring). All values are synthetic / reserved-for-testing.
+
 ### runtime profiles
 
 Security profile CRUD and profile-level audit.

--- a/docs/runtime/dlp-gen.md
+++ b/docs/runtime/dlp-gen.md
@@ -1,0 +1,62 @@
+# DLP Test-File Generation
+
+`airs runtime dlp-gen` generates **DLP test corpora** — clean carrier files plus "dirty"
+copies with **synthetic** sensitive data embedded via multiple hiding techniques. Use it to
+measure how well a content scanner detects sensitive data across file formats and channels.
+
+!!! danger "Synthetic data only"
+    Every embedded value comes from a reserved / documented test range (reserved-range SSNs,
+    Luhn-valid test PANs, `example.com` emails, `555-01xx` phones, AWS `…EXAMPLE` keys). No
+    real PII is ever produced.
+
+## Usage
+
+```bash
+airs runtime dlp-gen [options]
+```
+
+| Option | Default | Meaning |
+|--------|---------|---------|
+| `--types <list>` | `all` | Comma list of `pdf,png,jpeg,svg,docx` (or `all`) |
+| `--count <n>` | `1` | Clean files per type |
+| `--out <dir>` | `./temp` | Output base directory |
+| `--techniques <list>` | `all` | `all` or comma list of technique ids |
+| `--seed <n>` | random | Seed for reproducible payloads |
+| `--output <fmt>` | `pretty` | `pretty` or `json` summary |
+
+**Auth:** none — purely local file generation.
+
+## Output
+
+```
+<out>/
+  clean/<type>/<base>.<ext>                 # benign carriers (true-negative controls)
+  dirty/<type>/<base>__<technique>.<ext>    # one per (clean file × technique)
+  manifest.json                             # dirty file -> technique + embedded values
+```
+
+Use `manifest.json` to score scanner hits/misses: it lists, per dirty file, the technique and
+the exact synthetic values embedded.
+
+## Techniques
+
+| Format | Technique ids |
+|--------|---------------|
+| PDF | `meta`, `hidden-text`, `trailer` |
+| PNG | `text-chunks`, `trailer`, `stego-lsb` |
+| JPEG | `exif`, `com`, `trailer` |
+| SVG | `meta`, `hidden-text`, `comment` |
+| DOCX | `core-props`, `hidden-run`, `visible` |
+
+## Examples
+
+```bash
+# Full corpus into ./temp
+airs runtime dlp-gen
+
+# Images only, 3 each, reproducible
+airs runtime dlp-gen --types png,jpeg,svg --count 3 --seed 42
+
+# Just PNG LSB steganography, JSON summary
+airs runtime dlp-gen --types png --techniques stego-lsb --output json
+```

--- a/docs/superpowers/plans/2026-05-21-dlp-test-file-generator.md
+++ b/docs/superpowers/plans/2026-05-21-dlp-test-file-generator.md
@@ -1,0 +1,408 @@
+# DLP Test-File Generator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `airs runtime dlp-gen`, a CLI command that generates clean carrier files and "dirty" copies with synthetic sensitive data embedded via multiple techniques, plus a `.claude/skills/dlp-test-files` skill that drives it.
+
+**Architecture:** Framework-free, unit-tested core under `src/dlp/` (payload generator, lorem, manifest, per-format clean generators, per-format embedders, orchestrator). Thin Commander wiring under `src/cli/` registers `dlp-gen` in the existing `runtime` group. A committed skill documents when/how to invoke the command.
+
+**Tech Stack:** TypeScript, Commander, Zod, Vitest; `pdf-lib`, `docx`, `sharp`, `piexifjs`.
+
+---
+
+## File Structure
+
+```
+src/dlp/
+  types.ts            # PayloadValue, ManifestEntry, Technique, GenerateOptions
+  rng.ts              # seeded RNG (mulberry32)
+  payload.ts          # synthetic PII generator (uses rng)
+  lorem.ts            # lorem ipsum generator (uses rng)
+  manifest.ts         # manifest assembly + JSON write
+  generate/{pdf,docx,png,jpeg,svg}.ts   # clean file bytes
+  embed/{pdf,docx,png,jpeg,svg}.ts      # technique map: (bytes, payload) -> dirty bytes
+  embed/extractors.ts # test-only helpers to recover embedded values (also used by --verify)
+  index.ts            # orchestration: generate -> embed per technique -> write + manifest
+src/dlp/__tests__/*.test.ts
+src/cli/commands/runtime.ts             # MODIFY: register `dlp-gen`
+src/cli/renderer/runtime.ts             # MODIFY: render summary
+.claude/skills/dlp-test-files/SKILL.md  # the skill
+.changeset/0008-runtime-dlp-gen.md
+```
+
+Test layout: confirm convention in Task 0 (`src/**/__tests__/*.test.ts` vs co-located). Follow whatever exists.
+
+---
+
+## Task 0: Scaffolding, deps, test-convention
+
+**Files:** `package.json` (deps), confirm test layout.
+
+- [ ] **Step 1:** Inspect existing test convention.
+
+Run: `find src -name "*.test.ts" | head; cat vitest.config.* 2>/dev/null; grep -n '"test"' package.json`
+Expected: learn where tests live and the coverage `exclude` globs. Use that location for all `*.test.ts` below.
+
+- [ ] **Step 2:** Add runtime deps.
+
+Run: `pnpm add pdf-lib docx sharp piexifjs && pnpm add -D @types/piexifjs`
+Expected: deps land in `package.json`; `pnpm install` succeeds.
+
+- [ ] **Step 3:** Verify build still green.
+
+Run: `pnpm typecheck && pnpm lint`
+Expected: PASS.
+
+- [ ] **Step 4:** Commit.
+
+```bash
+git add package.json pnpm-lock.yaml
+git commit -m "build: add pdf-lib, docx, sharp, piexifjs for dlp-gen"
+```
+
+---
+
+## Task 1: Types + seeded RNG
+
+**Files:** Create `src/dlp/types.ts`, `src/dlp/rng.ts`, test `rng.test.ts`.
+
+- [ ] **Step 1: Write failing test** (`rng.test.ts`)
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { makeRng } from "../rng";
+
+describe("makeRng", () => {
+  it("is deterministic for a seed", () => {
+    const a = makeRng(42); const b = makeRng(42);
+    expect([a(), a(), a()]).toEqual([b(), b(), b()]);
+  });
+  it("differs across seeds", () => {
+    expect(makeRng(1)()).not.toEqual(makeRng(2)());
+  });
+  it("returns floats in [0,1)", () => {
+    const r = makeRng(7);
+    for (let i = 0; i < 100; i++) { const v = r(); expect(v).toBeGreaterThanOrEqual(0); expect(v).toBeLessThan(1); }
+  });
+});
+```
+
+- [ ] **Step 2:** Run `pnpm vitest run src/dlp` → FAIL (no module).
+
+- [ ] **Step 3: Implement**
+
+`src/dlp/rng.ts`:
+```typescript
+/** Deterministic PRNG (mulberry32). Returns () => float in [0,1). */
+export function makeRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+export const pick = <T>(rng: () => number, xs: T[]): T => xs[Math.floor(rng() * xs.length)];
+export const digits = (rng: () => number, n: number): string =>
+  Array.from({ length: n }, () => Math.floor(rng() * 10)).join("");
+```
+
+`src/dlp/types.ts`:
+```typescript
+export type Format = "pdf" | "png" | "jpeg" | "svg" | "docx";
+export interface PayloadValue { category: string; value: string; }
+export interface Technique {
+  id: string; format: Format; label: string;
+  embed: (clean: Buffer, payload: PayloadValue[]) => Promise<Buffer> | Buffer;
+}
+export interface ManifestEntry {
+  format: Format; technique: string; clean: string; dirty: string; values: PayloadValue[];
+}
+export interface GenerateOptions {
+  types: Format[]; count: number; out: string; techniques: "all" | string[]; seed?: number;
+}
+```
+
+- [ ] **Step 4:** Run `pnpm vitest run src/dlp` → PASS.
+
+- [ ] **Step 5:** Commit `feat(dlp): seeded rng + core types`.
+
+---
+
+## Task 2: Synthetic payload generator
+
+**Files:** Create `src/dlp/payload.ts`, test `payload.test.ts`.
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { makePayload, luhnValid } from "../payload";
+
+describe("makePayload", () => {
+  it("is deterministic by seed", () => {
+    expect(makePayload(makeRngFromSeed(5))).toEqual(makePayload(makeRngFromSeed(5)));
+  });
+  it("emits a luhn-valid test PAN", () => {
+    const pan = find(makePayload(rng()), "credit_card").replace(/\s/g, "");
+    expect(luhnValid(pan)).toBe(true);
+    expect(pan.startsWith("4")).toBe(true);            // test Visa BIN family
+  });
+  it("uses only reserved/example ranges (no real-PII shapes)", () => {
+    const all = makePayload(rng()).map(v => v.value).join(" ");
+    expect(all).toMatch(/@example\.(com|org|net)/);
+    expect(all).toMatch(/\b555-01\d\d\b/);
+    expect(all).not.toMatch(/sk_live_/);               // no stripe push-protection trigger
+  });
+});
+```
+(Add small local `rng`/`find` helpers in the test.)
+
+- [ ] **Step 2:** Run → FAIL.
+
+- [ ] **Step 3: Implement** `src/dlp/payload.ts`
+
+```typescript
+import { type PayloadValue } from "./types";
+import { digits, pick } from "./rng";
+
+export function luhnValid(pan: string): boolean {
+  let sum = 0, alt = false;
+  for (let i = pan.length - 1; i >= 0; i--) {
+    let d = pan.charCodeAt(i) - 48;
+    if (alt) { d *= 2; if (d > 9) d -= 9; }
+    sum += d; alt = !alt;
+  }
+  return pan.length > 0 && sum % 10 === 0;
+}
+
+function testPan(rng: () => number): string {
+  const body = "4" + digits(rng, 14);            // Visa-family test BIN, 15 digits
+  for (let c = 0; c < 10; c++) { const cand = body + c; if (luhnValid(cand)) return cand; }
+  return body + "0";
+}
+const ssn = (rng: () => number) => `9${digits(rng, 2)}-${digits(rng, 2)}-${digits(rng, 4)}`; // 900-range never issued
+const phone = (rng: () => number) => `555-01${digits(rng, 2)}`;
+const email = (rng: () => number) =>
+  `${pick(rng, ["john.public", "jane.doe", "sam.roe"])}.${digits(rng, 3)}@${pick(rng, ["example.com", "example.org", "example.net"])}`;
+const awsKey = (rng: () => number) => `AKIA${Array.from({ length: 12 }, () => pick(rng, [..."ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"])).join("")}EXAMPLE`.slice(0, 20);
+
+export function makePayload(rng: () => number): PayloadValue[] {
+  const pan = testPan(rng);
+  return [
+    { category: "ssn", value: ssn(rng) },
+    { category: "credit_card", value: pan.replace(/(\d{4})(?=\d)/g, "$1 ").trim() },
+    { category: "email", value: email(rng) },
+    { category: "phone", value: phone(rng) },
+    { category: "aws_key", value: awsKey(rng) },
+    { category: "passport", value: `X${digits(rng, 8)}` },
+    { category: "dob", value: `19${60 + Math.floor(rng() * 40)}-0${1 + Math.floor(rng() * 9)}-1${Math.floor(rng() * 9)}` },
+  ];
+}
+```
+
+- [ ] **Step 4:** Run → PASS. - [ ] **Step 5:** Commit `feat(dlp): synthetic payload generator`.
+
+---
+
+## Task 3: Lorem + manifest
+
+**Files:** Create `src/dlp/lorem.ts`, `src/dlp/manifest.ts`, tests.
+
+- [ ] **Step 1: Tests**
+
+```typescript
+// lorem.test.ts
+import { lorem } from "../lorem";
+it("returns N deterministic paragraphs", () => {
+  expect(lorem(makeRng(1), 3).split("\n\n")).toHaveLength(3);
+  expect(lorem(makeRng(1), 3)).toEqual(lorem(makeRng(1), 3));
+});
+// manifest.test.ts
+import { buildManifest } from "../manifest";
+it("maps dirty files to technique + values", () => {
+  const m = buildManifest([{ format:"svg", technique:"meta", clean:"a.svg", dirty:"a__meta.svg", values:[{category:"ssn",value:"900-00-0000"}] }]);
+  expect(m.entries[0].technique).toBe("meta");
+  expect(m.count).toBe(1);
+});
+```
+
+- [ ] **Step 2:** Run → FAIL.
+
+- [ ] **Step 3: Implement**
+
+`src/dlp/lorem.ts`: a fixed word bank + `pick`-based sentence/paragraph assembly, `lorem(rng, paras)` returns paragraphs joined by `\n\n`.
+
+`src/dlp/manifest.ts`:
+```typescript
+import { writeFile } from "node:fs/promises";
+import { type ManifestEntry } from "./types";
+export interface Manifest { generatedAt: string; count: number; entries: ManifestEntry[]; }
+export function buildManifest(entries: ManifestEntry[]): Manifest {
+  return { generatedAt: new Date().toISOString(), count: entries.length, entries };
+}
+export const writeManifest = (path: string, m: Manifest) => writeFile(path, JSON.stringify(m, null, 2));
+```
+
+- [ ] **Step 4:** Run → PASS. - [ ] **Step 5:** Commit `feat(dlp): lorem + manifest`.
+
+---
+
+## Task 4: Clean generators
+
+**Files:** Create `src/dlp/generate/{pdf,docx,png,jpeg,svg}.ts`, test `generate.test.ts`.
+
+Each exports `async (rng) => Buffer`. Tests assert the magic bytes / structural validity:
+
+- [ ] **Step 1: Test** (one assertion per format)
+
+```typescript
+import { pdf } from "../generate/pdf"; // etc.
+it("pdf starts with %PDF", async () => expect((await pdf(makeRng(1))).subarray(0,4).toString()).toBe("%PDF"));
+it("png magic", async () => expect((await png(makeRng(1))).subarray(1,4).toString()).toBe("PNG"));
+it("jpeg SOI", async () => expect((await jpeg(makeRng(1))).subarray(0,2).toString("hex")).toBe("ffd8"));
+it("svg root", async () => expect((await svg(makeRng(1))).toString()).toContain("<svg"));
+it("docx is a zip (PK)", async () => expect((await docx(makeRng(1))).subarray(0,2).toString()).toBe("PK"));
+```
+
+- [ ] **Step 2:** Run → FAIL.
+
+- [ ] **Step 3: Implement** each:
+  - `pdf.ts`: `pdf-lib` `PDFDocument.create()`, add page(s), `drawText(lorem(rng,3))`, `.save()` → Buffer.
+  - `docx.ts`: `docx` `Document` with heading + lorem paragraphs, `Packer.toBuffer`.
+  - `png.ts`/`jpeg.ts`: `sharp` from a raw gradient buffer (`{create:{width,height,channels,background}}` or raw pixel `Buffer`), `.png()`/`.jpeg()` → Buffer.
+  - `svg.ts`: template string with `<svg xmlns=...>` + shapes + `<title>/<desc>`; return `Buffer.from(...)`.
+
+- [ ] **Step 4:** Run → PASS. - [ ] **Step 5:** Commit `feat(dlp): clean file generators`.
+
+---
+
+## Task 5: Embedders + extractors (one task per format)
+
+`embed/extractors.ts` provides `extract<Format>(buf): string` returning all recoverable text, used by both tests and an optional `--verify`. Each `embed/<fmt>.ts` exports `Record<string, Technique>`.
+
+For each format below: **(a)** write a test that, for every technique, embeds a known payload then asserts each value is recoverable via the extractor AND the carrier re-parses; **(b)** run → FAIL; **(c)** implement; **(d)** run → PASS; **(e)** commit.
+
+### Task 5a: SVG (`embed/svg.ts`) — `meta`, `hidden-text`, `comment`
+
+- `meta`: inject `<metadata>`, `<desc>`, `<title>` after `<svg …>`.
+- `hidden-text`: `<text x="-9999" y="-9999">` + `<text opacity="0">` blocks.
+- `comment`: `<!-- … -->` after the root.
+- Extractor: strip tags / read full string; assert values present; re-parse with a quick well-formedness check (no unclosed `<svg`).
+- Test asserts: each technique's output contains every payload value; output still contains `</svg>`.
+- Commit `feat(dlp): svg embedders`.
+
+### Task 5b: PNG (`embed/png.ts`) — `text-chunks`, `trailer`, `stego-lsb`
+
+- `text-chunks`: append `tEXt`/`zTXt`/`iTXt` chunks before `IEND` (write chunk: length, type, data, CRC32).
+- `trailer`: append payload bytes after the `IEND` chunk.
+- `stego-lsb`: decode pixels via `sharp(buf).raw()`, write length-prefixed bytes into LSBs, re-encode `.png()`.
+- Extractors: `text-chunks` → parse chunks; `trailer` → bytes after IEND; `stego-lsb` → read LSBs.
+- Test: each technique recoverable; PNG signature intact; `sharp(out).metadata()` resolves.
+- Commit `feat(dlp): png embedders`.
+
+### Task 5c: JPEG (`embed/jpeg.ts`) — `exif`, `com`, `trailer`
+
+- `exif`: `piexifjs` set `ImageDescription` + `UserComment`, `piexif.insert`.
+- `com`: insert `FFFE` segment after SOI (length-prefixed).
+- `trailer`: append after `FFD9` EOI.
+- Extractors accordingly; test: recoverable; `sharp(out).metadata()` resolves; starts `ffd8`.
+- Commit `feat(dlp): jpeg embedders`.
+
+### Task 5d: PDF (`embed/pdf.ts`) — `meta`, `hidden-text`, `trailer`
+
+- `meta`: `pdf-lib` load, `setTitle/setSubject/setKeywords` with payload, save.
+- `hidden-text`: load, draw payload text then set invisible — push content-stream operator `3 Tr` around the text; **fallback**: draw with white color at 1pt if render-mode injection fails. Document the chosen path in a code comment.
+- `trailer`: append bytes after the final `%%EOF`.
+- Extractor: `meta` → re-load pdf-lib + read info; `trailer` → bytes after last `%%EOF`; `hidden-text` → search decompressed/text via `pdf-lib` low-level or a raw-string contains check for the literal.
+- Test: recoverable; output starts `%PDF`; re-loads with `PDFDocument.load`.
+- Commit `feat(dlp): pdf embedders`.
+
+### Task 5e: DOCX (`embed/docx.ts`) — `core-props`, `hidden-run`, `visible`
+
+- DOCX is a zip; use a zip lib already available (`docx` produces; for editing use `node:zlib`+manual or add `jszip` if needed — confirm in Task 0; prefer regenerating the doc with payload baked in rather than post-editing).
+- Approach: regenerate the doc from lorem **plus** payload runs: `core-props` via `Document({ title, subject, keywords })`; `hidden-run` via a `TextRun({ text, vanish: true })` or white color; `visible` via a normal paragraph.
+- Extractor: unzip `word/document.xml` + `docProps/core.xml`, assert values present.
+- Test: recoverable; output `PK` zip; re-open via the unzip path.
+- Commit `feat(dlp): docx embedders`.
+
+---
+
+## Task 6: Technique registry + orchestrator
+
+**Files:** Create `src/dlp/index.ts`, test `orchestrate.test.ts`.
+
+- [ ] **Step 1: Test**
+
+```typescript
+import { generateCorpus } from "../index";
+it("writes clean+dirty+manifest and is seed-reproducible", async () => {
+  const out = await mkdtemp();
+  const r1 = await generateCorpus({ types:["svg"], count:1, out, techniques:"all", seed:9 });
+  expect(existsSync(`${out}/clean/svg`)).toBe(true);
+  expect(readdirSync(`${out}/dirty/svg`).length).toBe(3); // 3 svg techniques
+  const m = JSON.parse(readFileSync(`${out}/manifest.json`,"utf8"));
+  expect(m.entries.every(e => e.values.length > 0)).toBe(true);
+  // reproducibility
+  const out2 = await mkdtemp();
+  await generateCorpus({ types:["svg"], count:1, out:out2, techniques:"all", seed:9 });
+  expect(readFileSync(`${out}/dirty/svg/${readdirSync(`${out}/dirty/svg`)[0]}`)).toEqual(
+    readFileSync(`${out2}/dirty/svg/${readdirSync(`${out2}/dirty/svg`)[0]}`));
+});
+```
+
+- [ ] **Step 2:** Run → FAIL.
+
+- [ ] **Step 3: Implement** `index.ts`:
+  - Build `ALL_TECHNIQUES: Technique[]` from the five `embed/*` maps.
+  - `generateCorpus(opts)`: for each type → `count` clean files (seeded rng per file), write to `clean/<type>/`; for each requested technique of that type → fresh payload, `embed`, write `dirty/<type>/<base>__<id>.<ext>`, push ManifestEntry; finally `writeManifest`. Return summary `{ clean, dirty, manifestPath }`.
+  - Seed handling: derive per-file/per-technique sub-seeds from `seed` deterministically.
+
+- [ ] **Step 4:** Run → PASS. - [ ] **Step 5:** Commit `feat(dlp): orchestrator + technique registry`.
+
+---
+
+## Task 7: CLI wiring
+
+**Files:** Modify `src/cli/commands/runtime.ts`, `src/cli/renderer/runtime.ts`.
+
+- [ ] **Step 1:** Add a `dlp-gen` subcommand to the `runtime` Commander group: options `--types`, `--count`, `--out`, `--techniques`, `--seed`, `--output`. Parse comma lists; default out `./temp`; call `generateCorpus`; render summary (counts per format, manifest path) via renderer; support `--output json`.
+
+- [ ] **Step 2:** Manual smoke:
+
+Run: `pnpm build && node dist/cli/index.js runtime dlp-gen --types svg,png --out /tmp/dlp-smoke --seed 1`
+Expected: `/tmp/dlp-smoke/clean`, `/tmp/dlp-smoke/dirty`, `manifest.json` created; summary printed.
+
+- [ ] **Step 3:** `pnpm typecheck && pnpm lint && pnpm test` → PASS (coverage met; `src/cli/**` excluded).
+
+- [ ] **Step 4:** Commit `feat(runtime): add dlp-gen command`.
+
+---
+
+## Task 8: The skill
+
+**Files:** Create `.claude/skills/dlp-test-files/SKILL.md`.
+
+- [ ] **Step 1:** Write SKILL.md with YAML frontmatter (`name: dlp-test-files`, `description:` including triggers: "generate DLP test files", "embed sensitive data in PDF/PNG/JPEG/SVG/DOCX", "clean/dirty corpus"). Body: when to use; `airs runtime dlp-gen` invocation patterns; the technique table; output layout; how to feed `dirty/` + `manifest.json` into a scan/score loop with `airs runtime scan`. No logic duplication — point at the CLI.
+
+- [ ] **Step 2:** Sanity: confirm frontmatter parses (name + description present, description < ~1024 chars).
+
+- [ ] **Step 3:** Commit `feat(skill): add dlp-test-files skill`.
+
+---
+
+## Task 9: Docs + changeset + PR
+
+- [ ] **Step 1:** Add `.changeset/0008-runtime-dlp-gen.md` (minor): "Add `airs runtime dlp-gen` to generate clean + dirty DLP test corpora across PDF/PNG/JPEG/SVG/DOCX, plus a dlp-test-files skill."
+- [ ] **Step 2:** Update `AGENTS.md` and `docs/` (runtime section + reference/cli-commands) with the new command. `mkdocs build` clean.
+- [ ] **Step 3:** `pnpm test && pnpm lint && pnpm typecheck` → PASS.
+- [ ] **Step 4:** Commit, push branch `cdot65/runtime-dlp-gen`, open PR.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** command/flags (T7), output layout+manifest (T3,T6), all 15 techniques (T5a–e), randomized seeded payload (T1,T2,T6), skill (T8), deps (T0), testing (every task), docs/changeset (T9). ✓
+- **Placeholders:** none — each embedder task names its exact techniques + extractor + assertions. Note T0 confirms test-dir + whether a zip lib is needed for docx (decision: regenerate doc rather than post-edit, avoiding extra dep).
+- **Type consistency:** `Technique.embed(clean, payload)`, `makePayload(rng)`, `generateCorpus(GenerateOptions)`, `buildManifest(entries)` used consistently across tasks. ✓

--- a/docs/superpowers/specs/2026-05-21-dlp-test-file-generator-design.md
+++ b/docs/superpowers/specs/2026-05-21-dlp-test-file-generator-design.md
@@ -1,0 +1,162 @@
+# DLP Test-File Generator — Design
+
+**Date:** 2026-05-21
+**Status:** Approved (brainstorm)
+**Topic:** `airs runtime dlp-gen` + `.claude/skills/dlp-test-files`
+
+## Purpose
+
+Provide a repeatable way to generate **DLP test corpora**: pairs of clean carrier files and
+"dirty" copies with synthetic sensitive data embedded via multiple hiding techniques. Used to
+measure how well a content scanner (Prisma AIRS) detects sensitive data across file modalities
+and embedding channels.
+
+Two deliverables:
+
+1. **Engine** — a new CLI subcommand `airs runtime dlp-gen` (TypeScript), with testable core
+   logic under `src/dlp/`.
+2. **Skill** — `.claude/skills/dlp-test-files/SKILL.md`, the repo's first committed skill. A
+   thin guide that teaches Claude when/how to run the subcommand; it does **not** reimplement
+   logic.
+
+## User-facing command
+
+```
+airs runtime dlp-gen [options]
+  --types <list>         Comma list of pdf,png,jpeg,svg,docx (default: all)
+  --count <n>            Clean files to generate per type (default: 1)
+  --out <dir>            Base output directory (default: ./temp)
+  --techniques <list>    all | comma list of technique ids (default: all)
+  --seed <n>             Seed the synthetic-payload RNG for reproducible runs (optional)
+  --output <format>      Summary format: pretty (default) | json
+```
+
+**Auth:** none (purely local file generation; no AIRS API calls).
+
+## Output layout
+
+```
+<out>/
+  clean/
+    pdf/<base>.pdf   png/<base>.png   jpeg/<base>.jpg   svg/<base>.svg   docx/<base>.docx
+  dirty/
+    pdf/<base>__<technique>.pdf       # one file per (clean file × technique)
+    png/<base>__<technique>.png
+    ...
+  manifest.json
+```
+
+`manifest.json` records, per dirty file: source clean file, format, technique id, and the exact
+synthetic values embedded (category → value). This lets a later step score scanner hits/misses.
+
+`<base>` is a short random slug (or seed-derived). Re-running with the same `--seed` reproduces
+identical files and payloads.
+
+## Architecture (modules)
+
+All core logic is framework-free and unit-testable under `src/dlp/`:
+
+```
+src/dlp/
+  payload.ts          # synthetic PII generator (seeded RNG)
+  lorem.ts            # lorem ipsum text generator
+  manifest.ts         # manifest record types + writer
+  generate/           # CLEAN file generators
+    pdf.ts  docx.ts  png.ts  jpeg.ts  svg.ts
+  embed/              # technique implementations (clean bytes + payload -> dirty bytes)
+    pdf.ts  docx.ts  png.ts  jpeg.ts  svg.ts
+  index.ts            # orchestration: generate -> embed (per technique) -> write + manifest
+```
+
+CLI wiring lives in `src/cli/commands/runtime.ts` (register `dlp-gen` under the existing
+`runtime` group) with a small renderer in `src/cli/renderer/runtime.ts`. CLI files under
+`src/cli/**` are excluded from coverage by the existing config; the testable logic is in
+`src/dlp/**`.
+
+## Clean-file generation
+
+| Format | Library | Content |
+|--------|---------|---------|
+| PDF | `pdf-lib` | Multi-paragraph lorem ipsum, 1–2 pages |
+| DOCX | `docx` | Lorem ipsum heading + paragraphs |
+| PNG | `sharp` | Generated raster (gradient + shapes) |
+| JPEG | `sharp` | Generated raster (gradient + shapes) |
+| SVG | (hand-built XML) | Valid vector (shapes + title/desc) |
+
+## Embedding techniques (dirty variants)
+
+Each technique has a stable `id` usable in `--techniques`.
+
+| Format | id | Technique |
+|--------|----|-----------|
+| PDF | `meta` | Document info dict (Title/Subject/Keywords) |
+| PDF | `hidden-text` | Invisible text (render mode 3; fallback white 1pt) |
+| PDF | `trailer` | Bytes appended after `%%EOF` |
+| PNG | `text-chunks` | `tEXt` / `zTXt` / `iTXt` chunks |
+| PNG | `trailer` | Bytes appended after `IEND` |
+| PNG | `stego-lsb` | LSB steganography (length-prefixed) |
+| JPEG | `exif` | EXIF `UserComment` / `ImageDescription` |
+| JPEG | `com` | JPEG `COM` comment segment |
+| JPEG | `trailer` | Bytes appended after `EOI` |
+| SVG | `meta` | `<metadata>` / `<desc>` / `<title>` |
+| SVG | `hidden-text` | `<text>` with opacity-0 / off-canvas |
+| SVG | `comment` | XML comment |
+| DOCX | `core-props` | Core/app document properties |
+| DOCX | `hidden-run` | Hidden run (vanish + white) |
+| DOCX | `visible` | Visible body line |
+
+## Synthetic payload generator
+
+`payload.ts` emits clearly-synthetic, validation-shaped values from reserved/test ranges,
+seeded for reproducibility:
+
+- **SSN** — reserved ranges that never get issued
+- **Credit card** — Luhn-valid numbers from documented network *test* BINs (e.g. 4111-series)
+- **Email** — `*@example.com|org|net`
+- **Phone** — `555-0100`–`555-0199` fictional block
+- **Credentials** — AWS `…EXAMPLE` access key + secret-shaped value; **no Stripe `sk_live_`
+  pattern** (to avoid GitHub push-protection on committed fixtures)
+- **Identity** — invented passport number + DOB
+
+Never emits real PII. Each dirty file gets a randomized subset/instance; manifest records exact
+values.
+
+## The skill
+
+`.claude/skills/dlp-test-files/SKILL.md`:
+
+- **Frontmatter:** name + description with trigger phrases ("generate DLP test files", "embed
+  sensitive data in PDF/PNG/JPEG/SVG/DOCX", "create clean/dirty test corpus").
+- **Body:** when to use; the `airs runtime dlp-gen` invocation patterns; the technique table;
+  output layout; how to feed `dirty/` files + `manifest.json` into a scan/score loop. Points at
+  the CLI; no logic duplication.
+
+## Dependencies (new)
+
+`pdf-lib`, `docx`, `sharp`, `piexifjs`. (`sharp` ships a native binary; acceptable.)
+
+## Testing strategy
+
+Vitest unit tests under `src/dlp/`:
+
+- `payload`: seeded determinism; SSN/PAN format + Luhn validity; no real-PII patterns.
+- each `embed/*`: after embedding, the synthetic values are recoverable by the matching
+  extractor (e.g. parse PNG chunks, read EXIF, decode LSB, grep SVG/XML, unzip docx XML), and
+  the carrier remains structurally valid (re-parses).
+- `generate/*`: output is a structurally valid file of the right type.
+- orchestration: correct clean/dirty/manifest layout; `--seed` reproducibility.
+
+Meets repo coverage thresholds via `src/dlp/**` (CLI wiring excluded).
+
+## Non-goals / out of scope
+
+- **IPTC** embedding for JPEG (needs exiftool); JPEG covered by exif + com + trailer.
+- Real PII of any kind.
+- Submitting files to AIRS or scoring detection (separate workflow; manifest enables it).
+- XMP for images (EXIF/text-chunks cover the metadata channel).
+
+## Open questions
+
+- `dirty/` filename scheme: `<base>__<technique>.<ext>` — OK, or include format dir only?
+- Should `manifest.json` also store base64 of each dirty file, or paths only? (Default: paths.)
+- Default `--count` of 1 acceptable, or higher?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
   - Runtime Security:
       - Overview: runtime/overview.md
       - Prompt Scanning: runtime/scanning.md
+      - DLP Test-File Generation: runtime/dlp-gen.md
       - Configuration Management: runtime/config-management.md
       - Guardrail Optimization:
           - How It Works: runtime/guardrails/overview.md

--- a/package.json
+++ b/package.json
@@ -49,10 +49,14 @@
     "@langchain/google-vertexai": "^2.1.26",
     "chalk": "^5.6.2",
     "commander": "^14.0.3",
+    "docx": "^9.6.1",
     "dotenv": "^17.3.1",
     "js-yaml": "^4.1.1",
     "nanoid": "^5.0.0",
     "p-limit": "^6.0.0",
+    "pdf-lib": "^1.17.1",
+    "piexifjs": "^1.0.6",
+    "sharp": "^0.34.5",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
+      docx:
+        specifier: ^9.6.1
+        version: 9.6.1
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
@@ -50,6 +53,15 @@ importers:
       p-limit:
         specifier: ^6.0.0
         version: 6.2.0
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
+      piexifjs:
+        specifier: ^1.0.6
+        version: 1.0.6
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -320,6 +332,9 @@ packages:
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
     engines: {node: '>=18'}
@@ -479,6 +494,143 @@ packages:
   '@google/generative-ai@0.24.1':
     resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
     engines: {node: '>=18.0.0'}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
@@ -718,6 +870,12 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+
+  '@pdf-lib/upng@1.0.1':
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1058,6 +1216,9 @@ packages:
   '@types/node@22.19.13':
     resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
 
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
@@ -1211,6 +1372,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1235,6 +1399,14 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  docx@9.6.1:
+    resolution: {integrity: sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==}
+    engines: {node: '>=10'}
 
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
@@ -1375,6 +1547,9 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
@@ -1389,6 +1564,12 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -1399,6 +1580,9 @@ packages:
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1442,6 +1626,9 @@ packages:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
@@ -1465,6 +1652,9 @@ packages:
       openai:
         optional: true
 
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -1480,6 +1670,9 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -1568,6 +1761,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   path-expression-matcher@1.1.3:
     resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
     engines: {node: '>=14.0.0'}
@@ -1590,6 +1786,9 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1597,9 +1796,18 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  piexifjs@1.0.6:
+    resolution: {integrity: sha512-0wVyH0cKohzBQ5Gi2V1BuxYpxWfxF3cSqfFXfPIpl5tl9XLS5z4ogqhUCD20AbHi0h9aJkqXNJnkVev6gwh2ag==}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -1616,16 +1824,30 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1669,6 +1891,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1735,6 +1960,9 @@ packages:
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1755,8 +1983,14 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   until-async@3.0.2:
     resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
@@ -1874,6 +2108,13 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
+
+  xml@1.0.1:
+    resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2445,6 +2686,11 @@ snapshots:
 
   '@cfworker/json-schema@4.1.1': {}
 
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
@@ -2524,6 +2770,102 @@ snapshots:
     optional: true
 
   '@google/generative-ai@0.24.1': {}
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@inquirer/ansi@1.0.2':
     optional: true
@@ -2784,6 +3126,14 @@ snapshots:
 
   '@open-draft/until@2.1.0':
     optional: true
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    dependencies:
+      pako: 1.0.11
+
+  '@pdf-lib/upng@1.0.1':
+    dependencies:
+      pako: 1.0.11
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -3185,6 +3535,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/statuses@2.0.6':
     optional: true
 
@@ -3338,6 +3692,8 @@ snapshots:
   cookie@1.1.1:
     optional: true
 
+  core-util-is@1.0.3: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3353,6 +3709,17 @@ snapshots:
   decamelize@1.2.0: {}
 
   deep-eql@5.0.2: {}
+
+  detect-libc@2.1.2: {}
+
+  docx@9.6.1:
+    dependencies:
+      '@types/node': 25.9.1
+      hash.js: 1.1.7
+      jszip: 3.10.1
+      nanoid: 5.1.6
+      xml: 1.0.1
+      xml-js: 1.6.11
 
   dotenv@17.3.1: {}
 
@@ -3543,6 +3910,11 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   headers-polyfill@4.0.3:
     optional: true
 
@@ -3559,12 +3931,18 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  immediate@3.0.6: {}
+
+  inherits@2.0.4: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-node-process@1.2.0:
     optional: true
 
   is-stream@2.0.1: {}
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -3616,6 +3994,13 @@ snapshots:
       '@babel/runtime': 7.28.6
       ts-algebra: 2.0.0
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -3636,6 +4021,10 @@ snapshots:
       semver: 7.7.4
       uuid: 10.0.0
 
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
@@ -3653,6 +4042,8 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -3735,6 +4126,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.11: {}
+
   path-expression-matcher@1.1.3: {}
 
   path-key@3.1.1: {}
@@ -3751,15 +4144,36 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pdf-lib@1.17.1:
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  piexifjs@1.0.6: {}
 
   postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  process-nextick-args@2.0.1: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   require-directory@2.1.1:
     optional: true
@@ -3800,11 +4214,48 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
 
+  sax@1.6.0: {}
+
   semver@7.7.4: {}
+
+  setimmediate@1.0.5: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:
@@ -3841,6 +4292,10 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   strip-ansi@6.0.1:
     dependencies:
@@ -3901,6 +4356,8 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
+  tslib@1.14.1: {}
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -3919,8 +4376,12 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.24.6: {}
+
   until-async@3.0.2:
     optional: true
+
+  util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
 
@@ -4039,6 +4500,12 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.2.0
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.6.0
+
+  xml@1.0.1: {}
 
   y18n@5.0.8:
     optional: true

--- a/src/cli/commands/dlp-gen.ts
+++ b/src/cli/commands/dlp-gen.ts
@@ -1,0 +1,61 @@
+import chalk from 'chalk';
+import type { Command } from 'commander';
+import { generateCorpus } from '../../dlp/index.js';
+import type { Format } from '../../dlp/types.js';
+
+const ALL_FORMATS: Format[] = ['pdf', 'png', 'jpeg', 'svg', 'docx'];
+
+function parseTypes(value: string): Format[] {
+  if (value === 'all') {
+    return ALL_FORMATS;
+  }
+  const types = value.split(',').map((t) => t.trim().toLowerCase());
+  const invalid = types.filter((t) => !ALL_FORMATS.includes(t as Format));
+  if (invalid.length > 0) {
+    throw new Error(`Unknown type(s): ${invalid.join(', ')}. Valid: ${ALL_FORMATS.join(', ')}`);
+  }
+  return types as Format[];
+}
+
+export function registerDlpGenCommand(parent: Command): void {
+  parent
+    .command('dlp-gen')
+    .description(
+      'Generate clean + dirty DLP test files (synthetic sensitive data) across PDF/PNG/JPEG/SVG/DOCX',
+    )
+    .option('--types <list>', 'Comma list: pdf,png,jpeg,svg,docx (or all)', 'all')
+    .option('--count <n>', 'Clean files per type', '1')
+    .option('--out <dir>', 'Output base directory', './temp')
+    .option('--techniques <list>', 'all or comma list of technique ids', 'all')
+    .option('--seed <n>', 'Seed for reproducible payloads')
+    .option('--output <format>', 'Summary format: pretty or json', 'pretty')
+    .action(async (opts) => {
+      const types = parseTypes(opts.types);
+      const count = Number.parseInt(opts.count, 10);
+      if (!Number.isInteger(count) || count < 1) {
+        throw new Error('--count must be a positive integer');
+      }
+      const techniques =
+        opts.techniques === 'all'
+          ? 'all'
+          : (opts.techniques as string).split(',').map((t) => t.trim());
+      const seed = opts.seed === undefined ? undefined : Number.parseInt(opts.seed, 10);
+
+      const summary = await generateCorpus({ types, count, out: opts.out, techniques, seed });
+
+      if (opts.output === 'json') {
+        console.log(JSON.stringify(summary, null, 2));
+        return;
+      }
+
+      console.log(chalk.bold('\n  DLP Test-File Generation'));
+      console.log(`  Output:   ${summary.out}`);
+      console.log(`  Seed:     ${summary.seed}`);
+      console.log(`  Clean:    ${summary.clean}    Dirty: ${summary.dirty}`);
+      console.log(`  Manifest: ${summary.manifestPath}\n`);
+      for (const [fmt, counts] of Object.entries(summary.byFormat)) {
+        console.log(`    ${fmt.padEnd(5)} clean=${counts.clean} dirty=${counts.dirty}`);
+      }
+      console.log('');
+    });
+}

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -31,6 +31,7 @@ import {
   renderTopicList,
 } from '../renderer/index.js';
 import { registerAuditCommand } from './audit.js';
+import { registerDlpGenCommand } from './dlp-gen.js';
 import { registerCleanupCommand } from './profiles-cleanup.js';
 import { registerApplyCommand } from './topics-apply.js';
 import { registerCreateCommand } from './topics-create.js';
@@ -890,4 +891,9 @@ export function registerRuntimeCommand(program: Command): void {
         process.exit(1);
       }
     });
+
+  // -----------------------------------------------------------------------
+  // runtime dlp-gen — generate clean + dirty DLP test files
+  // -----------------------------------------------------------------------
+  registerDlpGenCommand(runtime);
 }

--- a/src/dlp/embed/docx.ts
+++ b/src/dlp/embed/docx.ts
@@ -1,0 +1,58 @@
+import { Document, HeadingLevel, Packer, Paragraph, TextRun } from 'docx';
+import { lorem } from '../lorem.js';
+import { makeRng } from '../rng.js';
+import type { PayloadValue, Technique } from '../types.js';
+
+const join = (p: PayloadValue[]): string => p.map((v) => `${v.category}: ${v.value}`).join(' | ');
+
+function bodyParagraphs(): Paragraph[] {
+  return lorem(makeRng(1), 2)
+    .split('\n\n')
+    .map((t) => new Paragraph({ children: [new TextRun(t)] }));
+}
+
+interface Core {
+  title?: string;
+  subject?: string;
+  keywords?: string;
+}
+
+async function build(extra: Paragraph[], core: Core = {}): Promise<Buffer> {
+  const doc = new Document({
+    title: core.title,
+    subject: core.subject,
+    keywords: core.keywords,
+    sections: [
+      {
+        children: [
+          new Paragraph({ text: 'Generated Document', heading: HeadingLevel.HEADING_1 }),
+          ...bodyParagraphs(),
+          ...extra,
+        ],
+      },
+    ],
+  });
+  return Packer.toBuffer(doc);
+}
+
+export const docxTechniques: Record<string, Technique> = {
+  'core-props': {
+    id: 'core-props',
+    format: 'docx',
+    label: 'core document properties',
+    embed: (_clean, p) => build([], { title: join(p), subject: join(p), keywords: join(p) }),
+  },
+  'hidden-run': {
+    id: 'hidden-run',
+    format: 'docx',
+    label: 'hidden (vanish) run',
+    embed: (_clean, p) =>
+      build([new Paragraph({ children: [new TextRun({ text: join(p), vanish: true })] })]),
+  },
+  visible: {
+    id: 'visible',
+    format: 'docx',
+    label: 'visible body line',
+    embed: (_clean, p) => build([new Paragraph({ children: [new TextRun(join(p))] })]),
+  },
+};

--- a/src/dlp/embed/index.ts
+++ b/src/dlp/embed/index.ts
@@ -1,0 +1,24 @@
+import type { Format, Technique } from '../types.js';
+import { docxTechniques } from './docx.js';
+import { jpegTechniques } from './jpeg.js';
+import { pdfTechniques } from './pdf.js';
+import { pngTechniques } from './png.js';
+import { svgTechniques } from './svg.js';
+
+/** All embedding techniques grouped by file format. */
+export const techniquesByFormat: Record<Format, Technique[]> = {
+  pdf: Object.values(pdfTechniques),
+  png: Object.values(pngTechniques),
+  jpeg: Object.values(jpegTechniques),
+  svg: Object.values(svgTechniques),
+  docx: Object.values(docxTechniques),
+};
+
+/** Unique set of all technique ids across formats. */
+export const ALL_TECHNIQUE_IDS: string[] = [
+  ...new Set(
+    Object.values(techniquesByFormat)
+      .flat()
+      .map((t) => t.id),
+  ),
+];

--- a/src/dlp/embed/jpeg.ts
+++ b/src/dlp/embed/jpeg.ts
@@ -1,0 +1,65 @@
+import piexif from 'piexifjs';
+import type { PayloadValue, Technique } from '../types.js';
+
+const join = (p: PayloadValue[]): string => p.map((v) => `${v.category}: ${v.value}`).join(' | ');
+
+function u16(n: number): Buffer {
+  const b = Buffer.alloc(2);
+  b.writeUInt16BE(n, 0);
+  return b;
+}
+
+function setExif(clean: Buffer, text: string): Buffer {
+  const zeroth: Record<number, string> = {};
+  zeroth[piexif.ImageIFD.ImageDescription] = text;
+  zeroth[piexif.ImageIFD.Artist] = text;
+  zeroth[piexif.ImageIFD.Copyright] = text;
+  const exifStr = piexif.dump({
+    '0th': zeroth,
+    Exif: {},
+    GPS: {},
+    Interop: {},
+    '1st': {},
+    thumbnail: null,
+  });
+  return Buffer.from(piexif.insert(exifStr, clean.toString('binary')), 'binary');
+}
+
+/** Recover EXIF 0th-IFD string fields from a JPEG. */
+export function jpegExifExtract(jpeg: Buffer): string {
+  const exif = piexif.load(jpeg.toString('binary'));
+  const zeroth = exif['0th'] ?? {};
+  return Object.values(zeroth)
+    .filter((v: unknown): v is string => typeof v === 'string')
+    .join('\n');
+}
+
+export const jpegTechniques: Record<string, Technique> = {
+  exif: {
+    id: 'exif',
+    format: 'jpeg',
+    label: 'EXIF ImageDescription/Artist/Copyright',
+    embed: (c, p) => setExif(c, join(p)),
+  },
+  com: {
+    id: 'com',
+    format: 'jpeg',
+    label: 'COM comment segment',
+    embed: (c, p) => {
+      const d = Buffer.from(`DLP ${join(p)}`, 'utf8');
+      return Buffer.concat([
+        c.subarray(0, 2),
+        Buffer.from([0xff, 0xfe]),
+        u16(d.length + 2),
+        d,
+        c.subarray(2),
+      ]);
+    },
+  },
+  trailer: {
+    id: 'trailer',
+    format: 'jpeg',
+    label: 'bytes after EOI',
+    embed: (c, p) => Buffer.concat([c, Buffer.from(`\nDLP ${join(p)}\n`, 'utf8')]),
+  },
+};

--- a/src/dlp/embed/pdf.ts
+++ b/src/dlp/embed/pdf.ts
@@ -1,0 +1,99 @@
+import { inflateSync } from 'node:zlib';
+import { PDFDocument, rgb } from 'pdf-lib';
+import type { PayloadValue, Technique } from '../types.js';
+
+const join = (p: PayloadValue[]): string => p.map((v) => `${v.category}: ${v.value}`).join(' | ');
+
+async function setMeta(clean: Buffer, p: PayloadValue[]): Promise<Buffer> {
+  const doc = await PDFDocument.load(clean);
+  doc.setTitle(join(p));
+  doc.setSubject(join(p));
+  doc.setKeywords(p.map((v) => v.value));
+  doc.setAuthor(p.find((v) => v.category === 'email')?.value ?? 'synthetic');
+  return Buffer.from(await doc.save());
+}
+
+// "Hidden" text layer: drawn in white so it does not show on a white page, but the
+// literal string remains in the (uncompressed) page content stream. pdf-lib does not
+// expose text render-mode 3, so white-on-white is the chosen, reliably-verifiable approach.
+async function hiddenText(clean: Buffer, p: PayloadValue[]): Promise<Buffer> {
+  const doc = await PDFDocument.load(clean);
+  const page = doc.getPage(0);
+  let y = 760;
+  for (const v of p) {
+    page.drawText(`${v.category}: ${v.value}`, { x: 40, y, size: 6, color: rgb(1, 1, 1) });
+    y -= 8;
+  }
+  return Buffer.from(await doc.save());
+}
+
+const trailer = (clean: Buffer, p: PayloadValue[]): Buffer =>
+  Buffer.concat([clean, Buffer.from(`\n% DLP ${join(p)}\n`, 'utf8')]);
+
+/** Recover text from all PDF streams (inflating FlateDecode streams; falling back to raw). */
+export function pdfStreamText(pdf: Buffer): string {
+  const parts: string[] = [];
+  let idx = 0;
+  for (;;) {
+    const s = pdf.indexOf('stream', idx);
+    if (s < 0) {
+      break;
+    }
+    let dataStart = s + 6;
+    if (pdf[dataStart] === 0x0d) {
+      dataStart++;
+    }
+    if (pdf[dataStart] === 0x0a) {
+      dataStart++;
+    }
+    const e = pdf.indexOf('endstream', dataStart);
+    if (e < 0) {
+      break;
+    }
+    const raw = pdf.subarray(dataStart, e);
+    try {
+      parts.push(inflateSync(raw).toString('latin1'));
+    } catch {
+      parts.push(raw.toString('latin1'));
+    }
+    idx = e + 9;
+  }
+  const combined = parts.join('\n');
+  // pdf-lib renders drawn text as PDF hex strings (<...>); decode them too.
+  const decoded: string[] = [combined];
+  for (const m of combined.matchAll(/<([0-9A-Fa-f]+)>/g)) {
+    if (m[1].length % 2 === 0) {
+      decoded.push(Buffer.from(m[1], 'hex').toString('latin1'));
+    }
+  }
+  return decoded.join('\n');
+}
+
+/** Recover document-info-dict metadata from a PDF. */
+export async function pdfMetaExtract(pdf: Buffer): Promise<string> {
+  const doc = await PDFDocument.load(pdf);
+  return [doc.getTitle(), doc.getSubject(), doc.getAuthor(), doc.getKeywords()]
+    .filter((v): v is string => typeof v === 'string')
+    .join('\n');
+}
+
+export const pdfTechniques: Record<string, Technique> = {
+  meta: {
+    id: 'meta',
+    format: 'pdf',
+    label: 'document info dict',
+    embed: (c, p) => setMeta(c, p),
+  },
+  'hidden-text': {
+    id: 'hidden-text',
+    format: 'pdf',
+    label: 'white (hidden) text layer',
+    embed: (c, p) => hiddenText(c, p),
+  },
+  trailer: {
+    id: 'trailer',
+    format: 'pdf',
+    label: 'bytes after %%EOF',
+    embed: (c, p) => trailer(c, p),
+  },
+};

--- a/src/dlp/embed/piexifjs.d.ts
+++ b/src/dlp/embed/piexifjs.d.ts
@@ -1,0 +1,1 @@
+declare module 'piexifjs';

--- a/src/dlp/embed/png-chunks.ts
+++ b/src/dlp/embed/png-chunks.ts
@@ -1,0 +1,108 @@
+import { deflateSync, inflateSync } from 'node:zlib';
+
+const CRC_TABLE: Uint32Array = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    t[n] = c >>> 0;
+  }
+  return t;
+})();
+
+function crc32(buf: Buffer): number {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) {
+    c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  }
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+export interface Chunk {
+  type: string;
+  data: Buffer;
+}
+
+export function parseChunks(png: Buffer): Chunk[] {
+  const chunks: Chunk[] = [];
+  let off = 8;
+  while (off + 8 <= png.length) {
+    const len = png.readUInt32BE(off);
+    const type = png.toString('latin1', off + 4, off + 8);
+    chunks.push({ type, data: png.subarray(off + 8, off + 8 + len) });
+    off += 12 + len;
+    if (type === 'IEND') {
+      break;
+    }
+  }
+  return chunks;
+}
+
+function buildChunk(type: string, data: Buffer): Buffer {
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length, 0);
+  const typeBuf = Buffer.from(type, 'latin1');
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(Buffer.concat([typeBuf, data])), 0);
+  return Buffer.concat([len, typeBuf, data, crc]);
+}
+
+export function insertBeforeIEND(png: Buffer, extra: Buffer): Buffer {
+  let off = 8;
+  while (off + 8 <= png.length) {
+    const len = png.readUInt32BE(off);
+    const type = png.toString('latin1', off + 4, off + 8);
+    if (type === 'IEND') {
+      break;
+    }
+    off += 12 + len;
+  }
+  return Buffer.concat([png.subarray(0, off), extra, png.subarray(off)]);
+}
+
+export const tEXt = (keyword: string, text: string): Buffer =>
+  buildChunk(
+    'tEXt',
+    Buffer.concat([Buffer.from(keyword, 'latin1'), Buffer.from([0]), Buffer.from(text, 'latin1')]),
+  );
+
+export const zTXt = (keyword: string, text: string): Buffer =>
+  buildChunk(
+    'zTXt',
+    Buffer.concat([
+      Buffer.from(keyword, 'latin1'),
+      Buffer.from([0, 0]),
+      deflateSync(Buffer.from(text, 'latin1')),
+    ]),
+  );
+
+export const iTXt = (keyword: string, text: string): Buffer =>
+  buildChunk(
+    'iTXt',
+    Buffer.concat([
+      Buffer.from(keyword, 'latin1'),
+      Buffer.from([0, 0, 0, 0, 0]),
+      Buffer.from(text, 'utf8'),
+    ]),
+  );
+
+/** Recover all textual-chunk content (tEXt/zTXt/iTXt) as a single string. */
+export function readTextChunks(png: Buffer): string {
+  const parts: string[] = [];
+  for (const ch of parseChunks(png)) {
+    if (ch.type === 'tEXt') {
+      parts.push(ch.data.toString('latin1'));
+    } else if (ch.type === 'zTXt') {
+      const nul = ch.data.indexOf(0);
+      parts.push(inflateSync(ch.data.subarray(nul + 2)).toString('latin1'));
+    } else if (ch.type === 'iTXt') {
+      let i = ch.data.indexOf(0) + 3; // after keyword\0 + compFlag + compMethod
+      i = ch.data.indexOf(0, i) + 1; // after language tag
+      i = ch.data.indexOf(0, i) + 1; // after translated keyword
+      parts.push(ch.data.subarray(i).toString('utf8'));
+    }
+  }
+  return parts.join('\n');
+}

--- a/src/dlp/embed/png.ts
+++ b/src/dlp/embed/png.ts
@@ -1,0 +1,76 @@
+import sharp from 'sharp';
+import type { PayloadValue, Technique } from '../types.js';
+import { insertBeforeIEND, iTXt, tEXt, zTXt } from './png-chunks.js';
+
+const join = (p: PayloadValue[]): string => p.map((v) => `${v.category}: ${v.value}`).join(' | ');
+
+async function lsbEmbed(png: Buffer, text: string): Promise<Buffer> {
+  const { data, info } = await sharp(png).raw().toBuffer({ resolveWithObject: true });
+  const payload = Buffer.from(text, 'utf8');
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(payload.length, 0);
+  const blob = Buffer.concat([header, payload]);
+  const bits = blob.length * 8;
+  if (bits > data.length) {
+    throw new Error('cover image too small for stego payload');
+  }
+  for (let i = 0; i < bits; i++) {
+    const bit = (blob[i >> 3] >> (7 - (i & 7))) & 1;
+    data[i] = (data[i] & 0xfe) | bit;
+  }
+  return sharp(data, {
+    raw: { width: info.width, height: info.height, channels: info.channels },
+  })
+    .png()
+    .toBuffer();
+}
+
+/** Recover an LSB-embedded UTF-8 payload from a PNG. */
+export async function lsbExtract(png: Buffer): Promise<string> {
+  const { data } = await sharp(png).raw().toBuffer({ resolveWithObject: true });
+  const readByte = (start: number): number => {
+    let b = 0;
+    for (let k = 0; k < 8; k++) {
+      b = (b << 1) | (data[start + k] & 1);
+    }
+    return b;
+  };
+  let len = 0;
+  for (let i = 0; i < 4; i++) {
+    len = (len << 8) | readByte(i * 8);
+  }
+  const out = Buffer.alloc(len);
+  for (let i = 0; i < len; i++) {
+    out[i] = readByte((4 + i) * 8);
+  }
+  return out.toString('utf8');
+}
+
+export const pngTechniques: Record<string, Technique> = {
+  'text-chunks': {
+    id: 'text-chunks',
+    format: 'png',
+    label: 'tEXt/zTXt/iTXt chunks',
+    embed: (c, p) =>
+      insertBeforeIEND(
+        c,
+        Buffer.concat([
+          tEXt('Comment', join(p)),
+          zTXt('Description', join(p)),
+          iTXt('Keywords', join(p)),
+        ]),
+      ),
+  },
+  trailer: {
+    id: 'trailer',
+    format: 'png',
+    label: 'bytes after IEND',
+    embed: (c, p) => Buffer.concat([c, Buffer.from(`\nDLP ${join(p)}\n`, 'utf8')]),
+  },
+  'stego-lsb': {
+    id: 'stego-lsb',
+    format: 'png',
+    label: 'LSB steganography',
+    embed: (c, p) => lsbEmbed(c, join(p)),
+  },
+};

--- a/src/dlp/embed/svg.ts
+++ b/src/dlp/embed/svg.ts
@@ -1,0 +1,36 @@
+import type { PayloadValue, Technique } from '../types.js';
+
+const line = (vals: PayloadValue[]): string =>
+  vals.map((v) => `${v.category}: ${v.value}`).join(' | ');
+
+/** Insert a snippet immediately after the opening `<svg ...>` tag. */
+function inject(clean: Buffer, snippet: string): Buffer {
+  const s = clean.toString('utf8');
+  const idx = s.indexOf('>') + 1;
+  return Buffer.from(s.slice(0, idx) + snippet + s.slice(idx), 'utf8');
+}
+
+export const svgTechniques: Record<string, Technique> = {
+  meta: {
+    id: 'meta',
+    format: 'svg',
+    label: 'metadata + desc',
+    embed: (c, p) => inject(c, `<metadata>${line(p)}</metadata><desc>${line(p)}</desc>`),
+  },
+  'hidden-text': {
+    id: 'hidden-text',
+    format: 'svg',
+    label: 'off-canvas <text>',
+    embed: (c, p) =>
+      inject(
+        c,
+        p.map((v) => `<text x="-9999" y="-9999">${v.category}: ${v.value}</text>`).join(''),
+      ),
+  },
+  comment: {
+    id: 'comment',
+    format: 'svg',
+    label: 'XML comment',
+    embed: (c, p) => inject(c, `<!-- ${line(p)} -->`),
+  },
+};

--- a/src/dlp/embed/zip.ts
+++ b/src/dlp/embed/zip.ts
@@ -1,0 +1,25 @@
+import { inflateRawSync } from 'node:zlib';
+
+const LOCAL_HEADER = 0x04034b50;
+
+/** Extract concatenated text from all entries of a ZIP buffer (e.g. a DOCX). */
+export function unzipText(zip: Buffer): string {
+  const parts: string[] = [];
+  let off = 0;
+  while (off + 30 <= zip.length && zip.readUInt32LE(off) === LOCAL_HEADER) {
+    const method = zip.readUInt16LE(off + 8);
+    const compSize = zip.readUInt32LE(off + 18);
+    const nameLen = zip.readUInt16LE(off + 26);
+    const extraLen = zip.readUInt16LE(off + 28);
+    const dataStart = off + 30 + nameLen + extraLen;
+    const data = zip.subarray(dataStart, dataStart + compSize);
+    try {
+      const content = method === 8 ? inflateRawSync(data) : data;
+      parts.push(content.toString('utf8'));
+    } catch {
+      // skip entries that cannot be inflated
+    }
+    off = dataStart + compSize;
+  }
+  return parts.join('\n');
+}

--- a/src/dlp/generate/docx.ts
+++ b/src/dlp/generate/docx.ts
@@ -1,0 +1,20 @@
+import { Document, HeadingLevel, Packer, Paragraph, TextRun } from 'docx';
+import { lorem } from '../lorem.js';
+
+/** Generate a valid DOCX (zip) filled with lorem ipsum. */
+export async function docx(rng: () => number): Promise<Buffer> {
+  const paragraphs = lorem(rng, 3)
+    .split('\n\n')
+    .map((p) => new Paragraph({ children: [new TextRun(p)] }));
+  const doc = new Document({
+    sections: [
+      {
+        children: [
+          new Paragraph({ text: 'Generated Document', heading: HeadingLevel.HEADING_1 }),
+          ...paragraphs,
+        ],
+      },
+    ],
+  });
+  return Packer.toBuffer(doc);
+}

--- a/src/dlp/generate/index.ts
+++ b/src/dlp/generate/index.ts
@@ -1,0 +1,23 @@
+import type { Format } from '../types.js';
+import { docx } from './docx.js';
+import { jpeg } from './jpeg.js';
+import { pdf } from './pdf.js';
+import { png } from './png.js';
+import { svg } from './svg.js';
+
+/** Clean-file generators keyed by format. */
+export const generators: Record<Format, (rng: () => number) => Promise<Buffer> | Buffer> = {
+  pdf,
+  png,
+  jpeg,
+  svg,
+  docx,
+};
+
+export const EXT: Record<Format, string> = {
+  pdf: 'pdf',
+  png: 'png',
+  jpeg: 'jpg',
+  svg: 'svg',
+  docx: 'docx',
+};

--- a/src/dlp/generate/jpeg.ts
+++ b/src/dlp/generate/jpeg.ts
@@ -1,0 +1,8 @@
+import sharp from 'sharp';
+import { raster } from './raster.js';
+
+/** Generate a valid JPEG with deterministic gradient content. */
+export async function jpeg(rng: () => number): Promise<Buffer> {
+  const { data, width, height, channels } = raster(rng);
+  return sharp(data, { raw: { width, height, channels } }).jpeg({ quality: 90 }).toBuffer();
+}

--- a/src/dlp/generate/pdf.ts
+++ b/src/dlp/generate/pdf.ts
@@ -1,0 +1,19 @@
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+import { lorem } from '../lorem.js';
+
+/** Generate a valid single-page PDF filled with lorem ipsum. */
+export async function pdf(rng: () => number): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  const page = doc.addPage([612, 792]);
+  page.drawText(lorem(rng, 3), {
+    x: 54,
+    y: 720,
+    size: 11,
+    font,
+    lineHeight: 15,
+    maxWidth: 504,
+  });
+  const bytes = await doc.save();
+  return Buffer.from(bytes);
+}

--- a/src/dlp/generate/png.ts
+++ b/src/dlp/generate/png.ts
@@ -1,0 +1,8 @@
+import sharp from 'sharp';
+import { raster } from './raster.js';
+
+/** Generate a valid PNG with deterministic gradient content. */
+export async function png(rng: () => number): Promise<Buffer> {
+  const { data, width, height, channels } = raster(rng);
+  return sharp(data, { raw: { width, height, channels } }).png().toBuffer();
+}

--- a/src/dlp/generate/raster.ts
+++ b/src/dlp/generate/raster.ts
@@ -1,0 +1,26 @@
+export interface Raster {
+  data: Buffer;
+  width: number;
+  height: number;
+  channels: 3;
+}
+
+/** Build a deterministic RGB gradient raster for use as image cover content. */
+export function raster(rng: () => number): Raster {
+  const width = 256;
+  const height = 192;
+  const channels = 3 as const;
+  const data = Buffer.alloc(width * height * channels);
+  const rb = Math.floor(rng() * 256);
+  const gb = Math.floor(rng() * 256);
+  const bb = Math.floor(rng() * 256);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * channels;
+      data[i] = (x + rb) & 255;
+      data[i + 1] = (y + gb) & 255;
+      data[i + 2] = (x + y + bb) & 255;
+    }
+  }
+  return { data, width, height, channels };
+}

--- a/src/dlp/generate/svg.ts
+++ b/src/dlp/generate/svg.ts
@@ -1,0 +1,18 @@
+import { pick } from '../rng.js';
+
+/** Generate a valid SVG (namespaced root) with deterministic placeholder shapes. */
+export function svg(rng: () => number): Buffer {
+  const width = 240;
+  const height = 160;
+  const fill = pick(rng, ['#673ab7', '#2196f3', '#4caf50', '#ff9800']);
+  const cx = 40 + Math.floor(rng() * 160);
+  const xml =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" ` +
+    `viewBox="0 0 ${width} ${height}" role="img">` +
+    '<title>Generated image</title>' +
+    '<desc>A generated placeholder graphic.</desc>' +
+    `<rect width="${width}" height="${height}" fill="#ffffff"/>` +
+    `<circle cx="${cx}" cy="80" r="48" fill="${fill}"/>` +
+    '</svg>';
+  return Buffer.from(xml, 'utf8');
+}

--- a/src/dlp/index.ts
+++ b/src/dlp/index.ts
@@ -1,0 +1,71 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { techniquesByFormat } from './embed/index.js';
+import { EXT, generators } from './generate/index.js';
+import { buildManifest, writeManifest } from './manifest.js';
+import { makePayload } from './payload.js';
+import { makeRng, subSeed } from './rng.js';
+import type { GenerateOptions, ManifestEntry } from './types.js';
+
+export interface GenerateSummary {
+  clean: number;
+  dirty: number;
+  out: string;
+  manifestPath: string;
+  seed: number;
+  byFormat: Record<string, { clean: number; dirty: number }>;
+}
+
+/** Generate a clean/dirty DLP test corpus and a manifest describing it. */
+export async function generateCorpus(opts: GenerateOptions): Promise<GenerateSummary> {
+  const seed = opts.seed ?? Math.floor(Math.random() * 0x7fffffff);
+  const entries: ManifestEntry[] = [];
+  const byFormat: Record<string, { clean: number; dirty: number }> = {};
+  let cleanCount = 0;
+  let typeIndex = 0;
+
+  for (const fmt of opts.types) {
+    const ext = EXT[fmt];
+    const cleanDir = join(opts.out, 'clean', fmt);
+    const dirtyDir = join(opts.out, 'dirty', fmt);
+    await mkdir(cleanDir, { recursive: true });
+    await mkdir(dirtyDir, { recursive: true });
+    byFormat[fmt] = { clean: 0, dirty: 0 };
+
+    const wanted = techniquesByFormat[fmt].filter(
+      (t) => opts.techniques === 'all' || opts.techniques.includes(t.id),
+    );
+
+    for (let i = 0; i < opts.count; i++) {
+      const fileSeed = subSeed(seed, typeIndex * 1000 + i);
+      const base = `${fmt}-${fileSeed.toString(16).padStart(8, '0')}`;
+      const cleanBuf = Buffer.from(await generators[fmt](makeRng(fileSeed)));
+      const cleanPath = join(cleanDir, `${base}.${ext}`);
+      await writeFile(cleanPath, cleanBuf);
+      cleanCount++;
+      byFormat[fmt].clean++;
+
+      let tIdx = 0;
+      for (const technique of wanted) {
+        const payload = makePayload(makeRng(subSeed(fileSeed, 7919 + tIdx)));
+        const dirtyBuf = Buffer.from(await technique.embed(cleanBuf, payload));
+        const dirtyPath = join(dirtyDir, `${base}__${technique.id}.${ext}`);
+        await writeFile(dirtyPath, dirtyBuf);
+        entries.push({
+          format: fmt,
+          technique: technique.id,
+          clean: cleanPath,
+          dirty: dirtyPath,
+          values: payload,
+        });
+        byFormat[fmt].dirty++;
+        tIdx++;
+      }
+    }
+    typeIndex++;
+  }
+
+  const manifestPath = join(opts.out, 'manifest.json');
+  await writeManifest(manifestPath, buildManifest(entries));
+  return { clean: cleanCount, dirty: entries.length, out: opts.out, manifestPath, seed, byFormat };
+}

--- a/src/dlp/lorem.ts
+++ b/src/dlp/lorem.ts
@@ -1,0 +1,67 @@
+import { pick } from './rng.js';
+
+const WORDS = [
+  'lorem',
+  'ipsum',
+  'dolor',
+  'sit',
+  'amet',
+  'consectetur',
+  'adipiscing',
+  'elit',
+  'sed',
+  'do',
+  'eiusmod',
+  'tempor',
+  'incididunt',
+  'ut',
+  'labore',
+  'et',
+  'dolore',
+  'magna',
+  'aliqua',
+  'enim',
+  'ad',
+  'minim',
+  'veniam',
+  'quis',
+  'nostrud',
+  'exercitation',
+  'ullamco',
+  'laboris',
+  'nisi',
+  'aliquip',
+  'ex',
+  'ea',
+  'commodo',
+  'consequat',
+  'duis',
+  'aute',
+  'irure',
+  'in',
+  'reprehenderit',
+  'voluptate',
+  'velit',
+  'esse',
+  'cillum',
+  'fugiat',
+  'nulla',
+  'pariatur',
+  'excepteur',
+  'sint',
+];
+
+function sentence(rng: () => number): string {
+  const len = 8 + Math.floor(rng() * 8);
+  const words = Array.from({ length: len }, () => pick(rng, WORDS));
+  const text = words.join(' ');
+  return `${text.charAt(0).toUpperCase()}${text.slice(1)}.`;
+}
+
+/** Generate `paragraphs` paragraphs of lorem ipsum, joined by blank lines. */
+export function lorem(rng: () => number, paragraphs: number): string {
+  return Array.from({ length: paragraphs }, () => {
+    const sentences = 3 + Math.floor(rng() * 3);
+    return Array.from({ length: sentences }, () => sentence(rng)).join(' ');
+  }).join('\n\n');
+}

--- a/src/dlp/manifest.ts
+++ b/src/dlp/manifest.ts
@@ -1,0 +1,22 @@
+import { writeFile } from 'node:fs/promises';
+import type { ManifestEntry } from './types.js';
+
+export interface Manifest {
+  generatedAt: string;
+  count: number;
+  entries: ManifestEntry[];
+}
+
+/** Assemble a manifest from dirty-file entries. */
+export function buildManifest(entries: ManifestEntry[]): Manifest {
+  return {
+    generatedAt: new Date().toISOString(),
+    count: entries.length,
+    entries,
+  };
+}
+
+/** Write a manifest to disk as pretty JSON. */
+export async function writeManifest(path: string, manifest: Manifest): Promise<void> {
+  await writeFile(path, `${JSON.stringify(manifest, null, 2)}\n`);
+}

--- a/src/dlp/payload.ts
+++ b/src/dlp/payload.ts
@@ -1,0 +1,69 @@
+import { digits, pick } from './rng.js';
+import type { PayloadValue } from './types.js';
+
+const BASE32 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+/** Luhn checksum validation for a digit string. */
+export function luhnValid(pan: string): boolean {
+  if (pan.length === 0) {
+    return false;
+  }
+  let sum = 0;
+  let alt = false;
+  for (let i = pan.length - 1; i >= 0; i--) {
+    let d = pan.charCodeAt(i) - 48;
+    if (alt) {
+      d *= 2;
+      if (d > 9) {
+        d -= 9;
+      }
+    }
+    sum += d;
+    alt = !alt;
+  }
+  return sum % 10 === 0;
+}
+
+/** A 16-digit, Luhn-valid PAN from the Visa-family test BIN (starts with 4). */
+function testPan(rng: () => number): string {
+  const body = `4${digits(rng, 14)}`;
+  for (let c = 0; c < 10; c++) {
+    const candidate = `${body}${c}`;
+    if (luhnValid(candidate)) {
+      return candidate;
+    }
+  }
+  return `${body}0`;
+}
+
+// SSNs in area 900-999 are never issued by the SSA, so these are synthetic-safe.
+const ssn = (rng: () => number): string => `9${digits(rng, 2)}-${digits(rng, 2)}-${digits(rng, 4)}`;
+const phone = (rng: () => number): string => `555-01${digits(rng, 2)}`;
+const email = (rng: () => number): string =>
+  `${pick(rng, ['john.public', 'jane.doe', 'sam.roe'])}.${digits(rng, 3)}@${pick(rng, [
+    'example.com',
+    'example.org',
+    'example.net',
+  ])}`;
+const awsKey = (rng: () => number): string =>
+  `AKIA${Array.from({ length: 9 }, () => pick(rng, [...BASE32])).join('')}EXAMPLE`;
+const dob = (rng: () => number): string => {
+  const year = 1960 + Math.floor(rng() * 40);
+  const month = String(1 + Math.floor(rng() * 12)).padStart(2, '0');
+  const day = String(1 + Math.floor(rng() * 28)).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+/** Generate a set of clearly-synthetic, format-valid sensitive markers. */
+export function makePayload(rng: () => number): PayloadValue[] {
+  const pan = testPan(rng);
+  return [
+    { category: 'ssn', value: ssn(rng) },
+    { category: 'credit_card', value: pan.replace(/(\d{4})(?=\d)/g, '$1 ').trim() },
+    { category: 'email', value: email(rng) },
+    { category: 'phone', value: phone(rng) },
+    { category: 'aws_key', value: awsKey(rng) },
+    { category: 'passport', value: `X${digits(rng, 8)}` },
+    { category: 'dob', value: dob(rng) },
+  ];
+}

--- a/src/dlp/rng.ts
+++ b/src/dlp/rng.ts
@@ -1,0 +1,30 @@
+/** Deterministic PRNG (mulberry32). Returns a function yielding floats in [0, 1). */
+export function makeRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Pick a deterministic element from a non-empty array. */
+export function pick<T>(rng: () => number, xs: readonly T[]): T {
+  return xs[Math.floor(rng() * xs.length)];
+}
+
+/** Build a string of `n` random decimal digits. */
+export function digits(rng: () => number, n: number): string {
+  let out = '';
+  for (let i = 0; i < n; i++) {
+    out += Math.floor(rng() * 10).toString();
+  }
+  return out;
+}
+
+/** Derive a stable sub-seed from a base seed and an index. */
+export function subSeed(seed: number, index: number): number {
+  return (Math.imul(seed ^ 0x9e3779b9, 0x85ebca6b) + index * 0x27d4eb2f) >>> 0;
+}

--- a/src/dlp/types.ts
+++ b/src/dlp/types.ts
@@ -1,0 +1,29 @@
+export type Format = 'pdf' | 'png' | 'jpeg' | 'svg' | 'docx';
+
+export interface PayloadValue {
+  category: string;
+  value: string;
+}
+
+export interface Technique {
+  id: string;
+  format: Format;
+  label: string;
+  embed: (clean: Buffer, payload: PayloadValue[]) => Promise<Buffer> | Buffer;
+}
+
+export interface ManifestEntry {
+  format: Format;
+  technique: string;
+  clean: string;
+  dirty: string;
+  values: PayloadValue[];
+}
+
+export interface GenerateOptions {
+  types: Format[];
+  count: number;
+  out: string;
+  techniques: 'all' | string[];
+  seed?: number;
+}

--- a/tests/unit/dlp/embed-docx.spec.ts
+++ b/tests/unit/dlp/embed-docx.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { docxTechniques } from '../../../src/dlp/embed/docx.js';
+import { unzipText } from '../../../src/dlp/embed/zip.js';
+import { makePayload } from '../../../src/dlp/payload.js';
+import { makeRng } from '../../../src/dlp/rng.js';
+
+const payload = makePayload(makeRng(1));
+
+describe('docx embedders', () => {
+  for (const [id, technique] of Object.entries(docxTechniques)) {
+    it(`${id}: values recoverable; output is a zip`, async () => {
+      const out = Buffer.from(await technique.embed(Buffer.alloc(0), payload));
+      expect(out.subarray(0, 2).toString()).toBe('PK');
+      const text = unzipText(out);
+      for (const v of payload) {
+        expect(text).toContain(v.value);
+      }
+    });
+  }
+});

--- a/tests/unit/dlp/embed-jpeg.spec.ts
+++ b/tests/unit/dlp/embed-jpeg.spec.ts
@@ -1,0 +1,39 @@
+import sharp from 'sharp';
+import { describe, expect, it } from 'vitest';
+import { jpegExifExtract, jpegTechniques } from '../../../src/dlp/embed/jpeg.js';
+import { jpeg } from '../../../src/dlp/generate/jpeg.js';
+import { makePayload } from '../../../src/dlp/payload.js';
+import { makeRng } from '../../../src/dlp/rng.js';
+
+const payload = makePayload(makeRng(1));
+
+describe('jpeg embedders', () => {
+  it('exif: recoverable via piexif; jpeg stays valid', async () => {
+    const clean = await jpeg(makeRng(2));
+    const out = Buffer.from(await jpegTechniques.exif.embed(clean, payload));
+    const text = jpegExifExtract(out);
+    for (const v of payload) {
+      expect(text).toContain(v.value);
+    }
+    expect((await sharp(out).metadata()).format).toBe('jpeg');
+  });
+
+  it('com: values present in segment; jpeg stays valid', async () => {
+    const clean = await jpeg(makeRng(2));
+    const out = Buffer.from(await jpegTechniques.com.embed(clean, payload));
+    const s = out.toString('latin1');
+    for (const v of payload) {
+      expect(s).toContain(v.value);
+    }
+    expect((await sharp(out).metadata()).format).toBe('jpeg');
+  });
+
+  it('trailer: values present after EOI', async () => {
+    const clean = await jpeg(makeRng(2));
+    const out = Buffer.from(await jpegTechniques.trailer.embed(clean, payload));
+    const tail = out.subarray(Math.max(0, out.length - 300)).toString('latin1');
+    for (const v of payload) {
+      expect(tail).toContain(v.value);
+    }
+  });
+});

--- a/tests/unit/dlp/embed-pdf.spec.ts
+++ b/tests/unit/dlp/embed-pdf.spec.ts
@@ -1,0 +1,41 @@
+import { PDFDocument } from 'pdf-lib';
+import { describe, expect, it } from 'vitest';
+import { pdfMetaExtract, pdfStreamText, pdfTechniques } from '../../../src/dlp/embed/pdf.js';
+import { pdf } from '../../../src/dlp/generate/pdf.js';
+import { makePayload } from '../../../src/dlp/payload.js';
+import { makeRng } from '../../../src/dlp/rng.js';
+
+const payload = makePayload(makeRng(1));
+
+describe('pdf embedders', () => {
+  it('meta: recoverable via info dict; pdf valid', async () => {
+    const clean = await pdf(makeRng(2));
+    const out = Buffer.from(await pdfTechniques.meta.embed(clean, payload));
+    const text = await pdfMetaExtract(out);
+    for (const v of payload) {
+      expect(text).toContain(v.value);
+    }
+    expect(out.subarray(0, 4).toString()).toBe('%PDF');
+  });
+
+  it('hidden-text: literal present in content; pdf reloads', async () => {
+    const clean = await pdf(makeRng(2));
+    const out = Buffer.from(await pdfTechniques['hidden-text'].embed(clean, payload));
+    const text = pdfStreamText(out);
+    for (const v of payload) {
+      expect(text).toContain(v.value);
+    }
+    await expect(PDFDocument.load(out)).resolves.toBeDefined();
+  });
+
+  it('trailer: values after final %%EOF; pdf reloads', async () => {
+    const clean = await pdf(makeRng(2));
+    const out = Buffer.from(await pdfTechniques.trailer.embed(clean, payload));
+    const parts = out.toString('latin1').split('%%EOF');
+    const tail = parts[parts.length - 1];
+    for (const v of payload) {
+      expect(tail).toContain(v.value);
+    }
+    await expect(PDFDocument.load(out)).resolves.toBeDefined();
+  });
+});

--- a/tests/unit/dlp/embed-png.spec.ts
+++ b/tests/unit/dlp/embed-png.spec.ts
@@ -1,0 +1,40 @@
+import sharp from 'sharp';
+import { describe, expect, it } from 'vitest';
+import { lsbExtract, pngTechniques } from '../../../src/dlp/embed/png.js';
+import { readTextChunks } from '../../../src/dlp/embed/png-chunks.js';
+import { png } from '../../../src/dlp/generate/png.js';
+import { makePayload } from '../../../src/dlp/payload.js';
+import { makeRng } from '../../../src/dlp/rng.js';
+
+const payload = makePayload(makeRng(1));
+
+describe('png embedders', () => {
+  it('text-chunks: values recoverable from chunks; png stays valid', async () => {
+    const clean = await png(makeRng(2));
+    const out = Buffer.from(await pngTechniques['text-chunks'].embed(clean, payload));
+    const text = readTextChunks(out);
+    for (const v of payload) {
+      expect(text).toContain(v.value);
+    }
+    expect((await sharp(out).metadata()).format).toBe('png');
+  });
+
+  it('trailer: values present after IEND', async () => {
+    const clean = await png(makeRng(2));
+    const out = Buffer.from(await pngTechniques.trailer.embed(clean, payload));
+    const tail = out.subarray(out.indexOf(Buffer.from('IEND'))).toString('latin1');
+    for (const v of payload) {
+      expect(tail).toContain(v.value);
+    }
+  });
+
+  it('stego-lsb: payload decodes back; png stays valid', async () => {
+    const clean = await png(makeRng(2));
+    const out = Buffer.from(await pngTechniques['stego-lsb'].embed(clean, payload));
+    const recovered = await lsbExtract(out);
+    for (const v of payload) {
+      expect(recovered).toContain(v.value);
+    }
+    expect((await sharp(out).metadata()).format).toBe('png');
+  });
+});

--- a/tests/unit/dlp/embed-svg.spec.ts
+++ b/tests/unit/dlp/embed-svg.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { svgTechniques } from '../../../src/dlp/embed/svg.js';
+import { svg } from '../../../src/dlp/generate/svg.js';
+import { makePayload } from '../../../src/dlp/payload.js';
+import { makeRng } from '../../../src/dlp/rng.js';
+
+const payload = makePayload(makeRng(1));
+const clean = svg(makeRng(2));
+
+describe('svg embedders', () => {
+  for (const [id, technique] of Object.entries(svgTechniques)) {
+    it(`${id}: embeds every value and stays a valid svg`, async () => {
+      const out = Buffer.from(await technique.embed(clean, payload));
+      const text = out.toString('utf8');
+      for (const v of payload) {
+        expect(text).toContain(v.value);
+      }
+      expect(text.startsWith('<svg')).toBe(true);
+      expect(text).toContain('</svg>');
+    });
+  }
+});

--- a/tests/unit/dlp/generate.spec.ts
+++ b/tests/unit/dlp/generate.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { generators } from '../../../src/dlp/generate/index.js';
+import { makeRng } from '../../../src/dlp/rng.js';
+
+describe('clean generators', () => {
+  it('pdf starts with %PDF', async () => {
+    const b = await generators.pdf(makeRng(1));
+    expect(b.subarray(0, 4).toString()).toBe('%PDF');
+  });
+
+  it('png has PNG magic', async () => {
+    const b = await generators.png(makeRng(1));
+    expect(b.subarray(1, 4).toString()).toBe('PNG');
+  });
+
+  it('jpeg has SOI marker', async () => {
+    const b = await generators.jpeg(makeRng(1));
+    expect(b.subarray(0, 2).toString('hex')).toBe('ffd8');
+  });
+
+  it('svg has a namespaced root', async () => {
+    const b = await generators.svg(makeRng(1));
+    expect(b.toString()).toContain('<svg xmlns="http://www.w3.org/2000/svg"');
+  });
+
+  it('docx is a zip (PK)', async () => {
+    const b = await generators.docx(makeRng(1));
+    expect(b.subarray(0, 2).toString()).toBe('PK');
+  });
+});

--- a/tests/unit/dlp/lorem.spec.ts
+++ b/tests/unit/dlp/lorem.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { lorem } from '../../../src/dlp/lorem.js';
+import { makeRng } from '../../../src/dlp/rng.js';
+
+describe('lorem', () => {
+  it('returns the requested number of paragraphs', () => {
+    expect(lorem(makeRng(1), 3).split('\n\n')).toHaveLength(3);
+  });
+
+  it('is deterministic by seed', () => {
+    expect(lorem(makeRng(1), 3)).toEqual(lorem(makeRng(1), 3));
+  });
+
+  it('produces non-empty capitalized sentences', () => {
+    const text = lorem(makeRng(2), 1);
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toMatch(/^[A-Z]/);
+    expect(text.trim().endsWith('.')).toBe(true);
+  });
+});

--- a/tests/unit/dlp/manifest.spec.ts
+++ b/tests/unit/dlp/manifest.spec.ts
@@ -1,0 +1,35 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildManifest, writeManifest } from '../../../src/dlp/manifest.js';
+import type { ManifestEntry } from '../../../src/dlp/types.js';
+
+const entry: ManifestEntry = {
+  format: 'svg',
+  technique: 'meta',
+  clean: 'a.svg',
+  dirty: 'a__meta.svg',
+  values: [{ category: 'ssn', value: '900-00-0000' }],
+};
+
+describe('buildManifest', () => {
+  it('maps dirty files to technique + values', () => {
+    const m = buildManifest([entry]);
+    expect(m.count).toBe(1);
+    expect(m.entries[0].technique).toBe('meta');
+    expect(m.entries[0].values[0].category).toBe('ssn');
+    expect(typeof m.generatedAt).toBe('string');
+  });
+});
+
+describe('writeManifest', () => {
+  it('writes valid JSON to disk', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'dlp-manifest-'));
+    const path = join(dir, 'manifest.json');
+    await writeManifest(path, buildManifest([entry]));
+    const parsed = JSON.parse(await readFile(path, 'utf8'));
+    expect(parsed.count).toBe(1);
+    expect(parsed.entries[0].dirty).toBe('a__meta.svg');
+  });
+});

--- a/tests/unit/dlp/orchestrate.spec.ts
+++ b/tests/unit/dlp/orchestrate.spec.ts
@@ -1,0 +1,55 @@
+import { existsSync } from 'node:fs';
+import { mkdtemp, readdir, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { generateCorpus } from '../../../src/dlp/index.js';
+
+describe('generateCorpus', () => {
+  it('writes clean + dirty + manifest across all formats and techniques', async () => {
+    const out = await mkdtemp(join(tmpdir(), 'dlp-corpus-'));
+    const summary = await generateCorpus({
+      types: ['svg', 'png', 'jpeg', 'pdf', 'docx'],
+      count: 1,
+      out,
+      techniques: 'all',
+      seed: 9,
+    });
+    expect(summary.clean).toBe(5);
+    expect(summary.dirty).toBe(15); // 3 techniques x 5 formats
+    expect(existsSync(summary.manifestPath)).toBe(true);
+
+    const manifest = JSON.parse(await readFile(summary.manifestPath, 'utf8'));
+    expect(manifest.entries).toHaveLength(15);
+    expect(manifest.entries.every((e: { values: unknown[] }) => e.values.length > 0)).toBe(true);
+    expect((await readdir(join(out, 'dirty', 'svg'))).length).toBe(3);
+    expect((await readdir(join(out, 'clean', 'png'))).length).toBe(1);
+  });
+
+  it('honors a technique filter', async () => {
+    const out = await mkdtemp(join(tmpdir(), 'dlp-filter-'));
+    const summary = await generateCorpus({
+      types: ['png'],
+      count: 1,
+      out,
+      techniques: ['stego-lsb'],
+      seed: 3,
+    });
+    expect(summary.dirty).toBe(1);
+    expect((await readdir(join(out, 'dirty', 'png')))[0]).toContain('__stego-lsb');
+  });
+
+  it('is byte-reproducible for a seed (svg)', async () => {
+    const a = await mkdtemp(join(tmpdir(), 'dlp-a-'));
+    const b = await mkdtemp(join(tmpdir(), 'dlp-b-'));
+    await generateCorpus({ types: ['svg'], count: 1, out: a, techniques: 'all', seed: 7 });
+    await generateCorpus({ types: ['svg'], count: 1, out: b, techniques: 'all', seed: 7 });
+    const files = (await readdir(join(a, 'dirty', 'svg'))).sort();
+    expect(files).toEqual((await readdir(join(b, 'dirty', 'svg'))).sort());
+    for (const f of files) {
+      expect(await readFile(join(a, 'dirty', 'svg', f))).toEqual(
+        await readFile(join(b, 'dirty', 'svg', f)),
+      );
+    }
+  });
+});

--- a/tests/unit/dlp/payload.spec.ts
+++ b/tests/unit/dlp/payload.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { luhnValid, makePayload } from '../../../src/dlp/payload.js';
+import { makeRng } from '../../../src/dlp/rng.js';
+
+const get = (rng: () => number, category: string): string =>
+  makePayload(rng).find((v) => v.category === category)?.value ?? '';
+
+describe('luhnValid', () => {
+  it('accepts a known-valid PAN and rejects a tampered one', () => {
+    expect(luhnValid('4111111111111111')).toBe(true);
+    expect(luhnValid('4111111111111112')).toBe(false);
+    expect(luhnValid('')).toBe(false);
+  });
+});
+
+describe('makePayload', () => {
+  it('is deterministic by seed', () => {
+    expect(makePayload(makeRng(5))).toEqual(makePayload(makeRng(5)));
+  });
+
+  it('emits a Luhn-valid Visa-family test PAN', () => {
+    const pan = get(makeRng(11), 'credit_card').replace(/\s/g, '');
+    expect(pan).toMatch(/^4\d{15}$/);
+    expect(luhnValid(pan)).toBe(true);
+  });
+
+  it('uses only reserved / example ranges and no real-PII shapes', () => {
+    const all = makePayload(makeRng(13))
+      .map((v) => v.value)
+      .join(' ');
+    expect(all).toMatch(/@example\.(com|org|net)/);
+    expect(all).toMatch(/\b555-01\d\d\b/);
+    expect(all).toMatch(/\b9\d\d-\d\d-\d{4}\b/); // 900-range SSN, never issued
+    expect(all).toMatch(/AKIA[A-Z2-7]{9}EXAMPLE/);
+    expect(all).not.toMatch(/sk_live_/); // avoid GitHub push-protection trigger
+  });
+
+  it('covers all expected categories', () => {
+    const cats = makePayload(makeRng(1)).map((v) => v.category);
+    expect(cats).toEqual(
+      expect.arrayContaining([
+        'ssn',
+        'credit_card',
+        'email',
+        'phone',
+        'aws_key',
+        'passport',
+        'dob',
+      ]),
+    );
+  });
+});

--- a/tests/unit/dlp/rng.spec.ts
+++ b/tests/unit/dlp/rng.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { digits, makeRng, pick, subSeed } from '../../../src/dlp/rng.js';
+
+describe('makeRng', () => {
+  it('is deterministic for a given seed', () => {
+    const a = makeRng(42);
+    const b = makeRng(42);
+    expect([a(), a(), a()]).toEqual([b(), b(), b()]);
+  });
+
+  it('differs across seeds', () => {
+    expect(makeRng(1)()).not.toEqual(makeRng(2)());
+  });
+
+  it('returns floats in [0, 1)', () => {
+    const r = makeRng(7);
+    for (let i = 0; i < 200; i++) {
+      const v = r();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+});
+
+describe('pick', () => {
+  it('selects an element from the array', () => {
+    const r = makeRng(3);
+    const xs = ['a', 'b', 'c'];
+    for (let i = 0; i < 50; i++) {
+      expect(xs).toContain(pick(r, xs));
+    }
+  });
+});
+
+describe('digits', () => {
+  it('returns exactly n decimal digits', () => {
+    const r = makeRng(9);
+    const d = digits(r, 12);
+    expect(d).toHaveLength(12);
+    expect(d).toMatch(/^[0-9]{12}$/);
+  });
+});
+
+describe('subSeed', () => {
+  it('is deterministic and index-sensitive', () => {
+    expect(subSeed(5, 0)).toEqual(subSeed(5, 0));
+    expect(subSeed(5, 0)).not.toEqual(subSeed(5, 1));
+  });
+});


### PR DESCRIPTION
## Summary
Adds `airs runtime dlp-gen`, a local generator for **DLP test corpora**, plus a companion `dlp-test-files` skill (the repo's first skill).

- Generates **clean** carrier files and **dirty** copies with **synthetic** sensitive data embedded via multiple techniques per format.
- Formats: **PDF, PNG, JPEG, SVG, DOCX**. 15 techniques total (3 each):
  - PDF: `meta`, `hidden-text`, `trailer`
  - PNG: `text-chunks`, `trailer`, `stego-lsb`
  - JPEG: `exif`, `com`, `trailer`
  - SVG: `meta`, `hidden-text`, `comment`
  - DOCX: `core-props`, `hidden-run`, `visible`
- Writes `<out>/clean/`, `<out>/dirty/`, and `manifest.json` (dirty file → technique + embedded values) for scanner scoring.
- Randomized synthetic payloads (reserved-range SSNs, Luhn-valid test PANs, `example.com` emails, AWS `…EXAMPLE` keys, …); `--seed` for reproducibility. **No real PII.**

## Architecture
- Framework-free, unit-tested core under `src/dlp/` (rng, payload, lorem, manifest, generators, embedders, orchestrator).
- Thin Commander wiring in `src/cli/commands/dlp-gen.ts`, registered under the `runtime` group.
- New deps: `pdf-lib`, `docx`, `sharp`, `piexifjs`.

## Tests / gates
- 50+ new unit tests under `tests/unit/dlp/` (each embedder verified via a real extractor: PNG chunk/LSB decode, EXIF read, PDF stream inflate + hex decode, docx unzip, etc.).
- Full suite: **562 tests pass**; coverage **93.13% lines / 88.11% branches / 99.61% functions** (above thresholds). `tsc --noEmit` clean; `mkdocs build` clean.

## Docs
- `docs/runtime/dlp-gen.md` (+ nav), `AGENTS.md` entry, changeset (minor).

## Test plan
- [x] `pnpm test:coverage`, `pnpm tsc --noEmit`, `mkdocs build` all green locally
- [x] CLI smoke: `airs runtime dlp-gen --types all --seed 1` → 5 clean + 15 dirty + manifest
- [ ] Run dirty files through a scanner and reconcile against `manifest.json`