### PR TITLE
feat(dlp): add visible-text techniques (incl. same-color) to dlp-gen

### DIFF
--- a/.changeset/0019-dlp-gen-visible-text.md
+++ b/.changeset/0019-dlp-gen-visible-text.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": minor
+---
+
+`airs runtime dlp-gen`: add visible-text embedding techniques. Every format now has a `visible` technique that renders the synthetic payload as on-page/on-canvas text with foreground ≠ background (genuinely visible / OCR-able). PDF and DOCX additionally get `visible-samecolor`, which draws the text in the **same color as its background** — present and extractable, but camouflaged from the eye. This brings the corpus to 21 dirty files per run with `--types all --count 1`.

--- a/.claude/skills/dlp-test-files/SKILL.md
+++ b/.claude/skills/dlp-test-files/SKILL.md
@@ -62,11 +62,14 @@ values embedded — use it to score scanner hits/misses.
 
 | Format | Technique ids |
 |--------|---------------|
-| PDF | `meta`, `hidden-text`, `trailer` |
-| PNG | `text-chunks`, `trailer`, `stego-lsb` |
-| JPEG | `exif`, `com`, `trailer` |
-| SVG | `meta`, `hidden-text`, `comment` |
-| DOCX | `core-props`, `hidden-run`, `visible` |
+| PDF | `meta`, `hidden-text`, `trailer`, `visible`, `visible-samecolor` |
+| PNG | `text-chunks`, `trailer`, `stego-lsb`, `visible` |
+| JPEG | `exif`, `com`, `trailer`, `visible` |
+| SVG | `meta`, `hidden-text`, `comment`, `visible` |
+| DOCX | `core-props`, `hidden-run`, `visible`, `visible-samecolor` |
+
+`visible` renders text with foreground ≠ background (OCR-able). `visible-samecolor` (PDF & DOCX)
+draws body text in the **same color as its background** — extractable but camouflaged.
 
 ## Scoring against a scanner
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,9 +137,11 @@ airs runtime dlp-gen [--types pdf,png,jpeg,svg,docx] [--count <n>] [--out <dir>]
 Generates clean carrier files and "dirty" copies with **synthetic** sensitive data embedded
 via multiple techniques (per format). Writes `<out>/clean/`, `<out>/dirty/`, and
 `<out>/manifest.json` (dirty file → technique + embedded values, for scoring). No auth required
-(local file generation). Technique ids: PDF `meta|hidden-text|trailer`; PNG
-`text-chunks|trailer|stego-lsb`; JPEG `exif|com|trailer`; SVG `meta|hidden-text|comment`; DOCX
-`core-props|hidden-run|visible`. All values are synthetic / reserved-for-testing.
+(local file generation). Technique ids: PDF `meta|hidden-text|trailer|visible|visible-samecolor`;
+PNG `text-chunks|trailer|stego-lsb|visible`; JPEG `exif|com|trailer|visible`; SVG
+`meta|hidden-text|comment|visible`; DOCX `core-props|hidden-run|visible|visible-samecolor`.
+`visible` = foreground ≠ background; `visible-samecolor` (PDF & DOCX) = foreground == background
+(camouflaged but extractable). All values are synthetic / reserved-for-testing.
 
 ---
 

--- a/docs/development/full-cli-sweep.md
+++ b/docs/development/full-cli-sweep.md
@@ -148,14 +148,14 @@ Expected output (pretty):
   DLP Test-File Generation
   Output:   ./temp
   Seed:     1
-  Clean:    5    Dirty: 15
+  Clean:    5    Dirty: 21
   Manifest: ./temp/manifest.json
 
