### PR TITLE
DLP UX — structured flags + curated output (2.10.0)

### DIFF
--- a/.changeset/0019-dlp-ux.md
+++ b/.changeset/0019-dlp-ux.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": minor
+---
+
+DLP UX overhaul. `dlp patterns|profiles|filtering-profiles` now accept structured CLI flags (`--name`, `--regex`, `--pattern-id`, `--file-based`, …) instead of forcing `--body-file pattern.json`. All output formats now route through a curated projection — `--output json` returns `{items, page}` and ack `{action,id,name,…}` instead of the raw SDK envelope.

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v2.10.0
+
+### Changed
+
+- **DLP write commands now take structured flags** — `patterns|profiles|filtering-profiles create/replace` accept `--name`, `--regex`, `--weighted-regex`, `--pattern-id`, `--file-based`, `--direction`, `--tag k=v`, etc. instead of forcing `--body-file pattern.json`. `--body`/`--body-file` retained as escape hatches for complex rule trees.
+- **DLP output curated across all formats** — `--output json|yaml` now returns `{items, page:{number,size,total,returned}}` for lists and `{action,id,name,type,status,version}` for acks, dropping the raw SDK envelope leak (`tenant_id`, `is_parent_managed`, `pageable.*`).
+
+---
+
 ## v2.9.0
 
 ### New

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -7,6 +7,10 @@
 - **DLP write commands now take structured flags** — `patterns|profiles|filtering-profiles create/replace` accept `--name`, `--regex`, `--weighted-regex`, `--pattern-id`, `--file-based`, `--direction`, `--tag k=v`, etc. instead of forcing `--body-file pattern.json`. `--body`/`--body-file` retained as escape hatches for complex rule trees.
 - **DLP output curated across all formats** — `--output json|yaml` now returns `{items, page:{number,size,total,returned}}` for lists and `{action,id,name,type,status,version}` for acks, dropping the raw SDK envelope leak (`tenant_id`, `is_parent_managed`, `pageable.*`).
 
+### Fixed
+
+- **`dlp dictionaries create` now honors `--output`** — was hardcoded to `pretty`, ignoring the flag. Now matches the rest of the DLP command surface.
+
 ---
 
 ## v2.9.0

--- a/docs/development/full-cli-sweep.md
+++ b/docs/development/full-cli-sweep.md
@@ -470,25 +470,18 @@ airs model-security groups delete <groupUuid> --force
 DLP mutations have **partial coverage** on this tenant — patterns support CREATE + DELETE, but PATCH/REPLACE/GET-by-id and all profile/dictionary mutations currently return generic 400 from the upstream API. See the known-issue callout in B.4 and the matrix at the end of this section.
 
 ```bash
-# CREATE a custom pattern (works ✓)
-cat > pattern.json <<'EOF'
-{
-  "name": "cli-smoke-pattern",
-  "type": "custom",
-  "description": "throwaway smoke test pattern",
-  "detection_config": {
-    "technique": "regex",
-    "supported_confidence_levels": ["high", "low"]
-  },
-  "matching_rules": {
-    "delimiter": ";",
-    "proximity_distance": 200,
-    "regexes": [{ "regex": "SMOKE-TEST-[A-Z0-9]{8}", "weight": 1 }]
-  },
-  "tags": { "classification": ["smoke-test"] }
-}
-EOF
-airs runtime dlp patterns create --body-file pattern.json --output json
+# CREATE a custom pattern via structured flags (works ✓)
+airs runtime dlp patterns create \
+  --name "cli-smoke-pattern" \
+  --description "throwaway smoke test pattern" \
+  --confidence-levels "high,low" \
+  --delimiter ";" \
+  --proximity-distance 200 \
+  --regex "SMOKE-TEST-[A-Z0-9]{8}" \
+  --tag "classification=smoke-test" \
+  --output json
+
+# --body-file pattern.json is still accepted as an escape hatch for complex bodies.
 
 # Soft-DELETE (works ✓ — status flips to "deleted", still resolvable via list filtering)
 airs runtime dlp patterns delete <patternId>

--- a/docs/runtime/dlp/dictionaries.md
+++ b/docs/runtime/dlp/dictionaries.md
@@ -87,10 +87,7 @@ Flag reference:
 | `--metadata-file <path>` | JSON metadata file (overrides flat flags) |
 | `--include-keywords` | Echo parsed `keywords[]` in response |
 
-**Output** — created dictionary with server-assigned `id`. If `--include-keywords`, the parsed entries are included.
-
-!!! note
-    The `create` action currently always renders in `pretty` format. Use `get <id> --output json` to retrieve a JSON-shaped record after create.
+**Output (`--output json`)** — curated ack `{action: "created", id, name, type, status, version}`. Add `--include-keywords` to attach the parsed keyword list to the underlying SDK response (visible via `get <id> --keywords --output json` after create).
 
 ## get
 

--- a/docs/runtime/dlp/dictionaries.md
+++ b/docs/runtime/dlp/dictionaries.md
@@ -27,7 +27,7 @@ airs runtime dlp dictionaries list --page 0 --size 50 --output json
 airs runtime dlp dictionaries list --keywords  # Include keyword array in output
 ```
 
-**Output (`--output json`)** — curated `{items, page}` projection:
+**Output (`--output json`)** — curated `{items, page}` projection. `status`, `keywords`, and `version` are omitted from JSON when undefined (typical for predefined entries):
 
 ```json
 {
@@ -35,20 +35,14 @@ airs runtime dlp dictionaries list --keywords  # Include keyword array in output
     {
       "id": "6901...",
       "name": "Bank Names",
-      "type": "predefined",
-      "status": null,
-      "keywords": null,
-      "version": null
+      "type": "predefined"
     }
   ],
-  "page": { "number": 0, "size": 25, "total": null, "returned": 1 }
+  "page": { "number": 0, "size": 25, "total": 32, "returned": 1 }
 }
 ```
 
-Use `get <id>` (with `--keywords` to include the keyword array) for nested fields (`description`, `category`, `region_name`, `is_case_sensitive`, `detection_technique`, `dictionary_metadata`, `tags`, `audit_metadata`).
-
-!!! note
-    `keywords` is `null` unless `--keywords` is passed.
+Custom entries with status/version populated include those fields. The `keywords` field shows the count (not the array) when the underlying entry has a populated keyword list. Use `get <id> --keywords` for the full keyword list and other nested fields (`description`, `category`, `region_name`, `is_case_sensitive`, `detection_technique`, `dictionary_metadata`, `tags`, `audit_metadata`).
 
 ## create
 
@@ -88,6 +82,9 @@ Flag reference:
 | `--include-keywords` | Echo parsed `keywords[]` in response |
 
 **Output (`--output json`)** — curated ack `{action: "created", id, name, type, status, version}`. Add `--include-keywords` to attach the parsed keyword list to the underlying SDK response (visible via `get <id> --keywords --output json` after create).
