### PR TITLE
fix(debug): include DLP host in AIRS_DOMAINS allowlist

### DIFF
--- a/.changeset/0020-fix-debug-logger-dlp-host.md
+++ b/.changeset/0020-fix-debug-logger-dlp-host.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Fix `--debug` so it captures DLP API traffic. The fetch interceptor's host allowlist was missing `api.dlp.paloaltonetworks.com`, so `runtime dlp` commands were silently bypassing the JSONL log.

--- a/src/cli/debug-logger.ts
+++ b/src/cli/debug-logger.ts
@@ -6,9 +6,10 @@ const AIRS_DOMAINS = [
   'api.sase.paloaltonetworks.com',
   'service.api.aisecurity.paloaltonetworks.com',
   'auth.apps.paloaltonetworks.com',
+  'api.dlp.paloaltonetworks.com',
 ];
 
-function isAirsUrl(url: string): boolean {
+export function isAirsUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     return AIRS_DOMAINS.some((d) => parsed.hostname === d || parsed.hostname.endsWith(`.${d}`));

--- a/tests/unit/cli/debug-logger.spec.ts
+++ b/tests/unit/cli/debug-logger.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { isAirsUrl } from '../../../src/cli/debug-logger.js';
+
+describe('isAirsUrl', () => {
+  it('matches each AIRS production host', () => {
+    expect(isAirsUrl('https://api.sase.paloaltonetworks.com/foo')).toBe(true);
+    expect(isAirsUrl('https://service.api.aisecurity.paloaltonetworks.com/foo')).toBe(true);
+    expect(isAirsUrl('https://auth.apps.paloaltonetworks.com/oauth2/access_token')).toBe(true);
+    expect(isAirsUrl('https://api.dlp.paloaltonetworks.com/v2/api/data-filtering-profiles')).toBe(
+      true,
+    );
+  });
+
+  it('matches regional subdomains via endsWith', () => {
+    expect(isAirsUrl('https://us.api.sase.paloaltonetworks.com/foo')).toBe(true);
+    expect(isAirsUrl('https://eu.api.dlp.paloaltonetworks.com/foo')).toBe(true);
+  });
+
+  it('rejects non-AIRS hosts and malformed URLs', () => {
+    expect(isAirsUrl('https://example.com/foo')).toBe(false);
+    expect(isAirsUrl('https://paloaltonetworks.com/foo')).toBe(false);
+    expect(isAirsUrl('not-a-url')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `--debug` fetch interceptor only matched api.sase / service.api.aisecurity / auth.apps hosts. `runtime dlp` traffic on `api.dlp.paloaltonetworks.com` was silently bypassing the JSONL log.
- Adds the DLP host to `AIRS_DOMAINS` and exports `isAirsUrl` for unit testing.
- Companion to PR #78 (DLP commands). Surfaced during PR #78 smoke test against live tenant.

## Test plan

- [x] New unit test `tests/unit/cli/debug-logger.spec.ts` covers per-host matching (4 prod hosts, regional subdomains via `endsWith`, rejects non-AIRS / malformed URLs)
- [x] Full suite: 565 tests pass
- [x] Biome + tsc clean
- [ ] Live smoke (needs PANW_MGMT_* env): `pnpm run dev --debug runtime dlp filtering-profiles list --output json` should produce JSONL entry for the DLP request