### PR TITLE
docs(dlp-patterns): add live input/output examples

### DIFF
--- a/.changeset/docs-dlp-patterns-examples.md
+++ b/.changeset/docs-dlp-patterns-examples.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+docs(cli): live input/output examples for `runtime dlp patterns` list, create, delete. `get`, `replace`, `patch` remain on the missing-allowlist with comments linking the upstream tracking issues ([#80](https://github.com/cdot65/prisma-airs-cli/issues/80), [#98](https://github.com/cdot65/prisma-airs-cli/issues/98)) — those page sections keep the "Example needed" placeholder until the upstream API 400 is fixed.

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -24,12 +24,12 @@ runtime topics update
 runtime dlp filtering-profiles list
 runtime dlp filtering-profiles get
 runtime dlp filtering-profiles replace
-runtime dlp patterns list
-runtime dlp patterns create
+# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/80
 runtime dlp patterns get
+# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/98
 runtime dlp patterns replace
+# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/98
 runtime dlp patterns patch
-runtime dlp patterns delete
 runtime dlp profiles list
 runtime dlp profiles create
 runtime dlp profiles get

--- a/docs/cli/examples/runtime.yaml
+++ b/docs/cli/examples/runtime.yaml
@@ -123,3 +123,88 @@
       input: airs runtime profiles cleanup --force --updated-by user@example.com
     - note: JSON output
       input: airs runtime profiles cleanup --force --output json
+
+"runtime dlp patterns list":
+  examples:
+    - note: Pretty output (default)
+      input: airs runtime dlp patterns list --size 2 --sort name,asc
+      output: |
+          Data Patterns:
+
+          000000000000000000000001
+            API Credentials Client ID - Amazon Web Services AWS  predefined  disabled regex v1
+          000000000000000000000002
+            API Credentials Client ID - Bitly  predefined  disabled regex v1
+
+          page=0 size=2 returned=2 total=1126
+    - note: JSON output
+      input: airs runtime dlp patterns list --size 2 --sort name,asc --output json
+      output: |
+        {
+          "items": [
+            {
+              "id": "000000000000000000000001",
+              "name": "API Credentials Client ID - Amazon Web Services AWS",
+              "type": "predefined",
+              "status": "disabled",
+              "technique": "regex",
+              "version": 1
+            },
+            {
+              "id": "000000000000000000000002",
+              "name": "API Credentials Client ID - Bitly",
+              "type": "predefined",
+              "status": "disabled",
+              "technique": "regex",
+              "version": 1
+            }
+          ],
+          "page": {
+            "number": 0,
+            "size": 2,
+            "total": 1126,
+            "returned": 2
+          }
+        }
+    - note: YAML output
+      input: airs runtime dlp patterns list --size 2 --sort name,asc --output yaml
+      output: |
+        items:
+          - id: 000000000000000000000001
+            name: API Credentials Client ID - Amazon Web Services AWS
+            type: predefined
+            status: disabled
+            technique: regex
+            version: 1
+          - id: 000000000000000000000002
+            name: API Credentials Client ID - Bitly
+            type: predefined
+            status: disabled
+            technique: regex
+            version: 1
+        page:
+          number: 0
+          size: 2
+          total: 1126
+          returned: 2
+
+"runtime dlp patterns create":
+  examples:
+    - note: Create a custom regex pattern with --name + --regex flags
+      input: airs runtime dlp patterns create --name docs-example-pattern --regex '\bACME-\d{6}\b' --output json
+      output: |
+        {
+          "action": "created",
+          "id": "000000000000000000000003",
+          "name": "docs-example-pattern",
+          "type": "custom",
+          "status": "active",
+          "version": 1
+        }
+
+"runtime dlp patterns delete":
+  examples:
+    - note: Soft-delete (archive) a data pattern by id
+      input: airs runtime dlp patterns delete 000000000000000000000003
+      output: |
+        archived 000000000000000000000003

--- a/docs/cli/runtime/dlp/patterns.md
+++ b/docs/cli/runtime/dlp/patterns.md
@@ -19,8 +19,84 @@ airs runtime dlp patterns list [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default)*
+
+```bash
+airs runtime dlp patterns list --size 2 --sort name,asc
+```
+
+```text
+Data Patterns:
+
+000000000000000000000001
+  API Credentials Client ID - Amazon Web Services AWS  predefined  disabled regex v1
+000000000000000000000002
+  API Credentials Client ID - Bitly  predefined  disabled regex v1
+
+page=0 size=2 returned=2 total=1126
+```
+
+*JSON output*
+
+```bash
+airs runtime dlp patterns list --size 2 --sort name,asc --output json
+```
+
+```text
+{
+  "items": [
+    {
+      "id": "000000000000000000000001",
+      "name": "API Credentials Client ID - Amazon Web Services AWS",
+      "type": "predefined",
+      "status": "disabled",
+      "technique": "regex",
+      "version": 1
+    },
+    {
+      "id": "000000000000000000000002",
+      "name": "API Credentials Client ID - Bitly",
+      "type": "predefined",
+      "status": "disabled",
+      "technique": "regex",
+      "version": 1
+    }
+  ],
+  "page": {
+    "number": 0,
+    "size": 2,
+    "total": 1126,
+    "returned": 2
+  }
+}
+```
+
+*YAML output*
+
+```bash
+airs runtime dlp patterns list --size 2 --sort name,asc --output yaml
+```
+
+```text
+items:
+  - id: 000000000000000000000001
+    name: API Credentials Client ID - Amazon Web Services AWS
+    type: predefined
+    status: disabled
+    technique: regex
+    version: 1
+  - id: 000000000000000000000002
+    name: API Credentials Client ID - Bitly
+    type: predefined
+    status: disabled
+    technique: regex
+    version: 1
+page:
+  number: 0
+  size: 2
+  total: 1126
+  returned: 2
+```
 
 ---
 
@@ -53,8 +129,22 @@ airs runtime dlp patterns create [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Create a custom regex pattern with --name + --regex flags*
+
+```bash
+airs runtime dlp patterns create --name docs-example-pattern --regex '\bACME-\d{6}\b' --output json
+```
+
+```text
+{
+  "action": "created",
+  "id": "000000000000000000000003",
+  "name": "docs-example-pattern",
+  "type": "custom",
+  "status": "active",
+  "version": 1
+}
+```
 
 ---
 
@@ -163,5 +253,12 @@ airs runtime dlp patterns delete [options] <id>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Soft-delete (archive) a data pattern by id*
+
+```bash
+airs runtime dlp patterns delete 000000000000000000000003
+```
+
+```text
+archived 000000000000000000000003
+```


### PR DESCRIPTION
Closes #86. Part of epic #83.

## Summary

Sidecar YAML entries in `docs/cli/examples/runtime.yaml` for the three working `runtime dlp patterns` commands. The remaining three stay on `.missing-allowlist` with comment lines linking the upstream-bug trackers, per the corrected workflow in [#102](https://github.com/cdot65/prisma-airs-cli/pull/102) (README.md). Doc pages are auto-generated; no hand edits to `.md`.

### Worked
- `runtime dlp patterns list` — pretty + JSON + YAML (captured with `--size 2 --sort name,asc`)
- `runtime dlp patterns create` — JSON (uses `--name` + `--regex` flags; no `--body-file` needed)
- `runtime dlp patterns delete` — input + `archived <id>` capture

### Blocked (kept on `.missing-allowlist` with `# Blocked by ...` comment)
- `runtime dlp patterns get` — upstream API 400 — [#80](https://github.com/cdot65/prisma-airs-cli/issues/80)
- `runtime dlp patterns replace` — upstream API 400 — [#98](https://github.com/cdot65/prisma-airs-cli/issues/98)
- `runtime dlp patterns patch` — upstream API 400 — [#98](https://github.com/cdot65/prisma-airs-cli/issues/98)

Those page sections keep the default `!!! warning "Example needed"` placeholder until the upstream API is fixed.

## Redaction

- Pattern IDs renumbered to `000000000000000000000001`..`...000003`
- Pattern names left as the real predefined `API Credentials Client ID - Amazon Web Services AWS` / `... - Bitly` rows (public, non-sensitive)
- Custom-pattern example uses `docs-example-pattern` + `\bACME-\d{6}\b` regex
- No tenant ID, customer name, or real keyword content present

## Files
- `docs/cli/examples/runtime.yaml` — 3 sidecar entries (list/create/delete)
- `docs/cli/examples/.missing-allowlist` — list/create/delete removed; get/replace/patch kept with tracking-issue comment lines
- `docs/cli/runtime/dlp/patterns.md` — regenerated via `pnpm docs:gen`
- `.changeset/docs-dlp-patterns-examples.md` — patch bump

## Validation
- `pnpm docs:gen` clean
- `pnpm format` clean
- `pnpm docs:check` clean — 124 commands, 101 on allowlist (was 104)