+
+!!! warning "Known upstream issue (2026-05-24)"
+    The DLP API currently returns generic HTTP 400 on `POST /v2/api/dictionaries` against live tenants. The CLI builds a correctly-formed multipart request — reproducible failure is server-side. Tracked in [cdot65/prisma-airs-sdk#162](https://github.com/cdot65/prisma-airs-sdk/issues/162) / [cdot65/prisma-airs-cli#80](https://github.com/cdot65/prisma-airs-cli/issues/80).
 
 ## get
 

--- a/docs/runtime/dlp/dictionaries.md
+++ b/docs/runtime/dlp/dictionaries.md
@@ -27,89 +27,70 @@ airs runtime dlp dictionaries list --page 0 --size 50 --output json
 airs runtime dlp dictionaries list --keywords  # Include keyword array in output
 ```
 
-**Output** — Spring `Page<>` envelope (`totalElements`/`totalPages` are emitted as `null` by this endpoint); example with one predefined entry:
+**Output (`--output json`)** — curated `{items, page}` projection:
 
 ```json
 {
-  "content": [
+  "items": [
     {
       "id": "6901...",
       "name": "Bank Names",
-      "description": "List of large international banks",
-      "category": "Finance",
-      "region_name": "GLOBAL",
       "type": "predefined",
-      "is_case_sensitive": false,
-      "is_parent_managed": false,
-      "detection_technique": "dictionary",
-      "detection_sub_technique": null,
-      "dictionary_metadata": {
-        "number_of_keywords": 0,
-        "original_file_name": "",
-        "original_file_size_in_byte": 0
-      },
+      "status": null,
       "keywords": null,
-      "tags": { "classification": ["pab"] },
-      "attributes": null,
-      "audit_metadata": {
-        "created_at": 1761657319491,
-        "created_by": "System",
-        "updated_at": 1761657319491,
-        "updated_by": "System"
-      }
+      "version": null
     }
   ],
-  "pageable": { "page_number": 0, "page_size": 25, "offset": 0, "paged": true, "unpaged": false },
-  "first": true,
-  "last": false,
-  "size": 25,
-  "number": 0,
-  "number_of_elements": 25,
-  "empty": false,
-  "totalElements": null,
-  "totalPages": null
+  "page": { "number": 0, "size": 25, "total": null, "returned": 1 }
 }
 ```
 
+Use `get <id>` (with `--keywords` to include the keyword array) for nested fields (`description`, `category`, `region_name`, `is_case_sensitive`, `detection_technique`, `dictionary_metadata`, `tags`, `audit_metadata`).
+
 !!! note
-    `keywords` is `null` unless `--keywords` is passed. `detection_sub_technique`, `attributes`, and the `audit_metadata.created_by`/`updated_by` slots are commonly `null` on predefined entries.
+    `keywords` is `null` unless `--keywords` is passed.
 
 ## create
 
-Create a new dictionary. Requires multipart: metadata JSON + keyword file (newline-delimited text).
+Multipart upload — keyword file + metadata. Pass metadata via flat flags (preferred) or `--metadata-file`. `--file` is required.
 
-First, create the keyword file `codenames.txt`:
-
-```
+```bash
+# Keyword file (newline-delimited)
+cat > codenames.txt <<'EOF'
 alpha
 bravo
 charlie
 delta
 echo
+EOF
+
+# Flag-based metadata (preferred)
+airs runtime dlp dictionaries create \
+  --name "project-codenames" \
+  --category Confidential \
+  --region us-west-2 \
+  --description "Internal project codenames — phonetic alphabet" \
+  --file codenames.txt \
+  --include-keywords
 ```
 
-Then create the metadata file `dict-meta.json`:
+Flag reference:
 
-```json
-{
-  "category": "Confidential",
-  "name": "project-codenames",
-  "original_file_name": "codenames.txt",
-  "region_name": "us-west-2",
-  "description": "Internal project codenames — phonetic alphabet",
-  "is_case_sensitive": false
-}
-```
+| Flag | Notes |
+|------|-------|
+| `--file <path>` | **Required** — keyword file (newline-delimited) |
+| `--name <s>` | Dictionary name |
+| `--category <s>` | `Academic`, `Confidential`, `Employment`, `Financial`, `Government`, `Healthcare`, `Legal`, `Marketing`, `Source Code` |
+| `--region <s>` | Region (e.g. `us-west-2`, `GLOBAL`) |
+| `--description <s>` | Optional |
+| `--classification <s>` | Tag value (becomes `tags.classification`) |
+| `--metadata-file <path>` | JSON metadata file (overrides flat flags) |
+| `--include-keywords` | Echo parsed `keywords[]` in response |
 
-Then invoke create:
+**Output** — created dictionary with server-assigned `id`. If `--include-keywords`, the parsed entries are included.
 
-```bash
-airs runtime dlp dictionaries create --metadata-file dict-meta.json --file-path codenames.txt
-airs runtime dlp dictionaries create --metadata-file dict-meta.json --file-path codenames.txt --output json
-airs runtime dlp dictionaries create --metadata-file dict-meta.json --file-path codenames.txt --keywords
-```
-
-**Output** — created dictionary with server-assigned `id` and lifecycle stamps. If `--keywords` is passed, the `keywords[]` array is included showing all parsed entries.
+!!! note
+    The `create` action currently always renders in `pretty` format. Use `get <id> --output json` to retrieve a JSON-shaped record after create.
 
 ## get
 
@@ -156,64 +137,40 @@ Note `dictionary_metadata.number_of_keywords` reflects the canonical server-side
 
 ## replace
 
-Perform a full multipart replace of both metadata and keyword file. The API may return 200+body (some regions) or 204+empty (others).
-
-Create updated metadata `dict-meta-v2.json`:
-
-```json
-{
-  "category": "Confidential",
-  "name": "project-codenames",
-  "original_file_name": "codenames.txt",
-  "region_name": "us-west-2",
-  "description": "Internal project codenames — updated",
-  "is_case_sensitive": false
-}
-```
-
-Create updated keyword file `codenames-v2.txt`:
-
-```
-alpha
-bravo
-charlie
-delta
-echo
-foxtrot
-```
-
-Then invoke replace:
+Full multipart replace of metadata + keyword file. Same flag set as `create`. The API returns 200+body in some regions, 204+empty in others — the CLI handles both.
 
 ```bash
-airs runtime dlp dictionaries replace 6901... --metadata-file dict-meta-v2.json --file-path codenames-v2.txt
-airs runtime dlp dictionaries replace 6901... --metadata-file dict-meta-v2.json --file-path codenames-v2.txt --output json
+airs runtime dlp dictionaries replace 6901... \
+  --name "project-codenames" \
+  --category Confidential \
+  --region us-west-2 \
+  --description "Internal project codenames — updated" \
+  --file codenames-v2.txt \
+  --output json
 ```
 
-**Output** — updated dictionary with incremented keyword count and refreshed `audit_metadata`. If the API returns 204, the output is empty; always re-fetch with `get --keywords` to canonically observe state.
+**Output (`--output json`)** — curated ack `{action: "replaced", id, name, type, status, version}` on 200; `replaced <id> (state not echoed by region)` on 204. After replace, re-fetch via `get --keywords` to canonically observe state.
 
 ## patch
 
-Use JSON Merge Patch to update only metadata fields. Required fields even on patch: `category`, `name`, `original_file_name`. Other fields use nullable semantics: omit to leave unchanged, send `null` to clear.
-
-Create a patch file `dict-patch.json`:
-
-```json
-{
-  "category": "Confidential",
-  "name": "project-codenames-v2",
-  "original_file_name": "codenames.txt",
-  "description": null
-}
-```
-
-Then invoke patch:
+JSON Merge Patch. Required fields even on patch: `category`, `name`, `original_file_name` — include via `--set` whenever patching anything else. `--set/--clear` values are coerced (numbers, booleans, `null`, JSON literals); quote to force strings: `--set count='"5"'`.
 
 ```bash
-airs runtime dlp dictionaries patch 6901... --body-file dict-patch.json
+# Rename and clear description
+airs runtime dlp dictionaries patch 6901... \
+  --set name='"project-codenames-v2"' \
+  --set category='"Confidential"' \
+  --set original_file_name='"codenames.txt"' \
+  --clear description \
+  --output json
+
+# Or via --body-file for arbitrary metadata
 airs runtime dlp dictionaries patch 6901... --body-file dict-patch.json --output json
 ```
 
-**Output** — patched dictionary with `description` cleared (omitted from response) and the new name persisted. Keywords are not affected by PATCH — use REPLACE to change the keyword file.
+`--body-file` is mutually exclusive with `--set/--clear`. Keywords are not affected by PATCH — use REPLACE to change the keyword file.
+
+**Output (`--output json`)** — curated ack `{action: "patched", id, name, type, status, version}`.
 
 ## delete
 

--- a/docs/runtime/dlp/filtering-profiles.md
+++ b/docs/runtime/dlp/filtering-profiles.md
@@ -24,64 +24,28 @@ airs runtime dlp filtering-profiles list --page 0 --size 20
 airs runtime dlp filtering-profiles list --sort name,asc --output json
 ```
 
-**Output** — Spring `Page<>` envelope, sample with one entry (`file_type` truncated; `totalElements`/`totalPages` are emitted as `null` by this endpoint):
+**Output (`--output json`)** — curated `{items, page}` projection:
 
 ```json
 {
-  "content": [
+  "items": [
     {
       "id": "6a10...",
       "name": "asdfafdsadsa",
-      "description": null,
-      "tenant_id": "<TENANT_ID>",
       "type": "custom",
-      "data_profile_id": 1234567890,
       "direction": "c2s",
-      "file_based": true,
-      "non_file_based": false,
-      "log_severity": "low",
-      "scan_type": "include",
-      "is_end_user_coaching_enabled": null,
-      "is_granular_profile": false,
-      "is_parent_managed": false,
-      "euc_template_id": null,
-      "version": 1,
-      "file_type": ["csv", "doc", "docx", "pdf", "txt-upload", "xlsx", "7z"],
-      "audit_metadata": {
-        "created_at": 1779473698140,
-        "created_by": null,
-        "updated_at": 1779473698140,
-        "updated_by": "Strata Cloud Manager"
-      },
-      "criteria_details": [],
-      "exception_rules": [],
-      "exclusions": {
-        "app_exclusion_list": [],
-        "url_exclusion_list": [],
-        "exclusion_list": {}
-      },
-      "rule1": {
-        "action": "alert",
-        "response_page": "This file has dlp issues",
-        "show_rsp_page": "no"
-      },
-      "rule2": null
+      "severity": "low",
+      "version": 1
     }
   ],
-  "pageable": { "page_number": 0, "page_size": 25, "offset": 0, "paged": true, "unpaged": false },
-  "first": true,
-  "last": false,
-  "size": 25,
-  "number": 0,
-  "number_of_elements": 25,
-  "empty": false,
-  "totalElements": null,
-  "totalPages": null
+  "page": { "number": 0, "size": 25, "total": null, "returned": 1 }
 }
 ```
 
+Use `get <id>` for the full nested fields (`file_type`, `criteria_details`, `exception_rules`, `exclusions`, `rule1`, `rule2`, `audit_metadata`).
+
 !!! note "Nullable fields"
-    The DLP API returns `null` for several fields on real tenants — including `description`, `rule2`, `audit_metadata.created_by`, and `is_end_user_coaching_enabled`. Make sure your downstream parsing accepts these. (CLI requires `@cdot65/prisma-airs-sdk@^0.9.2` or newer for full nullable coverage.)
+    Underlying API responses return `null` for several fields on real tenants — including `description`, `rule2`, `audit_metadata.created_by`, and `is_end_user_coaching_enabled`. CLI requires `@cdot65/prisma-airs-sdk@^0.9.2` or newer.
 
 ## get
 
@@ -132,11 +96,40 @@ airs runtime dlp filtering-profiles get 6a10... --output json
 
 ## replace
 
-Perform a full PUT to update a filtering profile. All fields in the request body are treated as the complete desired state — existing fields not re-sent will be cleared.
+Full PUT. `--file-based` and `--non-file-based` are required (both booleans); everything else is optional flat-field flags. For nested `exception_rules` or `exclusions`, use `--body-file`.
 
-Create a file `dfp-update.json`:
+```bash
+airs runtime dlp filtering-profiles replace 6a10... \
+  --file-based --non-file-based \
+  --description "Updated HR data filtering" \
+  --direction UPLOAD \
+  --log-severity CRITICAL \
+  --data-profile-id 1234567890 \
+  --file-type csv --file-type pdf --file-type docx \
+  --output json
+```
 
-```json
+Flag reference:
+
+| Flag | Notes |
+|------|-------|
+| `--file-based` / `--non-file-based` | **Required** booleans |
+| `--description <s>` | Optional |
+| `--direction <s>` | `BOTH`, `UPLOAD`, `DOWNLOAD` |
+| `--log-severity <s>` | `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFORMATIONAL` |
+| `--scan-type <s>` | `include`, `exclude` |
+| `--data-profile-id <n>` | Numeric profile ID to link |
+| `--euc-template-id <s>` | EUC template ID |
+| `--end-user-coaching` | Enable EUC |
+| `--granular` | Mark as granular profile |
+| `--file-type <s>` | Repeatable |
+
+### Escape hatch — `--body-file` for nested rules
+
+For `exception_rules`, `exclusions`, or other nested fields:
+
+```bash
+cat > dfp-update.json <<'EOF'
 {
   "file_based": true,
   "non_file_based": true,
@@ -145,27 +138,17 @@ Create a file `dfp-update.json`:
   "log_severity": "CRITICAL",
   "data_profile_id": 1234567890,
   "exception_rules": [
-    {
-      "action": "BLOCK",
+    { "action": "BLOCK",
       "log_severity": "CRITICAL",
       "data_profile_ids": [1234567890],
-      "source_attributes": {
-        "match_any": false,
-        "user_group_ids": ["legal-review"]
-      }
-    }
+      "source_attributes": { "match_any": false, "user_group_ids": ["legal-review"] } }
   ]
 }
-```
-
-Then invoke replace:
-
-```bash
-airs runtime dlp filtering-profiles replace 6a10... --body-file dfp-update.json
+EOF
 airs runtime dlp filtering-profiles replace 6a10... --body-file dfp-update.json --output json
 ```
 
-**Output** — updated profile with incremented version and refreshed audit metadata.
+**Output (`--output json`)** — curated ack `{action: "replaced", id, name, type, status, version}`.
 
 ## Tips
 

--- a/docs/runtime/dlp/filtering-profiles.md
+++ b/docs/runtime/dlp/filtering-profiles.md
@@ -38,7 +38,7 @@ airs runtime dlp filtering-profiles list --sort name,asc --output json
       "version": 1
     }
   ],
-  "page": { "number": 0, "size": 25, "total": null, "returned": 1 }
+  "page": { "number": 0, "size": 25, "total": 29, "returned": 1 }
 }
 ```
 

--- a/docs/runtime/dlp/patterns.md
+++ b/docs/runtime/dlp/patterns.md
@@ -48,7 +48,7 @@ airs runtime dlp patterns list --page 0 --size 50 --sort name,asc --output json
       "version": 1
     }
   ],
-  "page": { "number": 0, "size": 25, "total": null, "returned": 2 }
+  "page": { "number": 0, "size": 25, "total": 1123, "returned": 2 }
 }
 ```
 