-    svg   clean=1 dirty=3
-    png   clean=1 dirty=3
-    pdf   clean=1 dirty=3
-    jpeg  clean=1 dirty=3
-    docx  clean=1 dirty=3
+    pdf   clean=1 dirty=5
+    png   clean=1 dirty=4
+    jpeg  clean=1 dirty=4
+    svg   clean=1 dirty=4
+    docx  clean=1 dirty=4
 ```
 
 Produces `temp/clean/<type>/`, `temp/dirty/<type>/<base>__<technique>.<ext>`, and

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -218,9 +218,11 @@ airs runtime dlp-gen [--types <list>] [--count <n>] [--out <dir>] [--techniques 
 | `--seed <n>` | No | Seed the synthetic-payload RNG for reproducible runs |
 | `--output <fmt>` | No | Summary format: `pretty` (default) or `json` |
 
-Technique ids: PDF `meta`, `hidden-text`, `trailer`; PNG `text-chunks`, `trailer`, `stego-lsb`;
-JPEG `exif`, `com`, `trailer`; SVG `meta`, `hidden-text`, `comment`; DOCX `core-props`,
-`hidden-run`, `visible`.
+Technique ids: PDF `meta`, `hidden-text`, `trailer`, `visible`, `visible-samecolor`; PNG
+`text-chunks`, `trailer`, `stego-lsb`, `visible`; JPEG `exif`, `com`, `trailer`, `visible`;
+SVG `meta`, `hidden-text`, `comment`, `visible`; DOCX `core-props`, `hidden-run`, `visible`,
+`visible-samecolor`. (`visible` = foreground ≠ background; `visible-samecolor` = foreground ==
+background, camouflaged but extractable.)
 
 #### Examples
 
@@ -241,14 +243,14 @@ airs runtime dlp-gen --types png --techniques stego-lsb --output json
   DLP Test-File Generation
   Output:   ./temp
   Seed:     1
-  Clean:    5    Dirty: 15
+  Clean:    5    Dirty: 21
   Manifest: ./temp/manifest.json
 
-    svg   clean=1 dirty=3
-    png   clean=1 dirty=3
-    pdf   clean=1 dirty=3
-    jpeg  clean=1 dirty=3
-    docx  clean=1 dirty=3
+    pdf   clean=1 dirty=5
+    png   clean=1 dirty=4
+    jpeg  clean=1 dirty=4
+    svg   clean=1 dirty=4
+    docx  clean=1 dirty=4
 ```
 
 Output layout: `<out>/clean/<type>/`, `<out>/dirty/<type>/<base>__<technique>.<ext>`, and

--- a/docs/runtime/dlp-gen.md
+++ b/docs/runtime/dlp-gen.md
@@ -42,11 +42,15 @@ the exact synthetic values embedded.
 
 | Format | Technique ids |
 |--------|---------------|
-| PDF | `meta`, `hidden-text`, `trailer` |
-| PNG | `text-chunks`, `trailer`, `stego-lsb` |
-| JPEG | `exif`, `com`, `trailer` |
-| SVG | `meta`, `hidden-text`, `comment` |
-| DOCX | `core-props`, `hidden-run`, `visible` |
+| PDF | `meta`, `hidden-text`, `trailer`, `visible`, `visible-samecolor` |
+| PNG | `text-chunks`, `trailer`, `stego-lsb`, `visible` |
+| JPEG | `exif`, `com`, `trailer`, `visible` |
+| SVG | `meta`, `hidden-text`, `comment`, `visible` |
+| DOCX | `core-props`, `hidden-run`, `visible`, `visible-samecolor` |
+
+`visible` = rendered text with foreground ≠ background (genuinely visible / OCR-able).
+`visible-samecolor` (PDF & DOCX) = rendered body text drawn in the **same color as its
+background** — present and extractable, but camouflaged from the eye.
 
 ## Examples
 

--- a/src/dlp/embed/docx.ts
+++ b/src/dlp/embed/docx.ts
@@ -1,4 +1,4 @@
-import { Document, HeadingLevel, Packer, Paragraph, TextRun } from 'docx';
+import { Document, HeadingLevel, Packer, Paragraph, ShadingType, TextRun } from 'docx';
 import { lorem } from '../lorem.js';
 import { makeRng } from '../rng.js';
 import type { PayloadValue, Technique } from '../types.js';
@@ -52,7 +52,24 @@ export const docxTechniques: Record<string, Technique> = {
   visible: {
     id: 'visible',
     format: 'docx',
-    label: 'visible body line',
+    label: 'visible body text (foreground != background)',
     embed: (_clean, p) => build([new Paragraph({ children: [new TextRun(join(p))] })]),
+  },
+  'visible-samecolor': {
+    id: 'visible-samecolor',
+    format: 'docx',
+    label: 'visible run, same color as background (camouflaged)',
+    embed: (_clean, p) =>
+      build([
+        new Paragraph({
+          children: [
+            new TextRun({
+              text: join(p),
+              color: 'D9D9D9',
+              shading: { type: ShadingType.CLEAR, color: 'auto', fill: 'D9D9D9' },
+            }),
+          ],
+        }),
+      ]),
   },
 };

