### PR TITLE
ci: run GitHub Actions on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  # pnpm/action-setup has no Node 24 major yet; force it (and any JS action) onto Node 24.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
@@ -24,13 +24,13 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
@@ -39,13 +39,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
@@ -54,9 +54,9 @@ jobs:
   docs-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,8 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: cdot65/prisma-airs-cli
+  # Run JS actions (docker/*) on Node 24 — they have no newer major yet.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   build-and-push:
@@ -19,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -9,6 +9,10 @@ on:
       - ".github/workflows/mkdocs-deploy.yml"
   workflow_dispatch:
 
+env:
+  # Run JS actions (upload-pages-artifact/deploy-pages) on Node 24 — no newer major yet.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   contents: read
   pages: write
@@ -22,9 +26,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/redteam-scan.yml
+++ b/.github/workflows/redteam-scan.yml
@@ -11,6 +11,10 @@ on:
       - 'redteam/**'
   workflow_dispatch:
 
+env:
+  # pnpm/action-setup has no Node 24 major yet; force it (and any JS action) onto Node 24.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   redteam-scan:
     name: Red Team Scan

--- a/.github/workflows/redteam-scan.yml
+++ b/.github/workflows/redteam-scan.yml
@@ -21,15 +21,15 @@ jobs:
       PANW_MGMT_TSG_ID: ${{ secrets.PANW_MGMT_TSG_ID }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
Silences the GitHub "Node.js 20 actions are deprecated" warnings by moving all workflows onto Node 24.

- `actions/checkout` v4→v5, `actions/setup-node` v4→v5, `actions/setup-python` v5→v6 (their newer majors ship the Node 24 runtime).
- Project `node-version` 20→24 in `ci.yml` + `redteam-scan.yml` (matches `publish.yml`, which already runs Node 24).
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` added to `docker-publish.yml` (docker/* actions) and `mkdocs-deploy.yml` (Pages actions), which have no newer major yet — so they run on Node 24 too.
- `pnpm/action-setup@v4` left as-is (composite action, not flagged).

## Test plan
- [ ] This PR's CI runs `ci.yml` from the head branch → validates the upgraded actions **and** that lint/typecheck/test/docs build pass on **Node 24**.
- [ ] `mkdocs-deploy` verified on merge to main (runs on push).
- [ ] `publish`/`docker-publish` exercised at next release/tag.