--- a/docs/runtime/dlp/patterns.md
+++ b/docs/runtime/dlp/patterns.md
@@ -26,115 +26,96 @@ airs runtime dlp patterns list
 airs runtime dlp patterns list --page 0 --size 50 --sort name,asc --output json
 ```
 
-**Output** — Spring `Page<>` envelope; example showing both `custom` and `predefined` entries (`totalElements`/`totalPages` are emitted as `null` by this endpoint):
+**Output (`--output json`)** — curated `{items, page}` projection (not the raw SDK envelope):
 
 ```json
 {
-  "content": [
+  "items": [
     {
       "id": "6990...",
       "name": "IPv4",
-      "description": "Just a simple test",
-      "tenant_id": "<TENANT_ID>",
       "type": "custom",
       "status": "active",
-      "license_type": "standard",
-      "is_parent_managed": false,
-      "version": 1,
-      "detection_config": {
-        "technique": "regex",
-        "supported_confidence_levels": ["high", "low"]
-      },
-      "matching_rules": {
-        "delimiter": ";",
-        "proximity_distance": 200,
-        "proximity_keywords": null,
-        "regexes": [
-          {
-            "regex": "\\b(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)(?:\\.(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)){3}\\b",
-            "weight": 1
-          }
-        ],
-        "metadata_criteria": null
-      },
-      "tags": { "classification": ["pab"] },
-      "audit_metadata": {
-        "created_at": 1771088671081,
-        "created_by": "Strata Cloud Manager",
-        "updated_at": 1771088671081,
-        "updated_by": "Strata Cloud Manager"
-      }
+      "technique": "regex",
+      "version": 1
     },
     {
       "id": "6900...",
       "name": "Passport - Australia",
       "type": "predefined",
       "status": "disabled",
-      "license_type": "standard",
-      "version": 1,
-      "detection_config": { "technique": "regex", "supported_confidence_levels": ["high"] },
-      "matching_rules": {
-        "delimiter": null,
-        "proximity_keywords": ["passport", "passport no"],
-        "regexes": [{ "regex": "...", "weight": 1 }],
-        "metadata_criteria": null
-      }
+      "technique": "regex",
+      "version": 1
     }
   ],
-  "pageable": { "page_number": 0, "page_size": 25, "offset": 0, "paged": true, "unpaged": false },
-  "first": true,
-  "last": false,
-  "size": 25,
-  "number": 0,
-  "number_of_elements": 25,
-  "empty": false,
-  "totalElements": null,
-  "totalPages": null
+  "page": { "number": 0, "size": 25, "total": null, "returned": 2 }
 }
 ```
 
+`pretty` and `table` formats render columns ID, Name, Type, Status, Technique, Version. Use `get <id>` for full nested fields (`detection_config`, `matching_rules`, `tags`, `audit_metadata`).
+
 !!! note "Nullable fields"
-    Real responses include several `null` values on `matching_rules` nested fields — `delimiter`, `proximity_keywords`, `regexes`, `metadata_criteria` are each independently nullable depending on the detection technique. CLI requires `@cdot65/prisma-airs-sdk@^0.9.2` or newer to parse this surface; older SDK pins fail Zod validation.
+    Underlying API responses include `null` values on `matching_rules` nested fields — `delimiter`, `proximity_keywords`, `regexes`, `metadata_criteria` are each independently nullable depending on the detection technique. CLI requires `@cdot65/prisma-airs-sdk@^0.9.2` or newer to parse this surface; older SDK pins fail Zod validation.
 
 ## create
 
-Create a new data pattern. Required fields: `name`, `type`, `detection_config`.
+Create a new data pattern using structured CLI flags (`--name` is the only required flag; `--type` defaults to `custom`, `--technique` defaults to `regex`):
 
-Create a file `pattern.json`:
+```bash
+airs runtime dlp patterns create \
+  --name "cc-numbers-weighted" \
+  --description "Credit-card numbers, weighted by proximity to card-related keywords" \
+  --technique weighted_regex \
+  --confidence-levels "low,medium,high" \
+  --proximity-distance 30 \
+  --proximity-keyword card --proximity-keyword credit \
+  --proximity-keyword visa --proximity-keyword mastercard --proximity-keyword amex \
+  --weighted-regex "\\b\\d{16}\\b|1.0" \
+  --weighted-regex "\\b\\d{15}\\b|0.8" \
+  --tag "classification=PCI" \
+  --tag "compliance=PCI-DSS-3.2.1" \
+  --tag "geography=US,EU" \
+  --output json
+```
+
+Flag reference:
+
+| Flag | Notes |
+|------|-------|
+| `--name <s>` | Required (unless `--body-file`) |
+| `--type <s>` | `predefined`, `custom`, `file_property` (default `custom`) |
+| `--description <s>` | Optional |
+| `--technique <s>` | Detection technique (default `regex`) |
+| `--confidence-levels <csv>` | e.g. `high,low` |
+| `--regex <pattern>` | Repeatable, weight=1 |
+| `--weighted-regex <PATTERN\|N>` | Repeatable; splits on LAST `\|` so the pattern may contain pipes |
+| `--delimiter <s>` | For proximity matching |
+| `--proximity-distance <n>` | 2..1000 |
+| `--proximity-keyword <s>` | Repeatable |
+| `--tag <k=v>` | Repeatable; value may be CSV (`classification=pab,endpoint`) |
+
+**Output (`--output json`)** — curated ack:
 
 ```json
 {
+  "action": "created",
+  "id": "6a12...",
   "name": "cc-numbers-weighted",
   "type": "custom",
-  "description": "Credit-card numbers, weighted by proximity to card-related keywords",
-  "detection_config": {
-    "technique": "weighted_regex",
-    "supported_confidence_levels": ["low", "medium", "high"]
-  },
-  "matching_rules": {
-    "proximity_distance": 30,
-    "proximity_keywords": ["card", "credit", "visa", "mastercard", "amex"],
-    "regexes": [
-      { "regex": "\\b\\d{16}\\b", "weight": 1.0 },
-      { "regex": "\\b\\d{15}\\b", "weight": 0.8 }
-    ]
-  },
-  "tags": {
-    "classification": ["PCI"],
-    "compliance": ["PCI-DSS-3.2.1"],
-    "geography": ["US", "EU"]
-  }
+  "status": "active",
+  "version": 1
 }
 ```
 
-Then invoke create:
+### Escape hatch — `--body-file`
+
+For shapes the flags don't cover (e.g. unusual `metadata_criteria` on `matching_rules`), pass a JSON file:
 
 ```bash
-airs runtime dlp patterns create --body-file pattern.json
 airs runtime dlp patterns create --body-file pattern.json --output json
 ```
 
-**Output** — created pattern with server-assigned `id`, `status: 'active'`, `version: 1`, and `audit_metadata`.
+Body shape matches the API request — `{ name, type, detection_config, matching_rules, tags }`.
 
 ## get
 
@@ -152,79 +133,46 @@ airs runtime dlp patterns get 6990... --output json
 
 ## replace
 
-Perform a full PUT to update a pattern. The entire body is treated as the desired state.
-
-Create a file `pattern-update.json` with all required fields plus any changes:
-
-```json
-{
-  "name": "cc-numbers-weighted",
-  "type": "custom",
-  "detection_config": {
-    "technique": "weighted_regex",
-    "supported_confidence_levels": ["low", "medium", "high"]
-  },
-  "matching_rules": {
-    "proximity_distance": 30,
-    "proximity_keywords": ["card", "credit", "visa", "mastercard", "amex"],
-    "regexes": [
-      { "regex": "\\b\\d{16}\\b", "weight": 1.0 },
-      { "regex": "\\b\\d{15}\\b", "weight": 0.8 },
-      { "regex": "\\b\\d{13}\\b", "weight": 0.6 }
-    ]
-  },
-  "tags": {
-    "classification": ["PCI"],
-    "compliance": ["PCI-DSS-3.2.1"],
-    "geography": ["US", "EU"]
-  }
-}
-```
-
-Then invoke replace:
+Full PUT — the entire body becomes the desired state. Uses the same `writeFlags` as `create`:
 
 ```bash
-airs runtime dlp patterns replace 6990... --body-file pattern-update.json
-airs runtime dlp patterns replace 6990... --body-file pattern-update.json --output json
+airs runtime dlp patterns replace 6990... \
+  --name "cc-numbers-weighted" \
+  --technique weighted_regex \
+  --confidence-levels "low,medium,high" \
+  --proximity-distance 30 \
+  --proximity-keyword card --proximity-keyword credit \
+  --weighted-regex "\\b\\d{16}\\b|1.0" \
+  --weighted-regex "\\b\\d{15}\\b|0.8" \
+  --weighted-regex "\\b\\d{13}\\b|0.6" \
+  --tag "classification=PCI" \
+  --output json
 ```
 
-**Output** — updated pattern with incremented version and refreshed `audit_metadata`.
+`--body-file pattern-update.json` is also accepted.
+
+**Output (`--output json`)** — curated ack `{action: "replaced", id, name, type, status, version}` with incremented version.
 
 ## patch
 
-Use JSON Merge Patch to update only specified fields. Required fields even on patch: `name`, `type`, `detection_config`. Other fields use nullable semantics: omit to leave unchanged, send `null` to clear.
+JSON Merge Patch. Use `--set k=v` and `--clear k` for scalar tweaks; `--body-file` for nested fields. Required fields even on patch: `name`, `type`, `detection_config` — include them via `--set` if your patch touches anything else.
 
-Create a file `pattern-patch.json`:
-
-```json
-{
-  "name": "cc-numbers-weighted",
-  "type": "custom",
-  "detection_config": {
-    "technique": "weighted_regex",
-    "supported_confidence_levels": ["low", "medium", "high"]
-  },
-  "matching_rules": {
-    "proximity_distance": 30,
-    "proximity_keywords": ["card", "credit", "visa", "mastercard", "amex"],
-    "regexes": [
-      { "regex": "\\b\\d{16}\\b", "weight": 1.0 },
-      { "regex": "\\b\\d{15}\\b", "weight": 0.8 },
-      { "regex": "\\b\\d{13}\\b", "weight": 0.6 }
-    ]
-  },
-  "description": null
-}
-```
-
-Then invoke patch:
+`--set/--clear` values are coerced: numbers stay numeric, `true`/`false` become booleans, `null` clears, and JSON literals parse. To force a string that looks numeric, quote: `--set count='"5"'`.
 
 ```bash
-airs runtime dlp patterns patch 6990... --body-file pattern-patch.json
+# Scalar tweaks
+airs runtime dlp patterns patch 6990... \
+  --set name='"cc-numbers-weighted"' \
+  --set type='"custom"' \
+  --clear description
+
+# Nested fields via JSON file
 airs runtime dlp patterns patch 6990... --body-file pattern-patch.json --output json
 ```
 
-**Output** — patched pattern with `description` cleared (omitted from response) and the third regex persisted.
+`--body-file` is mutually exclusive with `--set/--clear`.
+
+**Output (`--output json`)** — curated ack `{action: "patched", id, name, type, status, version}`.
 
 ## delete
 

--- a/docs/runtime/dlp/profiles.md
+++ b/docs/runtime/dlp/profiles.md
@@ -25,170 +25,117 @@ airs runtime dlp profiles list
 airs runtime dlp profiles list --page 0 --size 50 --sort name,asc --output json
 ```
 
-**Output** — Spring `Page<>` envelope; example showing a `multi_profile` entry (server returns the composed pattern set echoed in `advance_data_patterns_rule_request`):
+**Output (`--output json`)** — curated `{items, page}` projection:
 
 ```json
 {
-  "content": [
+  "items": [
     {
       "id": "1234567890",
       "name": "EU-Regulated (umbrella)",
-      "description": null,
-      "tenant_id": "<TENANT_ID>",
       "type": "custom",
-      "profile_status": "active",
       "profile_type": "advanced",
-      "is_granular_data_profile": false,
-      "is_parent_managed": false,
-      "version": 1,
-      "advance_data_patterns_rule_request": [
-        "(... server-rendered detection expression, truncated ...)"
-      ],
-      "detection_rules": [
-        {
-          "rule_type": "multi_profile",
-          "multi_profile": {
-            "data_profile_ids": [1234567891, 1234567892, 1234567893],
-            "operator_type": "or"
-          }
-        }
-      ],
-      "audit_metadata": {
-        "created_at": 1779473698140,
-        "created_by": "Strata Cloud Manager",
-        "updated_at": 1779473698140,
-        "updated_by": "Strata Cloud Manager"
-      }
+      "status": "active",
+      "version": 1
     }
   ],
-  "pageable": { "page_number": 0, "page_size": 25, "offset": 0, "paged": true, "unpaged": false },
-  "first": true,
-  "last": false,
-  "size": 25,
-  "number": 0,
-  "number_of_elements": 25,
-  "empty": false,
-  "totalElements": null,
-  "totalPages": null
+  "page": { "number": 0, "size": 25, "total": null, "returned": 1 }
 }
 ```
 
-Example `expression_tree` entry (truncated to one leaf for brevity — real responses nest several layers of `sub_expressions`):
-
-```json
-{
-  "id": "1234567890",
-  "name": "InfoSec - Code Assistant - Strict",
-  "profile_type": "advanced",
-  "version": 5,
-  "detection_rules": [
-    {
-      "rule_type": "expression_tree",
-      "expression_tree": {
-        "operator_type": "or",
-        "rule_item": null,
-        "sub_expressions": [
-          {
-            "operator_type": null,
-            "rule_item": {
-              "detection_technique": "regex",
-              "id": "6900...",
-              "name": "Bank - ABA Routing Number",
-              "version": 1,
-              "by_unique_count": false,
-              "confidence_level": "low",
-              "supported_confidence_levels": ["high", "low"],
-              "occurrence_operator_type": "any"
-            },
-            "sub_expressions": []
-          }
-        ]
-      }
-    }
-  ]
-}
-```
+Use `get <id>` for nested fields (`detection_rules` with `expression_tree` or `multi_profile`, `audit_metadata`, server-rendered `advance_data_patterns_rule_request`).
 
 !!! note "Nullable fields"
-    The `expression_tree` is recursive and many nodes legitimately carry `null` values — particularly `operator_type`, `rule_item`, and (at intermediate nodes) `sub_expressions` slots. CLI requires `@cdot65/prisma-airs-sdk@^0.9.2` or newer to parse this surface; older SDK pins fail Zod validation on real responses.
+    Underlying API `expression_tree` responses are recursive — many nodes carry `null` for `operator_type`, `rule_item`, or `sub_expressions`. CLI requires `@cdot65/prisma-airs-sdk@^0.9.2` or newer to parse them.
 
 ## create
 
-Create a new data profile with `expression_tree` or `multi_profile` rules. Required fields: `name`, `detection_rules`.
+`--name` is required. `--profile-type` defaults to `advanced`. For the common case — a flat boolean of pattern IDs — pass `--pattern-id <id>` repeatedly and (optionally) `--combinator and|or|not|and_not|or_not` (default `or`):
 
-### Example: expression_tree (AND logic)
+```bash
+airs runtime dlp profiles create \
+  --name "High-risk PII (SSN OR CC)" \
+  --description "Fires on SSN or CC pattern leaves" \
+  --pattern-id 6990111aaa \
+  --pattern-id 6990222bbb \
+  --combinator or \
+  --confidence high \
+  --output json
+```
 
-Create a file `profile-expr.json`:
+Flag reference:
+
+| Flag | Notes |
+|------|-------|
+| `--name <s>` | Required (unless `--body-file`) |
+| `--profile-type <s>` | `basic` or `advanced` (default `advanced`) |
+| `--description <s>` | Optional |
+| `--granular` | Mark as granular data profile |
+| `--pattern-id <id>` | Repeatable; each becomes a leaf in `expression_tree.condition_pattern[]` |
+| `--combinator <op>` | `or` (default), `and`, `not`, `and_not`, `or_not` |
+| `--confidence <level>` | Leaf confidence (default `high`) |
+
+**Output (`--output json`)** — curated ack:
 
 ```json
 {
+  "action": "created",
+  "id": "1234567890",
+  "name": "High-risk PII (SSN OR CC)",
+  "type": "custom",
+  "status": "active",
+  "version": 1
+}
+```
+
+### Escape hatch — `--body-file` for complex rules
+
+For nested `expression_tree` (AND-of-ORs etc.) or `multi_profile` composition, pass JSON:
+
+```bash
+# expression_tree with AND of two sub-rules
+cat > profile-expr.json <<'EOF'
+{
   "name": "High-risk PII (SSN AND CC)",
-  "description": "Fires only when both SSN and CC pattern leaves match",
+  "profile_type": "advanced",
   "detection_rules": [
     {
       "rule_type": "expression_tree",
       "expression_tree": {
         "operator_type": "and",
         "sub_expressions": [
-          {
-            "rule_item": {
-              "detection_technique": "regex",
-              "match_type": "include",
-              "confidence_level": "high",
-              "occurrence_operator_type": "more_than_equal_to",
-              "occurrence_count": 1
-            }
-          },
-          {
-            "rule_item": {
-              "detection_technique": "weighted_regex",
-              "match_type": "include",
-              "confidence_level": "high",
-              "occurrence_operator_type": "more_than_equal_to",
-              "occurrence_count": 1
-            }
-          }
+          { "rule_item": { "detection_technique": "regex", "match_type": "include",
+                           "confidence_level": "high",
+                           "occurrence_operator_type": "more_than_equal_to",
+                           "occurrence_count": 1 } },
+          { "rule_item": { "detection_technique": "weighted_regex", "match_type": "include",
+                           "confidence_level": "high",
+                           "occurrence_operator_type": "more_than_equal_to",
+                           "occurrence_count": 1 } }
         ]
       }
     }
   ]
 }
-```
-
-Then invoke create:
-
-```bash
-airs runtime dlp profiles create --body-file profile-expr.json
+EOF
 airs runtime dlp profiles create --body-file profile-expr.json --output json
-```
 
-### Example: multi_profile (OR composition)
-
-Create a file `profile-multi.json`:
-
-```json
+# multi_profile composition
+cat > profile-multi.json <<'EOF'
 {
   "name": "EU-Regulated (umbrella)",
-  "description": "GDPR-PII OR EU-Healthcare",
+  "profile_type": "advanced",
   "detection_rules": [
-    {
-      "rule_type": "multi_profile",
-      "multi_profile": {
-        "operator_type": "or",
-        "data_profile_ids": [1234567891, 1234567892]
-      }
-    }
+    { "rule_type": "multi_profile",
+      "multi_profile": { "operator_type": "or",
+                         "data_profile_ids": [1234567891, 1234567892] } }
   ]
 }
-```
-
-Then invoke create:
-
-```bash
+EOF
 airs runtime dlp profiles create --body-file profile-multi.json --output json
 ```
 
-**Output** — created profile with server-assigned `id`, `profile_status: 'active'`, `version: 1`, and `audit_metadata`. Multi-profile compositions auto-promote `profile_type` to `'advanced'`.
+Multi-profile compositions auto-promote `profile_type` to `advanced`.
 
 ## get
 
@@ -206,83 +153,50 @@ airs runtime dlp profiles get 1234567890 --output json
 
 ## replace
 
-Perform a full PUT to update a profile. The entire body is treated as the desired state.
-
-Create a file `profile-update.json` with all required fields:
-
-```json
-{
-  "name": "High-risk PII (SSN AND CC)",
-  "description": "Updated: requires both SSN and CC with high confidence",
-  "detection_rules": [
-    {
-      "rule_type": "expression_tree",
-      "expression_tree": {
-        "operator_type": "and",
-        "sub_expressions": [
-          {
-            "rule_item": {
-              "detection_technique": "regex",
-              "match_type": "include",
-              "confidence_level": "high",
-              "occurrence_operator_type": "more_than_equal_to",
-              "occurrence_count": 1
-            }
-          },
-          {
-            "rule_item": {
-              "detection_technique": "weighted_regex",
-              "match_type": "include",
-              "confidence_level": "high",
-              "occurrence_operator_type": "more_than_equal_to",
-              "occurrence_count": 2
-            }
-          }
-        ]
-      }
-    }
-  ]
-}
-```
-
-Then invoke replace:
+Full PUT. Same flags as `create`, plus `--body-file` for complex rule trees:
 
 ```bash
-airs runtime dlp profiles replace 1234567890 --body-file profile-update.json
+# Simple flat pattern boolean
+airs runtime dlp profiles replace 1234567890 \
+  --name "High-risk PII (SSN OR CC)" \
+  --pattern-id 6990111aaa --pattern-id 6990222bbb \
+  --combinator or --confidence high \
+  --output json
+
+# Complex tree
 airs runtime dlp profiles replace 1234567890 --body-file profile-update.json --output json
 ```
 
-**Output** — updated profile with incremented version and refreshed `audit_metadata`.
+**Output (`--output json`)** — curated ack `{action: "replaced", id, name, type, status, version}` with incremented version.
 
 ## patch
 
-Use JSON Merge Patch to update only specified fields. Required fields even on patch: `name` and `profile_type`. Other fields use nullable semantics: omit to leave unchanged, send `null` to clear.
-
-Create a file `profile-patch.json`:
-
-```json
-{
-  "name": "High-risk PII (SSN AND CC)",
-  "profile_type": "advanced",
-  "description": "Patched description without touching detection_rules"
-}
-```
-
-Then invoke patch:
+JSON Merge Patch. Required fields even on patch: `name` and `profile_type` — include via `--set` if patching anything else. Use `--set/--clear` for scalars, `--body-file` for nested rules.
 
 ```bash
-airs runtime dlp profiles patch 1234567890 --body-file profile-patch.json
-airs runtime dlp profiles patch 1234567890 --body-file profile-patch.json --output json
+# Patch description without touching detection_rules
+airs runtime dlp profiles patch 1234567890 \
+  --set name='"High-risk PII (SSN AND CC)"' \
+  --set profile_type='"advanced"' \
+  --set description='"Patched description"'
+
+# Soft-delete via profile_status
+airs runtime dlp profiles patch 1234567890 \
+  --set name='"High-risk PII"' \
+  --set profile_type='"advanced"' \
+  --set profile_status='"deleted"'
 ```
 
-**Output** — patched profile with only the specified fields updated; detection rules preserved as-is.
+`--body-file` is mutually exclusive with `--set/--clear`. Values are coerced (numbers, booleans, `null`, JSON literals). Quote to force strings: `--set count='"5"'`.
+
+**Output (`--output json`)** — curated ack `{action: "patched", id, name, type, status, version}`.
 
 ## Tips
 
 - **Expression tree nesting**: Build complex detection logic using `and` / `or` operators with nested `sub_expressions` and leaf `rule_item` nodes. Each leaf carries the detection technique and technique-specific thresholds.
 - **Multi-profile composition**: Use `multi_profile` to combine multiple existing profiles with a single operator (`and` or `or`). The composed profile auto-promotes to `profile_type: 'advanced'` server-side.
 - **Merge Patch semantics**: On PATCH, `name` and `profile_type` are required. Arrays like `detection_rules` are replaced wholesale if sent; omit to preserve. Send `null` to clear optional fields like `description`.
-- **No DELETE**: Profiles cannot be deleted via API. To archive, PATCH with `profile_status: 'deleted'` if the API supports it, or use the Strata Cloud Manager UI.
+- **No DELETE**: Profiles cannot be deleted via API. To archive, PATCH with `--set profile_status='"deleted"'` (must also include `--set name=...` and `--set profile_type=...`), or use the Strata Cloud Manager UI.
 
 ## See also
 

--- a/docs/runtime/dlp/profiles.md
+++ b/docs/runtime/dlp/profiles.md
@@ -39,7 +39,7 @@ airs runtime dlp profiles list --page 0 --size 50 --sort name,asc --output json
       "version": 1
     }
   ],