--- a/src/dlp/embed/jpeg.ts
+++ b/src/dlp/embed/jpeg.ts
@@ -1,5 +1,6 @@
 import piexif from 'piexifjs';
 import type { PayloadValue, Technique } from '../types.js';
+import { renderVisibleText } from './overlay.js';
 
 const join = (p: PayloadValue[]): string => p.map((v) => `${v.category}: ${v.value}`).join(' | ');
 
@@ -61,5 +62,11 @@ export const jpegTechniques: Record<string, Technique> = {
     format: 'jpeg',
     label: 'bytes after EOI',
     embed: (c, p) => Buffer.concat([c, Buffer.from(`\nDLP ${join(p)}\n`, 'utf8')]),
+  },
+  visible: {
+    id: 'visible',
+    format: 'jpeg',
+    label: 'visible rendered text (dark on light)',
+    embed: (c, p) => renderVisibleText(c, p, 'jpeg'),
   },
 };

--- a/src/dlp/embed/overlay.ts
+++ b/src/dlp/embed/overlay.ts
@@ -1,0 +1,32 @@
+import sharp from 'sharp';
+import type { PayloadValue } from '../types.js';
+
+const esc = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+/**
+ * Paint the payload as visible text onto an image (foreground != background) by
+ * compositing an SVG overlay, then re-encode to the requested raster format.
+ */
+export async function renderVisibleText(
+  clean: Buffer,
+  payload: PayloadValue[],
+  format: 'png' | 'jpeg',
+): Promise<Buffer> {
+  const meta = await sharp(clean).metadata();
+  const w = meta.width ?? 256;
+  const h = meta.height ?? 192;
+  const lines = payload
+    .map(
+      (v, i) =>
+        `<text x="8" y="${18 + i * 16}" font-family="sans-serif" font-size="11" fill="#000000">` +
+        `${esc(`${v.category}: ${v.value}`)}</text>`,
+    )
+    .join('');
+  const bandH = Math.min(h, 18 + payload.length * 16);
+  const overlay =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}">` +
+    `<rect x="0" y="0" width="${w}" height="${bandH}" fill="#fafafa"/>${lines}</svg>`;
+  const img = sharp(clean).composite([{ input: Buffer.from(overlay), top: 0, left: 0 }]);
+  return format === 'png' ? img.png().toBuffer() : img.jpeg({ quality: 90 }).toBuffer();
+}

--- a/src/dlp/embed/pdf.ts
+++ b/src/dlp/embed/pdf.ts
@@ -30,6 +30,27 @@ async function hiddenText(clean: Buffer, p: PayloadValue[]): Promise<Buffer> {
 const trailer = (clean: Buffer, p: PayloadValue[]): Buffer =>
   Buffer.concat([clean, Buffer.from(`\n% DLP ${join(p)}\n`, 'utf8')]);
 
+// Visible text painted onto the page over a filled background band.
+//   sameColor=false -> dark text on a light band (genuinely visible)
+//   sameColor=true  -> text drawn in the band's own color (camouflaged, same fg/bg)
+async function visibleText(clean: Buffer, p: PayloadValue[], sameColor: boolean): Promise<Buffer> {
+  const doc = await PDFDocument.load(clean);
+  const page = doc.getPage(0);
+  const bg = rgb(0.93, 0.93, 0.85);
+  page.drawRectangle({ x: 36, y: 592, width: 524, height: 136, color: bg });
+  let y = 712;
+  for (const v of p) {
+    page.drawText(`${v.category}: ${v.value}`, {
+      x: 44,
+      y,
+      size: 9,
+      color: sameColor ? bg : rgb(0, 0, 0),
+    });
+    y -= 14;
+  }
+  return Buffer.from(await doc.save());
+}
+
 /** Recover text from all PDF streams (inflating FlateDecode streams; falling back to raw). */
 export function pdfStreamText(pdf: Buffer): string {
   const parts: string[] = [];
@@ -95,5 +116,17 @@ export const pdfTechniques: Record<string, Technique> = {
     format: 'pdf',
     label: 'bytes after %%EOF',
     embed: (c, p) => trailer(c, p),
+  },
+  visible: {
+    id: 'visible',
+    format: 'pdf',
+    label: 'visible page text (dark on light band)',
+    embed: (c, p) => visibleText(c, p, false),
+  },
+  'visible-samecolor': {
+    id: 'visible-samecolor',
+    format: 'pdf',
+    label: 'visible page text, same color as background (camouflaged)',
+    embed: (c, p) => visibleText(c, p, true),
   },
 };

--- a/src/dlp/embed/png.ts
+++ b/src/dlp/embed/png.ts
@@ -1,5 +1,6 @@
 import sharp from 'sharp';
 import type { PayloadValue, Technique } from '../types.js';
+import { renderVisibleText } from './overlay.js';
 import { insertBeforeIEND, iTXt, tEXt, zTXt } from './png-chunks.js';
 
 const join = (p: PayloadValue[]): string => p.map((v) => `${v.category}: ${v.value}`).join(' | ');
@@ -72,5 +73,11 @@ export const pngTechniques: Record<string, Technique> = {
     format: 'png',
     label: 'LSB steganography',
     embed: (c, p) => lsbEmbed(c, join(p)),
+  },
+  visible: {
+    id: 'visible',
+    format: 'png',
+    label: 'visible rendered text (dark on light)',
+    embed: (c, p) => renderVisibleText(c, p, 'png'),
   },
 };

--- a/src/dlp/embed/svg.ts
+++ b/src/dlp/embed/svg.ts
@@ -10,6 +10,13 @@ function inject(clean: Buffer, snippet: string): Buffer {
   return Buffer.from(s.slice(0, idx) + snippet + s.slice(idx), 'utf8');
 }
 
+/** Insert a snippet just before `</svg>` so it paints on top (visible). */
+function appendBeforeClose(clean: Buffer, snippet: string): Buffer {
+  const s = clean.toString('utf8');
+  const idx = s.lastIndexOf('</svg>');
+  return Buffer.from(s.slice(0, idx) + snippet + s.slice(idx), 'utf8');
+}
+
 export const svgTechniques: Record<string, Technique> = {
   meta: {
     id: 'meta',
@@ -32,5 +39,21 @@ export const svgTechniques: Record<string, Technique> = {
     format: 'svg',
     label: 'XML comment',
     embed: (c, p) => inject(c, `<!-- ${line(p)} -->`),
+  },
+  visible: {
+    id: 'visible',
+    format: 'svg',
+    label: 'visible on-canvas text (dark on light)',
+    embed: (c, p) =>
+      appendBeforeClose(
+        c,
+        `<rect x="6" y="6" width="228" height="${Math.min(148, 12 + p.length * 15)}" fill="#fafafa"/>` +
+          p
+            .map(
+              (v, i) =>
+                `<text x="10" y="${20 + i * 15}" font-size="10" fill="#111111">${v.category}: ${v.value}</text>`,
+            )
+            .join(''),
+      ),
   },
 };

--- a/tests/unit/dlp/embed-jpeg.spec.ts
+++ b/tests/unit/dlp/embed-jpeg.spec.ts
@@ -36,4 +36,15 @@ describe('jpeg embedders', () => {
       expect(tail).toContain(v.value);
     }
   });
+
+  it('visible: renders an overlay; stays a valid jpeg of the same size', async () => {
+    const clean = await jpeg(makeRng(2));
+    const out = Buffer.from(await jpegTechniques.visible.embed(clean, payload));
+    const cm = await sharp(clean).metadata();
+    const om = await sharp(out).metadata();
+    expect(om.format).toBe('jpeg');
+    expect(om.width).toBe(cm.width);
+    expect(om.height).toBe(cm.height);
+    expect(out.equals(clean)).toBe(false);
+  });
 });

--- a/tests/unit/dlp/embed-pdf.spec.ts
+++ b/tests/unit/dlp/embed-pdf.spec.ts
@@ -38,4 +38,17 @@ describe('pdf embedders', () => {
     }
     await expect(PDFDocument.load(out)).resolves.toBeDefined();
   });