-  "page": { "number": 0, "size": 25, "total": null, "returned": 1 }
+  "page": { "number": 0, "size": 25, "total": 30, "returned": 1 }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/prisma-airs-cli",
   "packageManager": "pnpm@10.6.5",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/commands/dlp/build-body.ts
+++ b/src/cli/commands/dlp/build-body.ts
@@ -1,0 +1,161 @@
+/**
+ * Body-builders for DLP CLI commands. Each function takes parsed commander opts
+ * and returns a plain object suitable for the SDK request. Validation is light —
+ * Zod in the SDK does the heavy lifting on the wire.
+ */
+
+// biome-ignore lint/suspicious/noExplicitAny: commander opts are loosely typed
+type Opts = Record<string, any>;
+
+function asCsv(v: string | undefined): string[] | undefined {
+  if (!v) return undefined;
+  return v
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function asNum(v: string | undefined): number | undefined {
+  if (v == null) return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function parseTags(values: string[] | undefined): Record<string, string[]> | undefined {
+  if (!values || values.length === 0) return undefined;
+  const out: Record<string, string[]> = {};
+  for (const v of values) {
+    const eq = v.indexOf('=');
+    if (eq < 0) throw new Error(`--tag must be 'key=value' (got '${v}')`);
+    const key = v.slice(0, eq).trim();
+    const val = v.slice(eq + 1).trim();
+    if (!key) throw new Error(`--tag missing key (got '${v}')`);
+    if (!out[key]) out[key] = [];
+    for (const part of val
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)) {
+      out[key].push(part);
+    }
+  }
+  return out;
+}
+
+function parseRegexes(
+  plain: string[] | undefined,
+  weighted: string[] | undefined,
+): { regex: string; weight: number }[] | undefined {
+  const out: { regex: string; weight: number }[] = [];
+  for (const r of plain ?? []) out.push({ regex: r, weight: 1 });
+  for (const r of weighted ?? []) {
+    const pipe = r.lastIndexOf('|');
+    if (pipe < 0) throw new Error(`--weighted-regex must be 'PATTERN|weight' (got '${r}')`);
+    const pattern = r.slice(0, pipe);
+    const weight = Number(r.slice(pipe + 1));
+    if (!Number.isFinite(weight)) throw new Error(`--weighted-regex weight invalid in '${r}'`);
+    out.push({ regex: pattern, weight });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Build a Data Pattern request body from CLI flags.
+ * `requireRequired` enforces name + type (use false for replace where caller already validated).
+ */
+export function buildPatternBody(opts: Opts, requireRequired = true): Record<string, unknown> {
+  if (requireRequired) {
+    if (!opts.name) throw new Error('--name is required');
+  }
+  const technique = opts.technique ?? 'regex';
+  const confidence = asCsv(opts.confidenceLevels);
+  const regexes = parseRegexes(opts.regex, opts.weightedRegex);
+  const tags = parseTags(opts.tag);
+
+  const detectionConfig: Record<string, unknown> = { technique };
+  if (confidence) detectionConfig.supported_confidence_levels = confidence;
+
+  const matchingRules: Record<string, unknown> = {};
+  if (opts.delimiter != null) matchingRules.delimiter = opts.delimiter;
+  if (opts.proximityDistance != null)
+    matchingRules.proximity_distance = asNum(opts.proximityDistance);
+  if (opts.proximityKeyword?.length) matchingRules.proximity_keywords = opts.proximityKeyword;
+  if (regexes) matchingRules.regexes = regexes;
+
+  const body: Record<string, unknown> = {
+    name: opts.name,
+    type: opts.type ?? 'custom',
+    detection_config: detectionConfig,
+  };
+  if (opts.description != null) body.description = opts.description;
+  if (Object.keys(matchingRules).length > 0) body.matching_rules = matchingRules;
+  if (tags) body.tags = tags;
+  return body;
+}
+
+/**
+ * Build a Data Filtering Profile request body from CLI flags.
+ * Required: --file-based, --non-file-based (booleans).
+ */
+export function buildFilteringProfileBody(opts: Opts): Record<string, unknown> {
+  if (opts.fileBased == null || opts.nonFileBased == null) {
+    throw new Error('--file-based and --non-file-based are both required');
+  }
+  const body: Record<string, unknown> = {
+    file_based: !!opts.fileBased,
+    non_file_based: !!opts.nonFileBased,
+  };
+  if (opts.description != null) body.description = opts.description;
+  if (opts.direction != null) body.direction = opts.direction;
+  if (opts.logSeverity != null) body.log_severity = opts.logSeverity;
+  if (opts.scanType != null) body.scan_type = opts.scanType;
+  if (opts.dataProfileId != null) body.data_profile_id = asNum(opts.dataProfileId);
+  if (opts.eucTemplateId != null) body.euc_template_id = opts.eucTemplateId;
+  if (opts.endUserCoaching != null) body.is_end_user_coaching_enabled = !!opts.endUserCoaching;
+  if (opts.granular != null) body.is_granular_profile = !!opts.granular;
+  if (opts.fileType?.length) body.file_type = opts.fileType;
+  return body;
+}
+
+/**
+ * Build a Data Profile request body. Supports the simple case: a single
+ * expression_tree rule that ORs (or ANDs) named pattern IDs. Complex rule
+ * trees fall back to --body-file.
+ */
+export function buildProfileBody(opts: Opts): Record<string, unknown> {
+  if (!opts.name) throw new Error('--name is required');
+  const profileType = opts.profileType ?? 'advanced';
+  const body: Record<string, unknown> = {
+    name: opts.name,
+    profile_type: profileType,
+  };
+  if (opts.description != null) body.description = opts.description;
+  if (opts.granular != null) body.is_granular_data_profile = !!opts.granular;
+  if (opts.patternId?.length) {
+    const op = (opts.combinator ?? 'or').toLowerCase();
+    if (!['and', 'or', 'not', 'and_not', 'or_not'].includes(op)) {
+      throw new Error(`--combinator must be one of and|or|not|and_not|or_not (got '${op}')`);
+    }
+    body.detection_rules = [
+      {
+        rule_type: 'expression_tree',
+        expression_tree: {
+          operator_type: op,
+          condition_pattern: opts.patternId.map((id: string) => ({
+            data_pattern_id: id,
+            confidence_level: opts.confidence ?? 'high',
+            occurrence_operator_type: 'any',
+            occurrence_count: 1,
+          })),
+        },
+      },
+    ];
+  }
+  return body;
+}
+
+/**
+ * Collect repeatable options. Use as the commander parser function.
+ */
+export function repeatable(value: string, prev: string[] = []): string[] {
+  return [...prev, value];
+}

--- a/src/cli/commands/dlp/dictionaries.ts
+++ b/src/cli/commands/dlp/dictionaries.ts
@@ -65,6 +65,7 @@ export function register(dlp: Command): void {
     .option('--file <path>', 'Keyword file')
     .option('--metadata-file <path>', 'JSON metadata file (overrides --name/--category/...)')
     .option('--include-keywords', 'Include keywords in response')
+    .option('--output <fmt>', 'Output format', 'pretty')
     .action(async (opts) => {
       try {
         const metadata = await buildMetadata(opts);
@@ -75,7 +76,7 @@ export function register(dlp: Command): void {
           file,
           includeKeywords: opts.includeKeywords,
         });
-        dlpDictionaries.renderCreated(r, 'pretty');
+        dlpDictionaries.renderCreated(r, opts.output as OutputFormat);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(2);

--- a/src/cli/commands/dlp/filtering-profiles.ts
+++ b/src/cli/commands/dlp/filtering-profiles.ts
@@ -1,17 +1,24 @@
 import type { Command } from 'commander';
 import { SdkDataFilteringProfilesService } from '../../../airs/dlp/data-filtering-profiles.js';
 import { dlpFilteringProfiles, type OutputFormat, renderError } from '../../renderer/index.js';
+import { buildFilteringProfileBody, repeatable } from './build-body.js';
 import { parseBody } from './patch.js';
 
 function listFlags<T extends Command>(cmd: T): T {
   return cmd
     .option('--page <n>', 'Zero-indexed page number', (v) => Number.parseInt(v, 10))
     .option('--size <n>', 'Page size', (v) => Number.parseInt(v, 10))
-    .option('--sort <field,dir>', 'Sort criteria (repeatable)', (v, prev: string[] = []) => [
-      ...prev,
-      v,
-    ])
+    .option('--sort <field,dir>', 'Sort criteria (repeatable)', repeatable)
     .option('--output <fmt>', 'Output format', 'pretty');
+}
+
+async function resolveReplaceBody(opts: Record<string, unknown>): Promise<unknown> {
+  if (opts.body || opts.bodyFile) {
+    const body = await parseBody({ body: opts.body as string, bodyFile: opts.bodyFile as string });
+    if (!body) throw new Error('--body or --body-file was empty');
+    return body;
+  }
+  return buildFilteringProfileBody(opts);
 }
 
 export function register(dlp: Command): void {
@@ -50,16 +57,26 @@ export function register(dlp: Command): void {
   group
     .command('replace <id>')
     .description('Full-replace a filtering profile (PUT)')
-    .option('--body <json|->', 'JSON body (or "-" for stdin)')
-    .option('--body-file <path>', 'Path to JSON body file')
+    .option('--file-based', 'Apply to file-based scans (boolean)')
+    .option('--non-file-based', 'Apply to non-file-based scans (boolean)')
+    .option('--description <s>', 'Description')
+    .option('--direction <s>', 'Direction: BOTH|UPLOAD|DOWNLOAD')
+    .option('--log-severity <s>', 'Severity: CRITICAL|HIGH|MEDIUM|LOW|INFORMATIONAL')
+    .option('--scan-type <s>', 'Scan type: include|exclude')
+    .option('--data-profile-id <n>', 'Data profile ID', (v) => Number(v))
+    .option('--euc-template-id <s>', 'EUC template ID')
+    .option('--end-user-coaching', 'Enable end-user coaching')
+    .option('--granular', 'Granular profile')
+    .option('--file-type <s>', 'File type (repeatable)', repeatable)
+    .option('--body <json|->', 'Raw JSON body (escape hatch; or "-" for stdin)')
+    .option('--body-file <path>', 'Raw JSON body file (escape hatch)')
     .option('--output <fmt>', 'Output format', 'pretty')
     .action(async (id, opts) => {
       try {
-        const body = await parseBody({ body: opts.body, bodyFile: opts.bodyFile });
-        if (!body) throw new Error('--body or --body-file is required');
+        const body = await resolveReplaceBody(opts);
         const svc = new SdkDataFilteringProfilesService();
         dlpFilteringProfiles.renderReplaced(
-          // biome-ignore lint/suspicious/noExplicitAny: parseBody returns unknown, cast for replace()
+          // biome-ignore lint/suspicious/noExplicitAny: body shape verified by SDK Zod
           await svc.replace(id, body as any),
           opts.output as OutputFormat,
         );

--- a/src/cli/commands/dlp/patterns.ts
+++ b/src/cli/commands/dlp/patterns.ts
@@ -1,17 +1,42 @@
 import type { Command } from 'commander';
 import { SdkDataPatternsService } from '../../../airs/dlp/data-patterns.js';
 import { dlpPatterns, type OutputFormat, renderError } from '../../renderer/index.js';
+import { buildPatternBody, repeatable } from './build-body.js';
 import { buildMergePatch, parseBody } from './patch.js';
 
 function listFlags<T extends Command>(cmd: T): T {
   return cmd
     .option('--page <n>', 'Zero-indexed page number', (v) => Number.parseInt(v, 10))
     .option('--size <n>', 'Page size', (v) => Number.parseInt(v, 10))
-    .option('--sort <field,dir>', 'Sort criteria (repeatable)', (v, prev: string[] = []) => [
-      ...prev,
-      v,
-    ])
+    .option('--sort <field,dir>', 'Sort criteria (repeatable)', repeatable)
     .option('--output <fmt>', 'Output format', 'pretty');
+}
+
+function writeFlags<T extends Command>(cmd: T): T {
+  return cmd
+    .option('--name <s>', 'Pattern name (required unless --body-file)')
+    .option('--type <s>', 'Pattern type: predefined|custom|file_property (default: custom)')
+    .option('--description <s>', 'Pattern description')
+    .option('--technique <s>', 'Detection technique (default: regex)')
+    .option('--confidence-levels <csv>', 'Confidence levels CSV: e.g. high,low')
+    .option('--regex <pattern>', 'Regex with weight=1 (repeatable)', repeatable)
+    .option('--weighted-regex <PATTERN|N>', 'Regex with explicit weight (repeatable)', repeatable)
+    .option('--delimiter <s>', 'Delimiter for proximity matching')
+    .option('--proximity-distance <n>', 'Proximity window (2..1000)')
+    .option('--proximity-keyword <s>', 'Proximity keyword (repeatable)', repeatable)
+    .option('--tag <k=v>', 'Tag (repeatable, value can be CSV)', repeatable)
+    .option('--body <json|->', 'Raw JSON body (escape hatch; or "-" for stdin)')
+    .option('--body-file <path>', 'Raw JSON body file (escape hatch)')
+    .option('--output <fmt>', 'Output format', 'pretty');
+}
+
+async function resolveWriteBody(opts: Record<string, unknown>): Promise<unknown> {
+  if (opts.body || opts.bodyFile) {
+    const body = await parseBody({ body: opts.body as string, bodyFile: opts.bodyFile as string });
+    if (!body) throw new Error('--body or --body-file was empty');
+    return body;
+  }
+  return buildPatternBody(opts);
 }
 
 export function register(dlp: Command): void {
@@ -30,27 +55,19 @@ export function register(dlp: Command): void {
     }
   });
 
-  group
-    .command('create')
-    .description('Create a data pattern')
-    .option('--body <json|->', 'JSON body (or "-" for stdin)')
-    .option('--body-file <path>', 'Path to JSON body file')
-    .option('--output <fmt>', 'Output format', 'pretty')
-    .action(async (opts) => {
-      try {
-        const body = await parseBody({ body: opts.body, bodyFile: opts.bodyFile });
-        if (!body) throw new Error('--body or --body-file is required');
-        const svc = new SdkDataPatternsService();
-        dlpPatterns.renderCreated(
-          // biome-ignore lint/suspicious/noExplicitAny: parseBody returns unknown, cast for create()
-          await svc.create(body as any),
-          opts.output as OutputFormat,
-        );
-      } catch (err) {
-        renderError(err instanceof Error ? err.message : String(err));
-        process.exit(2);
-      }
-    });
+  writeFlags(group.command('create').description('Create a data pattern')).action(async (opts) => {
+    try {
+      const body = await resolveWriteBody(opts);
+      dlpPatterns.renderCreated(
+        // biome-ignore lint/suspicious/noExplicitAny: body shape verified by SDK Zod
+        await new SdkDataPatternsService().create(body as any),
+        opts.output as OutputFormat,
+      );
+    } catch (err) {
+      renderError(err instanceof Error ? err.message : String(err));
+      process.exit(2);
+    }
+  });
 
   group
     .command('get <id>')
@@ -68,18 +85,12 @@ export function register(dlp: Command): void {
       }
     });
 
-  group
-    .command('replace <id>')
-    .description('Full-replace a data pattern (PUT)')
-    .option('--body <json|->', 'JSON body (or "-" for stdin)')
-    .option('--body-file <path>', 'Path to JSON body file')
-    .option('--output <fmt>', 'Output format', 'pretty')
-    .action(async (id, opts) => {
+  writeFlags(group.command('replace <id>').description('Full-replace a data pattern (PUT)')).action(
+    async (id, opts) => {
       try {
-        const body = await parseBody({ body: opts.body, bodyFile: opts.bodyFile });
-        if (!body) throw new Error('--body or --body-file is required');
+        const body = await resolveWriteBody(opts);
         dlpPatterns.renderReplaced(
-          // biome-ignore lint/suspicious/noExplicitAny: parseBody returns unknown, cast for replace()
+          // biome-ignore lint/suspicious/noExplicitAny: body shape verified by SDK Zod
           await new SdkDataPatternsService().replace(id, body as any),
           opts.output as OutputFormat,
         );
@@ -87,7 +98,8 @@ export function register(dlp: Command): void {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(2);
       }
-    });
+    },
+  );
 
   group
     .command('patch <id>')
@@ -97,12 +109,8 @@ export function register(dlp: Command): void {
         'To force a string, quote: --set count=\'"5"\'.',
     )
     .option('--body-file <path>', 'JSON merge-patch body file')
-    .option('--set <k=v...>', 'Set scalar field (repeatable)', (v, p: string[] = []) => [...p, v])
-    .option(
-      '--clear <key...>',
-      'Clear field via merge-patch null (repeatable)',
-      (v, p: string[] = []) => [...p, v],
-    )
+    .option('--set <k=v...>', 'Set scalar field (repeatable)', repeatable)
+    .option('--clear <key...>', 'Clear field via merge-patch null (repeatable)', repeatable)
     .option('--output <fmt>', 'Output format', 'pretty')
     .action(async (id, opts) => {
       try {

--- a/src/cli/commands/dlp/profiles.ts
+++ b/src/cli/commands/dlp/profiles.ts
@@ -1,17 +1,48 @@
 import type { Command } from 'commander';
 import { SdkDataProfilesService } from '../../../airs/dlp/data-profiles.js';
 import { dlpProfiles, type OutputFormat, renderError } from '../../renderer/index.js';
+import { buildProfileBody, repeatable } from './build-body.js';
 import { buildMergePatch, parseBody } from './patch.js';
 
 function listFlags<T extends Command>(cmd: T): T {
   return cmd
     .option('--page <n>', 'Zero-indexed page number', (v) => Number.parseInt(v, 10))
     .option('--size <n>', 'Page size', (v) => Number.parseInt(v, 10))
-    .option('--sort <field,dir>', 'Sort criteria (repeatable)', (v, prev: string[] = []) => [
-      ...prev,
-      v,
-    ])
+    .option('--sort <field,dir>', 'Sort criteria (repeatable)', repeatable)
     .option('--output <fmt>', 'Output format', 'pretty');
+}
+
+function writeFlags<T extends Command>(cmd: T): T {
+  return cmd
+    .option('--name <s>', 'Profile name (required unless --body-file)')
+    .option('--profile-type <s>', 'Profile type: basic|advanced (default: advanced)')
+    .option('--description <s>', 'Description')
+    .option('--granular', 'Granular data profile')
+    .option(
+      '--pattern-id <id>',
+      'Data pattern ID to include (repeatable). Builds a simple expression_tree.',
+      repeatable,
+    )
+    .option(
+      '--combinator <op>',
+      'Combinator for --pattern-id: or|and|not|and_not|or_not (default: or)',
+    )
+    .option('--confidence <level>', 'Confidence level for --pattern-id leaves (default: high)')
+    .option('--body <json|->', 'Raw JSON body (escape hatch; or "-" for stdin)')
+    .option(
+      '--body-file <path>',
+      'Raw JSON body file (escape hatch; required for complex rule trees)',
+    )
+    .option('--output <fmt>', 'Output format', 'pretty');
+}
+
+async function resolveWriteBody(opts: Record<string, unknown>): Promise<unknown> {
+  if (opts.body || opts.bodyFile) {
+    const body = await parseBody({ body: opts.body as string, bodyFile: opts.bodyFile as string });
+    if (!body) throw new Error('--body or --body-file was empty');
+    return body;
+  }
+  return buildProfileBody(opts);
 }
 
 export function register(dlp: Command): void {
@@ -34,27 +65,19 @@ export function register(dlp: Command): void {
     }
   });
 
-  group
-    .command('create')
-    .description('Create a data profile')
-    .option('--body <json|->', 'JSON body (or "-" for stdin)')
-    .option('--body-file <path>', 'Path to JSON body file')
-    .option('--output <fmt>', 'Output format', 'pretty')
-    .action(async (opts) => {
-      try {
-        const body = await parseBody({ body: opts.body, bodyFile: opts.bodyFile });
-        if (!body) throw new Error('--body or --body-file is required');
-        const svc = new SdkDataProfilesService();
-        dlpProfiles.renderCreated(
-          // biome-ignore lint/suspicious/noExplicitAny: parseBody returns unknown, cast for create()
-          await svc.create(body as any),
-          opts.output as OutputFormat,
-        );
-      } catch (err) {
-        renderError(err instanceof Error ? err.message : String(err));
-        process.exit(2);
-      }
-    });
+  writeFlags(group.command('create').description('Create a data profile')).action(async (opts) => {
+    try {
+      const body = await resolveWriteBody(opts);
+      dlpProfiles.renderCreated(
+        // biome-ignore lint/suspicious/noExplicitAny: body shape verified by SDK Zod
+        await new SdkDataProfilesService().create(body as any),
+        opts.output as OutputFormat,
+      );
+    } catch (err) {
+      renderError(err instanceof Error ? err.message : String(err));
+      process.exit(2);
+    }
+  });
 
   group
     .command('get <id>')
@@ -72,18 +95,12 @@ export function register(dlp: Command): void {
       }
     });
 
-  group
-    .command('replace <id>')
-    .description('Full-replace a data profile (PUT)')
-    .option('--body <json|->', 'JSON body (or "-" for stdin)')
-    .option('--body-file <path>', 'Path to JSON body file')
-    .option('--output <fmt>', 'Output format', 'pretty')
-    .action(async (id, opts) => {
+  writeFlags(group.command('replace <id>').description('Full-replace a data profile (PUT)')).action(
+    async (id, opts) => {
       try {
-        const body = await parseBody({ body: opts.body, bodyFile: opts.bodyFile });
-        if (!body) throw new Error('--body or --body-file is required');
+        const body = await resolveWriteBody(opts);
         dlpProfiles.renderReplaced(
-          // biome-ignore lint/suspicious/noExplicitAny: parseBody returns unknown, cast for replace()
+          // biome-ignore lint/suspicious/noExplicitAny: body shape verified by SDK Zod
           await new SdkDataProfilesService().replace(id, body as any),
           opts.output as OutputFormat,
         );
@@ -91,7 +108,8 @@ export function register(dlp: Command): void {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(2);
       }
-    });
+    },
+  );
 
   group
     .command('patch <id>')
@@ -101,12 +119,8 @@ export function register(dlp: Command): void {
         'To force a string, quote: --set count=\'"5"\'.',
     )
     .option('--body-file <path>', 'JSON merge-patch body file')
-    .option('--set <k=v...>', 'Set scalar field (repeatable)', (v, p: string[] = []) => [...p, v])
-    .option(
-      '--clear <key...>',
-      'Clear field via merge-patch null (repeatable)',
-      (v, p: string[] = []) => [...p, v],
-    )
+    .option('--set <k=v...>', 'Set scalar field (repeatable)', repeatable)
+    .option('--clear <key...>', 'Clear field via merge-patch null (repeatable)', repeatable)
     .option('--output <fmt>', 'Output format', 'pretty')
     .action(async (id, opts) => {
       try {
@@ -136,9 +150,8 @@ This DLP API has no DELETE for data profiles.
 To soft-delete, fetch the profile to get its name + profile_type, then patch:
 
   airs runtime dlp profiles get ${id} --output json
-  airs runtime dlp profiles patch ${id} --body-file - <<EOF
-  { "name": "...", "profile_type": "...", "profile_status": "deleted" }
-  EOF
+  airs runtime dlp profiles patch ${id} --set profile_status='"deleted"' \\
+    --set name='"<existing-name>"' --set profile_type='"<existing-type>"'
 `);
       process.exit(2);
     });

--- a/src/cli/renderer/dlp.ts
+++ b/src/cli/renderer/dlp.ts
@@ -1,110 +1,426 @@
+import chalk from 'chalk';
 import { dump as yamlDump } from 'js-yaml';
-import type { OutputFormat } from './common.js';
+import { formatOutput, type OutputFormat } from './common.js';
 
 // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-function emit(payload: any, fmt: OutputFormat): void {
-  switch (fmt) {
-    case 'json':
-      console.log(JSON.stringify(payload, null, 2));
-      return;
-    case 'yaml':
-      console.log(yamlDump(payload));
-      return;
+type Any = any;
+
+function statusColor(status: string | undefined): string {
+  switch (status) {
+    case 'active':
+      return chalk.green(status);
+    case 'deleted':
+    case 'disabled':
+      return chalk.yellow(status);
     default:
-      console.log(typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2));
+      return status ? chalk.dim(status) : chalk.dim('—');
   }
 }
 
+function ts(ms: number | undefined): string | undefined {
+  if (!ms) return undefined;
+  try {
+    return new Date(ms).toISOString();
+  } catch {
+    return undefined;
+  }
+}
+
+function emitStructured(payload: unknown, fmt: OutputFormat): void {
+  if (fmt === 'json') {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+  if (fmt === 'yaml') {
+    console.log(yamlDump(payload));
+    return;
+  }
+  console.log(JSON.stringify(payload, null, 2));
+}
+
+function pageMeta(page: Any, returned: number): Record<string, unknown> {
+  const p = page?.pageable ?? {};
+  return {
+    number: p?.pageNumber ?? p?.page_number ?? 0,
+    size: p?.pageSize ?? p?.page_size ?? returned,
+    total: page?.totalElements ?? page?.total_elements,
+    returned,
+  };
+}
+
+function emitList(
+  page: Any,
+  fmt: OutputFormat,
+  header: string,
+  toRow: (item: Any) => Record<string, unknown>,
+  columns: { key: string; label: string }[],
+  prettyLine: (item: Any) => string,
+): void {
+  const content: Any[] = Array.isArray(page?.content) ? page.content : [];
+  const rows = content.map(toRow);
+
+  if (fmt === 'json' || fmt === 'yaml') {
+    emitStructured({ items: rows, page: pageMeta(page, content.length) }, fmt);
+    return;
+  }
+  if (content.length === 0) {
+    console.log(chalk.dim(`  No ${header.toLowerCase()} found.\n`));
+    return;
+  }
+  if (fmt === 'pretty') {
+    console.log(chalk.bold(`\n  ${header}:\n`));
+    for (const item of content) console.log(prettyLine(item));
+    const meta = pageMeta(page, content.length);
+    console.log(
+      chalk.dim(
+        `\n  page=${meta.number} size=${meta.size} returned=${meta.returned} total=${meta.total ?? '?'}\n`,
+      ),
+    );
+    return;
+  }
+  console.log(formatOutput(rows, columns, fmt));
+}
+
+function fieldsToObject(
+  fields: { label: string; value: string | number | undefined }[],
+): Record<string, unknown> {
+  const obj: Record<string, unknown> = {};
+  for (const f of fields) {
+    if (f.value === undefined || f.value === null || f.value === '') continue;
+    obj[toKey(f.label)] = f.value;
+  }
+  return obj;
+}
+
+function toKey(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+(.)/g, (_, c) => c.toUpperCase())
+    .replace(/[^a-z0-9]/g, '');
+}
+
+function emitDetail(
+  item: Any,
+  fmt: OutputFormat,
+  fields: { label: string; value: string | number | undefined }[],
+  title: string,
+): void {
+  if (fmt === 'json' || fmt === 'yaml') {
+    emitStructured(fieldsToObject(fields), fmt);
+    return;
+  }
+  if (fmt === 'pretty') {
+    console.log(chalk.bold(`\n  ${title}:\n`));
+    const w = Math.max(...fields.map((f) => f.label.length));
+    for (const f of fields) {
+      if (f.value === undefined || f.value === null || f.value === '') continue;
+      console.log(`    ${f.label.padEnd(w)}  ${f.value}`);
+    }
+    console.log();
+    return;
+  }
+  const rows = [Object.fromEntries(fields.map((f) => [f.label, f.value ?? '']))];
+  const columns = fields.map((f) => ({ key: f.label, label: f.label }));
+  console.log(formatOutput(rows, columns, fmt));
+}
+
+function ackObject(verb: string, item: Any): Record<string, unknown> {
+  const out: Record<string, unknown> = { action: verb };
+  if (item?.id != null) out.id = item.id;
+  if (item?.name != null) out.name = item.name;
+  if (item?.type != null) out.type = item.type;
+  if (item?.status != null) out.status = item.status;
+  if (item?.profile_status != null) out.status = item.profile_status;
+  if (item?.version != null) out.version = item.version;
+  return out;
+}
+
+function emitAck(verb: string, color: (s: string) => string, item: Any, fmt: OutputFormat): void {
+  if (fmt === 'json' || fmt === 'yaml') {
+    emitStructured(ackObject(verb, item), fmt);
+    return;
+  }
+  if (fmt === 'table' || fmt === 'csv') {
+    const row = ackObject(verb, item);
+    const cols = Object.keys(row).map((k) => ({ key: k, label: k }));
+    console.log(formatOutput([row], cols, fmt));
+    return;
+  }
+  const ver = item?.version != null ? chalk.dim(` v${item.version}`) : '';
+  console.log(`  ${color(verb)} ${chalk.dim(item?.id ?? '')}  ${item?.name ?? ''}${ver}`);
+}
+
+function emitIdAck(verb: string, color: (s: string) => string, id: string): void {
+  console.log(`  ${color(verb)} ${chalk.dim(id)}`);
+}
+
+// ---------------------------------------------------------------------------
+// Filtering Profiles
+// ---------------------------------------------------------------------------
+
 export const dlpFilteringProfiles = {
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderList(page: any, fmt: OutputFormat) {
-    emit(page, fmt);
+  renderList(page: Any, fmt: OutputFormat) {
+    emitList(
+      page,
+      fmt,
+      'Data Filtering Profiles',
+      (it) => ({
+        id: it.id,
+        name: it.name,
+        type: it.type,
+        direction: it.direction,
+        severity: it.log_severity,
+        version: it.version,
+      }),
+      [
+        { key: 'id', label: 'ID' },
+        { key: 'name', label: 'Name' },
+        { key: 'type', label: 'Type' },
+        { key: 'direction', label: 'Direction' },
+        { key: 'severity', label: 'Severity' },
+        { key: 'version', label: 'Version' },
+      ],
+      (it) => {
+        const dir = it.direction ? chalk.dim(` dir:${it.direction}`) : '';
+        const sev = it.log_severity ? chalk.dim(` sev:${it.log_severity}`) : '';
+        const ver = it.version != null ? chalk.dim(` v${it.version}`) : '';
+        return `  ${chalk.dim(it.id)}\n    ${it.name}  ${chalk.cyan(it.type ?? '')}${dir}${sev}${ver}`;
+      },
+    );
   },
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderGet(item: any, fmt: OutputFormat) {
-    emit(item, fmt);
+  renderGet(item: Any, fmt: OutputFormat) {
+    emitDetail(
+      item,
+      fmt,
+      [
+        { label: 'ID', value: item?.id },
+        { label: 'Name', value: item?.name },
+        { label: 'Type', value: item?.type },
+        { label: 'Data Profile', value: item?.data_profile_id },
+        { label: 'Direction', value: item?.direction },
+        { label: 'Severity', value: item?.log_severity },
+        { label: 'Scan Type', value: item?.scan_type },
+        { label: 'File Based', value: item?.file_based ? 'yes' : 'no' },
+        { label: 'Non-File Based', value: item?.non_file_based ? 'yes' : 'no' },
+        { label: 'Version', value: item?.version },
+        {
+          label: 'File Types',
+          value: Array.isArray(item?.file_type) ? item.file_type.length : undefined,
+        },
+        { label: 'Updated', value: ts(item?.audit_metadata?.updated_at) },
+      ],
+      'Data Filtering Profile',
+    );
   },
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderReplaced(item: any, fmt: OutputFormat) {
-    if (fmt === 'pretty') console.log(`  replaced ${item.id}`);
-    else emit(item, fmt);
+  renderReplaced(item: Any, fmt: OutputFormat) {
+    emitAck('replaced', chalk.green, item, fmt);
   },
 };
+
+// ---------------------------------------------------------------------------
+// Patterns
+// ---------------------------------------------------------------------------
 
 export const dlpPatterns = {
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderList(page: any, fmt: OutputFormat) {
-    emit(page, fmt);
+  renderList(page: Any, fmt: OutputFormat) {
+    emitList(
+      page,
+      fmt,
+      'Data Patterns',
+      (it) => ({
+        id: it.id,
+        name: it.name,
+        type: it.type,
+        status: it.status,
+        technique: it.detection_config?.technique,
+        version: it.version,
+      }),
+      [
+        { key: 'id', label: 'ID' },
+        { key: 'name', label: 'Name' },
+        { key: 'type', label: 'Type' },
+        { key: 'status', label: 'Status' },
+        { key: 'technique', label: 'Technique' },
+        { key: 'version', label: 'Version' },
+      ],
+      (it) => {
+        const tech = it.detection_config?.technique
+          ? chalk.dim(` ${it.detection_config.technique}`)
+          : '';
+        const ver = it.version != null ? chalk.dim(` v${it.version}`) : '';
+        return `  ${chalk.dim(it.id)}\n    ${it.name}  ${chalk.cyan(it.type ?? '')}  ${statusColor(it.status)}${tech}${ver}`;
+      },
+    );
   },
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderCreated(item: any, fmt: OutputFormat) {
-    emit(item, fmt);
+  renderGet(item: Any, fmt: OutputFormat) {
+    emitDetail(
+      item,
+      fmt,
+      [
+        { label: 'ID', value: item?.id },
+        { label: 'Name', value: item?.name },
+        { label: 'Description', value: item?.description },
+        { label: 'Type', value: item?.type },
+        { label: 'Status', value: item?.status },
+        { label: 'Technique', value: item?.detection_config?.technique },
+        {
+          label: 'Confidence',
+          value:
+            (item?.detection_config?.supported_confidence_levels ?? []).join(', ') || undefined,
+        },
+        {
+          label: 'Regexes',
+          value: Array.isArray(item?.matching_rules?.regexes)
+            ? item.matching_rules.regexes.length
+            : undefined,
+        },
+        { label: 'Version', value: item?.version },
+        { label: 'Updated', value: ts(item?.audit_metadata?.updated_at) },
+      ],
+      'Data Pattern',
+    );
   },
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderGet(item: any, fmt: OutputFormat) {
-    emit(item, fmt);
+  renderCreated(item: Any, fmt: OutputFormat) {
+    emitAck('created', chalk.green, item, fmt);
   },
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderReplaced(item: any, fmt: OutputFormat) {
-    emit(item, fmt);
+  renderReplaced(item: Any, fmt: OutputFormat) {
+    emitAck('replaced', chalk.green, item, fmt);
   },
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderPatched(item: any, fmt: OutputFormat) {
-    emit(item, fmt);
+  renderPatched(item: Any, fmt: OutputFormat) {
+    emitAck('patched', chalk.green, item, fmt);
   },
   renderArchived(id: string) {
-    console.log(`  archived ${id}`);
+    emitIdAck('archived', chalk.yellow, id);
   },
 };
+
+// ---------------------------------------------------------------------------
+// Profiles (Data Profiles)
+// ---------------------------------------------------------------------------
 
 export const dlpProfiles = {
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderList(page: any, fmt: OutputFormat) {
-    emit(page, fmt);
+  renderList(page: Any, fmt: OutputFormat) {
+    emitList(
+      page,
+      fmt,
+      'Data Profiles',
+      (it) => ({
+        id: it.id,
+        name: it.name,
+        type: it.type,
+        profile_type: it.profile_type,
+        status: it.profile_status,
+        version: it.version,
+      }),
+      [
+        { key: 'id', label: 'ID' },
+        { key: 'name', label: 'Name' },
+        { key: 'type', label: 'Type' },
+        { key: 'profile_type', label: 'Profile Type' },
+        { key: 'status', label: 'Status' },
+        { key: 'version', label: 'Version' },
+      ],
+      (it) => {
+        const ptype = it.profile_type ? chalk.dim(` ${it.profile_type}`) : '';
+        const ver = it.version != null ? chalk.dim(` v${it.version}`) : '';
+        return `  ${chalk.dim(it.id)}\n    ${it.name}  ${chalk.cyan(it.type ?? '')}  ${statusColor(it.profile_status)}${ptype}${ver}`;
+      },
+    );
   },
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderCreated(item: any, fmt: OutputFormat) {
-    emit(item, fmt);
+  renderGet(item: Any, fmt: OutputFormat) {
+    emitDetail(
+      item,
+      fmt,
+      [
+        { label: 'ID', value: item?.id },
+        { label: 'Name', value: item?.name },
+        { label: 'Description', value: item?.description },
+        { label: 'Type', value: item?.type },
+        { label: 'Profile Type', value: item?.profile_type },
+        { label: 'Status', value: item?.profile_status },
+        { label: 'Version', value: item?.version },
+        { label: 'Updated', value: ts(item?.audit_metadata?.updated_at) },
+      ],
+      'Data Profile',
+    );
   },
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderGet(item: any, fmt: OutputFormat) {
-    emit(item, fmt);
+  renderCreated(item: Any, fmt: OutputFormat) {
+    emitAck('created', chalk.green, item, fmt);
   },
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderReplaced(item: any, fmt: OutputFormat) {
-    emit(item, fmt);
+  renderReplaced(item: Any, fmt: OutputFormat) {
+    emitAck('replaced', chalk.green, item, fmt);
   },
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderPatched(item: any, fmt: OutputFormat) {
-    emit(item, fmt);
+  renderPatched(item: Any, fmt: OutputFormat) {
+    emitAck('patched', chalk.green, item, fmt);
   },
 };
 
+// ---------------------------------------------------------------------------
+// Dictionaries
+// ---------------------------------------------------------------------------
+
 export const dlpDictionaries = {
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderList(page: any, fmt: OutputFormat) {
-    emit(page, fmt);
+  renderList(page: Any, fmt: OutputFormat) {
+    emitList(
+      page,
+      fmt,
+      'Data Dictionaries',
+      (it) => ({
+        id: it.id,
+        name: it.name,
+        type: it.type,
+        status: it.status,
+        keywords: Array.isArray(it.keywords) ? it.keywords.length : undefined,
+        version: it.version,
+      }),
+      [
+        { key: 'id', label: 'ID' },
+        { key: 'name', label: 'Name' },
+        { key: 'type', label: 'Type' },
+        { key: 'status', label: 'Status' },
+        { key: 'keywords', label: 'Keywords' },
+        { key: 'version', label: 'Version' },
+      ],
+      (it) => {
+        const kw = Array.isArray(it.keywords) ? chalk.dim(` ${it.keywords.length} kw`) : '';
+        const ver = it.version != null ? chalk.dim(` v${it.version}`) : '';
+        return `  ${chalk.dim(it.id)}\n    ${it.name}  ${chalk.cyan(it.type ?? '')}  ${statusColor(it.status)}${kw}${ver}`;
+      },
+    );
   },
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderCreated(item: any, fmt: OutputFormat) {
-    emit(item, fmt);
+  renderGet(item: Any, fmt: OutputFormat) {
+    emitDetail(
+      item,
+      fmt,
+      [
+        { label: 'ID', value: item?.id },
+        { label: 'Name', value: item?.name },
+        { label: 'Description', value: item?.description },
+        { label: 'Type', value: item?.type },
+        { label: 'Status', value: item?.status },
+        {
+          label: 'Keywords',
+          value: Array.isArray(item?.keywords) ? item.keywords.length : undefined,
+        },
+        { label: 'Version', value: item?.version },
+        { label: 'Updated', value: ts(item?.audit_metadata?.updated_at) },
+      ],
+      'Data Dictionary',
+    );
   },
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderGet(item: any, fmt: OutputFormat) {
-    emit(item, fmt);
+  renderCreated(item: Any, fmt: OutputFormat) {
+    emitAck('created', chalk.green, item, fmt);
   },
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderReplaced(item: any, fmt: OutputFormat) {
-    emit(item, fmt);
+  renderReplaced(item: Any, fmt: OutputFormat) {
+    emitAck('replaced', chalk.green, item, fmt);
   },
-  // biome-ignore lint/suspicious/noExplicitAny: renderer accepts arbitrary SDK payloads
-  renderPatched(item: any, fmt: OutputFormat) {
-    emit(item, fmt);
+  renderPatched(item: Any, fmt: OutputFormat) {
+    emitAck('patched', chalk.green, item, fmt);
   },
   renderReplaced204Fallback(id: string) {
-    console.log(`  replaced ${id} (state not echoed by region)`);
+    console.log(`  ${chalk.green('replaced')} ${chalk.dim(id)} (state not echoed by region)`);
   },
   renderDeleted(id: string) {
-    console.log(`  deleted ${id}`);
+    emitIdAck('deleted', chalk.yellow, id);
   },
 };

--- a/src/cli/renderer/dlp.ts
+++ b/src/cli/renderer/dlp.ts
@@ -100,7 +100,7 @@ function toKey(label: string): string {
 }
 
 function emitDetail(
-  item: Any,
+  _item: Any,
   fmt: OutputFormat,
   fields: { label: string; value: string | number | undefined }[],
   title: string,

--- a/tests/unit/cli/dlp-build-body.spec.ts
+++ b/tests/unit/cli/dlp-build-body.spec.ts
@@ -48,18 +48,24 @@ describe('buildPatternBody', () => {
 
   it('weighted-regex splits on LAST pipe', () => {
     const body = buildPatternBody({ name: 'X', weightedRegex: ['A|B|3'] });
-    expect((body.matching_rules as { regexes: { regex: string; weight: number }[] }).regexes[0]).toEqual({
+    expect(
+      (body.matching_rules as { regexes: { regex: string; weight: number }[] }).regexes[0],
+    ).toEqual({
       regex: 'A|B',
       weight: 3,
     });
   });
 
   it('weighted-regex rejects missing pipe', () => {
-    expect(() => buildPatternBody({ name: 'X', weightedRegex: ['NOPIPE'] })).toThrow(/PATTERN\|weight/);
+    expect(() => buildPatternBody({ name: 'X', weightedRegex: ['NOPIPE'] })).toThrow(
+      /PATTERN\|weight/,
+    );
   });
 
   it('weighted-regex rejects non-numeric weight', () => {
-    expect(() => buildPatternBody({ name: 'X', weightedRegex: ['ABC|nope'] })).toThrow(/weight invalid/);
+    expect(() => buildPatternBody({ name: 'X', weightedRegex: ['ABC|nope'] })).toThrow(
+      /weight invalid/,
+    );
   });
 
   it('parses confidence-levels CSV', () => {
@@ -160,7 +166,9 @@ describe('buildProfileBody', () => {
 
   it('builds expression_tree from --pattern-id with default OR combinator', () => {
     const body = buildProfileBody({ name: 'X', patternId: ['p1', 'p2'] });
-    const rules = (body.detection_rules as { rule_type: string; expression_tree: { operator_type: string } }[])[0];
+    const rules = (
+      body.detection_rules as { rule_type: string; expression_tree: { operator_type: string } }[]
+    )[0];
     expect(rules.rule_type).toBe('expression_tree');
     expect(rules.expression_tree.operator_type).toBe('or');
   });

--- a/tests/unit/cli/dlp-build-body.spec.ts
+++ b/tests/unit/cli/dlp-build-body.spec.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildFilteringProfileBody,
+  buildPatternBody,
+  buildProfileBody,
+  repeatable,
+} from '../../../src/cli/commands/dlp/build-body.js';
+
+describe('buildPatternBody', () => {
+  it('requires --name', () => {
+    expect(() => buildPatternBody({})).toThrow(/--name/);
+  });
+
+  it('defaults type=custom, technique=regex', () => {
+    const body = buildPatternBody({ name: 'X' });
+    expect(body).toMatchObject({
+      name: 'X',
+      type: 'custom',
+      detection_config: { technique: 'regex' },
+    });
+  });
+
+  it('builds matching_rules with regexes (weight 1)', () => {
+    const body = buildPatternBody({
+      name: 'X',
+      regex: ['ABC', 'DEF'],
+    });
+    expect(body.matching_rules).toEqual({
+      regexes: [
+        { regex: 'ABC', weight: 1 },
+        { regex: 'DEF', weight: 1 },
+      ],
+    });
+  });
+
+  it('parses weighted-regex PATTERN|N', () => {
+    const body = buildPatternBody({
+      name: 'X',
+      weightedRegex: ['ABC|2', 'DEF|5'],
+    });
+    expect(body.matching_rules).toEqual({
+      regexes: [
+        { regex: 'ABC', weight: 2 },
+        { regex: 'DEF', weight: 5 },
+      ],
+    });
+  });
+
+  it('weighted-regex splits on LAST pipe', () => {
+    const body = buildPatternBody({ name: 'X', weightedRegex: ['A|B|3'] });
+    expect((body.matching_rules as { regexes: { regex: string; weight: number }[] }).regexes[0]).toEqual({
+      regex: 'A|B',
+      weight: 3,
+    });
+  });
+
+  it('weighted-regex rejects missing pipe', () => {
+    expect(() => buildPatternBody({ name: 'X', weightedRegex: ['NOPIPE'] })).toThrow(/PATTERN\|weight/);
+  });
+
+  it('weighted-regex rejects non-numeric weight', () => {
+    expect(() => buildPatternBody({ name: 'X', weightedRegex: ['ABC|nope'] })).toThrow(/weight invalid/);
+  });
+
+  it('parses confidence-levels CSV', () => {
+    const body = buildPatternBody({
+      name: 'X',
+      confidenceLevels: 'high, low',
+    });
+    expect(body.detection_config).toEqual({
+      technique: 'regex',
+      supported_confidence_levels: ['high', 'low'],
+    });
+  });
+
+  it('parses tags with comma-separated values', () => {
+    const body = buildPatternBody({
+      name: 'X',
+      tag: ['classification=pab,endpoint', 'region=us'],
+    });
+    expect(body.tags).toEqual({
+      classification: ['pab', 'endpoint'],
+      region: ['us'],
+    });
+  });
+
+  it('rejects tag without "="', () => {
+    expect(() => buildPatternBody({ name: 'X', tag: ['nope'] })).toThrow(/key=value/);
+  });
+
+  it('includes delimiter, proximity_distance, proximity_keywords', () => {
+    const body = buildPatternBody({
+      name: 'X',
+      delimiter: ';',
+      proximityDistance: '100',
+      proximityKeyword: ['acct', 'account'],
+    });
+    expect(body.matching_rules).toEqual({
+      delimiter: ';',
+      proximity_distance: 100,
+      proximity_keywords: ['acct', 'account'],
+    });
+  });
+});
+
+describe('buildFilteringProfileBody', () => {
+  it('requires both --file-based and --non-file-based', () => {
+    expect(() => buildFilteringProfileBody({})).toThrow(/file-based/);
+    expect(() => buildFilteringProfileBody({ fileBased: true })).toThrow(/file-based/);
+  });
+
+  it('builds minimal body', () => {
+    expect(buildFilteringProfileBody({ fileBased: true, nonFileBased: false })).toEqual({
+      file_based: true,
+      non_file_based: false,
+    });
+  });
+
+  it('includes optional flat fields', () => {
+    const body = buildFilteringProfileBody({
+      fileBased: true,
+      nonFileBased: true,
+      description: 'd',
+      direction: 'BOTH',
+      logSeverity: 'HIGH',
+      scanType: 'include',
+      dataProfileId: '12345',
+      eucTemplateId: 'tmpl-1',
+      endUserCoaching: true,
+      granular: false,
+      fileType: ['pdf', 'docx'],
+    });
+    expect(body).toEqual({
+      file_based: true,
+      non_file_based: true,
+      description: 'd',
+      direction: 'BOTH',
+      log_severity: 'HIGH',
+      scan_type: 'include',
+      data_profile_id: 12345,
+      euc_template_id: 'tmpl-1',
+      is_end_user_coaching_enabled: true,
+      is_granular_profile: false,
+      file_type: ['pdf', 'docx'],
+    });
+  });
+});
+
+describe('buildProfileBody', () => {
+  it('requires --name', () => {
+    expect(() => buildProfileBody({})).toThrow(/--name/);
+  });
+
+  it('defaults profile_type=advanced', () => {
+    expect(buildProfileBody({ name: 'X' })).toEqual({
+      name: 'X',
+      profile_type: 'advanced',
+    });
+  });
+
+  it('builds expression_tree from --pattern-id with default OR combinator', () => {
+    const body = buildProfileBody({ name: 'X', patternId: ['p1', 'p2'] });
+    const rules = (body.detection_rules as { rule_type: string; expression_tree: { operator_type: string } }[])[0];
+    expect(rules.rule_type).toBe('expression_tree');
+    expect(rules.expression_tree.operator_type).toBe('or');
+  });
+
+  it('uses custom combinator', () => {
+    const body = buildProfileBody({ name: 'X', patternId: ['p1'], combinator: 'AND' });
+    const rules = (body.detection_rules as { expression_tree: { operator_type: string } }[])[0];
+    expect(rules.expression_tree.operator_type).toBe('and');
+  });
+
+  it('rejects invalid combinator', () => {
+    expect(() => buildProfileBody({ name: 'X', patternId: ['p1'], combinator: 'xor' })).toThrow(
+      /combinator/,
+    );
+  });
+});
+
+describe('repeatable', () => {
+  it('accumulates values', () => {
+    expect(repeatable('b', ['a'])).toEqual(['a', 'b']);
+    expect(repeatable('a')).toEqual(['a']);
+  });
+});

--- a/tests/unit/cli/dlp-renderer.spec.ts
+++ b/tests/unit/cli/dlp-renderer.spec.ts
@@ -8,25 +8,56 @@ import {
 } from '../../../src/cli/renderer/dlp.js';
 
 describe('dlpFilteringProfiles renderer', () => {
-  it('renderList json emits content + totalElements', () => {
+  it('renderList json emits curated items + page meta (not raw SDK envelope)', () => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     dlpFilteringProfiles.renderList(
-      { content: [{ id: 'a', name: 'p' }], totalElements: 1, pageable: { pageNumber: 0 } } as any,
+      {
+        content: [{ id: 'a', name: 'p', type: 'custom', is_parent_managed: false }],
+        totalElements: 1,
+        pageable: { pageNumber: 0, pageSize: 25 },
+      } as any,
       'json',
     );
-    expect(spy.mock.calls[0]?.[0]).toContain('"totalElements": 1');
+    const out = String(spy.mock.calls[0]?.[0]);
+    expect(out).toContain('"items"');
+    expect(out).toContain('"page"');
+    expect(out).toContain('"total": 1');
+    expect(out).not.toContain('is_parent_managed');
     spy.mockRestore();
   });
-  it('renderGet json round-trips', () => {
+
+  it('renderGet json emits curated fields only', () => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    dlpFilteringProfiles.renderGet({ id: 'a' } as any, 'json');
-    expect(spy.mock.calls[0]?.[0]).toContain('"id": "a"');
+    dlpFilteringProfiles.renderGet(
+      { id: 'a', name: 'p', type: 'custom', tenant_id: 'X', is_parent_managed: false } as any,
+      'json',
+    );
+    const out = String(spy.mock.calls[0]?.[0]);
+    expect(out).toContain('"id": "a"');
+    expect(out).toContain('"name": "p"');
+    expect(out).not.toContain('tenant_id');
+    expect(out).not.toContain('is_parent_managed');
     spy.mockRestore();
   });
-  it('renderReplaced emits confirmation', () => {
+
+  it('renderReplaced pretty emits confirmation line', () => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     dlpFilteringProfiles.renderReplaced({ id: 'a' } as any, 'pretty');
     expect(spy).toHaveBeenCalledWith(expect.stringContaining('replaced'));
+    spy.mockRestore();
+  });
+
+  it('renderReplaced json emits curated ack object', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    dlpFilteringProfiles.renderReplaced(
+      { id: 'a', name: 'p', version: 2, tenant_id: 'X' } as any,
+      'json',
+    );
+    const out = String(spy.mock.calls[0]?.[0]);
+    expect(out).toContain('"action": "replaced"');
+    expect(out).toContain('"id": "a"');
+    expect(out).toContain('"version": 2');
+    expect(out).not.toContain('tenant_id');
     spy.mockRestore();
   });
 });
@@ -35,39 +66,57 @@ describe('dlpPatterns renderer', () => {
   it('renderArchived prints "archived <id>"', () => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     dlpPatterns.renderArchived('p1');
-    expect(spy).toHaveBeenCalledWith(expect.stringContaining('archived p1'));
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('archived'));
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('p1'));
     spy.mockRestore();
   });
-  it('renderCreated/Patched/Replaced emit json on demand', () => {
+
+  it('renderCreated/Patched/Replaced json emit curated ack objects', () => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    dlpPatterns.renderCreated({ id: 'p1' } as any, 'json');
-    dlpPatterns.renderPatched({ id: 'p1', name: 'x' } as any, 'json');
-    dlpPatterns.renderReplaced({ id: 'p1' } as any, 'json');
+    dlpPatterns.renderCreated({ id: 'p1', name: 'x', version: 1 } as any, 'json');
+    dlpPatterns.renderPatched({ id: 'p1', name: 'x', version: 2 } as any, 'json');
+    dlpPatterns.renderReplaced({ id: 'p1', name: 'x', version: 3 } as any, 'json');
     expect(spy.mock.calls.every((c) => String(c[0]).includes('"id": "p1"'))).toBe(true);
+    expect(String(spy.mock.calls[0]?.[0])).toContain('"action": "created"');
+    expect(String(spy.mock.calls[1]?.[0])).toContain('"action": "patched"');
+    expect(String(spy.mock.calls[2]?.[0])).toContain('"action": "replaced"');
     spy.mockRestore();
   });
 });
 
 describe('dlpProfiles renderer', () => {
-  it('renderList json', () => {
+  it('renderList json emits curated items + page', () => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    dlpProfiles.renderList({ content: [{ id: 'dp' }], totalElements: 1 } as any, 'json');
-    expect(spy.mock.calls[0]?.[0]).toContain('"id": "dp"');
+    dlpProfiles.renderList(
+      {
+        content: [{ id: 'dp', name: 'n', tenant_id: 'X' }],
+        totalElements: 1,
+        pageable: { pageNumber: 0 },
+      } as any,
+      'json',
+    );
+    const out = String(spy.mock.calls[0]?.[0]);
+    expect(out).toContain('"id": "dp"');
+    expect(out).toContain('"total": 1');
+    expect(out).not.toContain('tenant_id');
     spy.mockRestore();
   });
 });
 
 describe('dlpDictionaries renderer', () => {
-  it('renderDeleted', () => {
+  it('renderDeleted prints "deleted <id>"', () => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     dlpDictionaries.renderDeleted('d1');
-    expect(spy).toHaveBeenCalledWith(expect.stringContaining('deleted d1'));
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('deleted'));
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('d1'));
     spy.mockRestore();
   });
+
   it('renderReplaced204Fallback', () => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     dlpDictionaries.renderReplaced204Fallback('d1');
-    expect(spy).toHaveBeenCalledWith(expect.stringContaining('replaced d1'));
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('replaced'));
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('d1'));
     expect(spy).toHaveBeenCalledWith(expect.stringContaining('state not echoed'));
     spy.mockRestore();
   });


### PR DESCRIPTION
## Summary

- `dlp patterns|profiles|filtering-profiles create/replace` accept structured CLI flags (`--name`, `--regex`, `--pattern-id`, `--file-based`, `--tag k=v`, …). `--body-file` retained as escape hatch.
- All DLP output formats route through a curated projection — `--output json` returns `{items, page}` for lists and `{action,id,name,…}` for acks. No more raw SDK envelope (`tenant_id`, `is_parent_managed`, `pageable.*`).
- Ships as 2.10.0.

## Test plan

- [x] `pnpm test` — 637 pass (incl. 20 new body-builder tests + reworked renderer tests)
- [x] `pnpm build` clean
- [x] Live tenant — `patterns create` via flags returns curated ack JSON; `patterns delete` archives
- [ ] Reviewer: `airs runtime dlp patterns list --output json` should not contain `tenant_id` or `pageable`
- [ ] Reviewer: `airs runtime dlp patterns create --name x --regex "ABC"` should round-trip without a JSON file