+
+  for (const id of ['visible', 'visible-samecolor']) {
+    it(`${id}: text present in page content; pdf reloads`, async () => {
+      const clean = await pdf(makeRng(2));
+      const out = Buffer.from(await pdfTechniques[id].embed(clean, payload));
+      const text = pdfStreamText(out);
+      for (const v of payload) {
+        expect(text).toContain(v.value);
+      }
+      expect(out.subarray(0, 4).toString()).toBe('%PDF');
+      await expect(PDFDocument.load(out)).resolves.toBeDefined();
+    });
+  }
 });

--- a/tests/unit/dlp/embed-png.spec.ts
+++ b/tests/unit/dlp/embed-png.spec.ts
@@ -37,4 +37,15 @@ describe('png embedders', () => {
     }
     expect((await sharp(out).metadata()).format).toBe('png');
   });
+
+  it('visible: renders an overlay; stays a valid png of the same size', async () => {
+    const clean = await png(makeRng(2));
+    const out = Buffer.from(await pngTechniques.visible.embed(clean, payload));
+    const cm = await sharp(clean).metadata();
+    const om = await sharp(out).metadata();
+    expect(om.format).toBe('png');
+    expect(om.width).toBe(cm.width);
+    expect(om.height).toBe(cm.height);
+    expect(out.equals(clean)).toBe(false); // overlay was painted on
+  });
 });

--- a/tests/unit/dlp/orchestrate.spec.ts
+++ b/tests/unit/dlp/orchestrate.spec.ts
@@ -16,13 +16,13 @@ describe('generateCorpus', () => {
       seed: 9,
     });
     expect(summary.clean).toBe(5);
-    expect(summary.dirty).toBe(15); // 3 techniques x 5 formats
+    expect(summary.dirty).toBe(21); // svg4 + png4 + jpeg4 + pdf5 + docx4
     expect(existsSync(summary.manifestPath)).toBe(true);
 
     const manifest = JSON.parse(await readFile(summary.manifestPath, 'utf8'));
-    expect(manifest.entries).toHaveLength(15);
+    expect(manifest.entries).toHaveLength(21);
     expect(manifest.entries.every((e: { values: unknown[] }) => e.values.length > 0)).toBe(true);
-    expect((await readdir(join(out, 'dirty', 'svg'))).length).toBe(3);
+    expect((await readdir(join(out, 'dirty', 'svg'))).length).toBe(4);
     expect((await readdir(join(out, 'clean', 'png'))).length).toBe(1);
   });
 


### PR DESCRIPTION
## Summary
Adds **visible-text** embedding techniques to `airs runtime dlp-gen`.

- **Every format** gets a `visible` technique — the synthetic payload is rendered as on-page / on-canvas text with **foreground ≠ background** (genuinely visible, OCR-able):
  - PDF: dark text on a light band (page content)
  - DOCX: visible body run
  - SVG: on-canvas `<text>` painted on top
  - PNG / JPEG: text composited onto the image pixels
- **PDF and DOCX** additionally get `visible-samecolor` — body text drawn in the **same color as its background** (fg == bg): present and extractable, but camouflaged from the eye.

Corpus is now **21 dirty files** per `--types all --count 1` (was 15): pdf 5, png/jpeg/svg/docx 4 each.

## Tests / gates
- New cases for pdf `visible`/`visible-samecolor` (text recoverable from content stream), png/jpeg `visible` (valid image, overlay applied), svg/docx auto-covered by their loops. Orchestrator counts updated 15→21.
- Full suite: **568 tests pass**; coverage 93.34% lines / 88.14% branches / 99.63% functions (above thresholds). `tsc --noEmit` + `mkdocs build` clean.
- Smoke: `airs runtime dlp-gen --types all` → 21 dirty files incl. all `visible*` variants; verified pdf `visible` text extracts via `pdftotext`, svg renders on-canvas, png/jpeg are valid images.

## Docs
- Updated technique tables + sample outputs in `docs/runtime/dlp-gen.md`, `docs/reference/cli-commands.md`, `docs/development/full-cli-sweep.md`, `AGENTS.md`, and the `dlp-test-files` skill. Changeset (minor).

## Test plan
- [ ] Generate a corpus and scan the new `visible` / `visible-samecolor` files to compare DLP detection (esp. same-color vs hidden-run/vanish).