### PR TITLE
docs(dlp-dictionaries): add live input/output examples

### DIFF
--- a/.changeset/docs-dlp-dictionaries-examples.md
+++ b/.changeset/docs-dlp-dictionaries-examples.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Add live input/output examples to `docs/cli/runtime/dlp/dictionaries.md` for `list`, `get`, and `delete` (pretty/JSON/YAML formats where applicable). `create`, `replace`, and `patch` remain on the docs allowlist pending upstream fix tracked in #99.

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -36,12 +36,12 @@ runtime dlp profiles get
 runtime dlp profiles replace
 runtime dlp profiles patch
 runtime dlp profiles delete
-runtime dlp dictionaries list
+# Blocked by upstream — see https://github.com/cdot65/prisma-airs-cli/issues/99
 runtime dlp dictionaries create
-runtime dlp dictionaries get
+# Blocked by upstream — see https://github.com/cdot65/prisma-airs-cli/issues/99
 runtime dlp dictionaries replace
+# Blocked by upstream — see https://github.com/cdot65/prisma-airs-cli/issues/99
 runtime dlp dictionaries patch
-runtime dlp dictionaries delete
 redteam abort
 redteam eula status
 redteam eula content

--- a/docs/cli/examples/runtime.yaml
+++ b/docs/cli/examples/runtime.yaml
@@ -208,3 +208,367 @@
       input: airs runtime dlp patterns delete 000000000000000000000003
       output: |
         archived 000000000000000000000003
+
+"runtime dlp dictionaries list":
+  examples:
+    - note: Pretty output (default — JSON envelope)
+      input: airs runtime dlp dictionaries list --size 2 --sort name,asc
+      output: |
+        {
+          "content": [
+            {
+              "id": "000000000000000000000001",
+              "name": "Allergy",
+              "description": "Most common allergies",
+              "category": "Medical",
+              "region_name": "GLOBAL",
+              "type": "predefined",
+              "is_case_sensitive": false,
+              "is_parent_managed": false,
+              "detection_technique": "dictionary",
+              "detection_sub_technique": null,
+              "dictionary_metadata": {
+                "number_of_keywords": 0,
+                "original_file_name": "",
+                "original_file_size_in_byte": 0
+              },
+              "keywords": null,
+              "tags": {
+                "classification": [
+                  "pab"
+                ]
+              },
+              "attributes": null,
+              "audit_metadata": {
+                "created_at": 1761657319488,
+                "created_by": "System",
+                "updated_at": 1761657319488,
+                "updated_by": "System"
+              }
+            },
+            {
+              "id": "000000000000000000000002",
+              "name": "Auto Insurance Providers",
+              "description": "List of most used auto insurance providers",
+              "category": "Insurance Providers",
+              "region_name": "GLOBAL",
+              "type": "predefined",
+              "is_case_sensitive": false,
+              "is_parent_managed": false,
+              "detection_technique": "dictionary",
+              "detection_sub_technique": null,
+              "dictionary_metadata": {
+                "number_of_keywords": 0,
+                "original_file_name": "",
+                "original_file_size_in_byte": 0
+              },
+              "keywords": null,
+              "tags": {
+                "classification": [
+                  "pab"
+                ]
+              },
+              "attributes": null,
+              "audit_metadata": {
+                "created_at": 1761657319489,
+                "created_by": "System",
+                "updated_at": 1761657319489,
+                "updated_by": "System"
+              }
+            }
+          ],
+          "empty": false,
+          "first": true,
+          "last": false,
+          "number": 0,
+          "pageable": {
+            "offset": 0,
+            "paged": true,
+            "unpaged": false,
+            "sort": {
+              "empty": true,
+              "sorted": false,
+              "unsorted": true
+            },
+            "page_number": 0,
+            "page_size": 2
+          },
+          "size": 2,
+          "sort": {
+            "empty": true,
+            "sorted": false,
+            "unsorted": true
+          },
+          "total_pages": 16,
+          "number_of_elements": 2,
+          "total_elements": 31
+        }
+    - note: JSON output (explicit)
+      input: airs runtime dlp dictionaries list --size 2 --sort name,asc --output json
+      output: |
+        {
+          "content": [
+            {
+              "id": "000000000000000000000001",
+              "name": "Allergy",
+              "description": "Most common allergies",
+              "category": "Medical",
+              "region_name": "GLOBAL",
+              "type": "predefined",
+              "is_case_sensitive": false,
+              "is_parent_managed": false,
+              "detection_technique": "dictionary",
+              "detection_sub_technique": null,
+              "dictionary_metadata": {
+                "number_of_keywords": 0,
+                "original_file_name": "",
+                "original_file_size_in_byte": 0
+              },
+              "keywords": null,
+              "tags": {
+                "classification": [
+                  "pab"
+                ]
+              },
+              "attributes": null,
+              "audit_metadata": {
+                "created_at": 1761657319488,
+                "created_by": "System",
+                "updated_at": 1761657319488,
+                "updated_by": "System"
+              }
+            },
+            {
+              "id": "000000000000000000000002",
+              "name": "Auto Insurance Providers",
+              "description": "List of most used auto insurance providers",
+              "category": "Insurance Providers",
+              "region_name": "GLOBAL",
+              "type": "predefined",
+              "is_case_sensitive": false,
+              "is_parent_managed": false,
+              "detection_technique": "dictionary",
+              "detection_sub_technique": null,
+              "dictionary_metadata": {
+                "number_of_keywords": 0,
+                "original_file_name": "",
+                "original_file_size_in_byte": 0
+              },
+              "keywords": null,
+              "tags": {
+                "classification": [
+                  "pab"
+                ]
+              },
+              "attributes": null,
+              "audit_metadata": {
+                "created_at": 1761657319489,
+                "created_by": "System",
+                "updated_at": 1761657319489,
+                "updated_by": "System"
+              }
+            }
+          ],
+          "empty": false,
+          "first": true,
+          "last": false,
+          "number": 0,
+          "pageable": {
+            "offset": 0,
+            "paged": true,
+            "unpaged": false,
+            "sort": {
+              "empty": true,
+              "sorted": false,
+              "unsorted": true
+            },
+            "page_number": 0,
+            "page_size": 2
+          },
+          "size": 2,
+          "sort": {
+            "empty": true,
+            "sorted": false,
+            "unsorted": true
+          },
+          "total_pages": 16,
+          "number_of_elements": 2,
+          "total_elements": 31
+        }
+    - note: YAML output
+      input: airs runtime dlp dictionaries list --size 2 --sort name,asc --output yaml
+      output: |
+        content:
+          - id: 000000000000000000000001
+            name: Allergy
+            description: Most common allergies
+            category: Medical
+            region_name: GLOBAL
+            type: predefined
+            is_case_sensitive: false
+            is_parent_managed: false
+            detection_technique: dictionary
+            detection_sub_technique: null
+            dictionary_metadata:
+              number_of_keywords: 0
+              original_file_name: ''
+              original_file_size_in_byte: 0
+            keywords: null
+            tags:
+              classification:
+                - pab
+            attributes: null
+            audit_metadata:
+              created_at: 1761657319488
+              created_by: System
+              updated_at: 1761657319488
+              updated_by: System
+          - id: 000000000000000000000002
+            name: Auto Insurance Providers
+            description: List of most used auto insurance providers
+            category: Insurance Providers
+            region_name: GLOBAL
+            type: predefined
+            is_case_sensitive: false
+            is_parent_managed: false
+            detection_technique: dictionary
+            detection_sub_technique: null
+            dictionary_metadata:
+              number_of_keywords: 0
+              original_file_name: ''
+              original_file_size_in_byte: 0
+            keywords: null
+            tags:
+              classification:
+                - pab
+            attributes: null
+            audit_metadata:
+              created_at: 1761657319489
+              created_by: System
+              updated_at: 1761657319489
+              updated_by: System
+        empty: false
+        first: true
+        last: false
+        number: 0
+        pageable:
+          offset: 0
+          paged: true
+          unpaged: false
+          sort:
+            empty: true
+            sorted: false
+            unsorted: true
+          page_number: 0
+          page_size: 2
+        size: 2
+        sort:
+          empty: true
+          sorted: false
+          unsorted: true
+        total_pages: 16
+        number_of_elements: 2
+        total_elements: 31
+
+"runtime dlp dictionaries get":
+  examples:
+    - note: Pretty output (default — JSON object)
+      input: airs runtime dlp dictionaries get 000000000000000000000001
+      output: |
+        {
+          "id": "000000000000000000000001",
+          "name": "Allergy",
+          "description": "Most common allergies",
+          "category": "Medical",
+          "region_name": "GLOBAL",
+          "type": "predefined",
+          "is_case_sensitive": false,
+          "is_parent_managed": false,
+          "detection_technique": "dictionary",
+          "detection_sub_technique": null,
+          "dictionary_metadata": {
+            "number_of_keywords": 85,
+            "original_file_name": "",
+            "original_file_size_in_byte": 0
+          },
+          "keywords": null,
+          "tags": {
+            "classification": [
+              "pab"
+            ]
+          },
+          "attributes": null,
+          "audit_metadata": {
+            "created_at": 1761657319488,
+            "created_by": null,
+            "updated_at": 1761657319488,
+            "updated_by": null
+          }
+        }
+    - note: JSON output (explicit)
+      input: airs runtime dlp dictionaries get 000000000000000000000001 --output json
+      output: |
+        {
+          "id": "000000000000000000000001",
+          "name": "Allergy",
+          "description": "Most common allergies",
+          "category": "Medical",
+          "region_name": "GLOBAL",
+          "type": "predefined",
+          "is_case_sensitive": false,
+          "is_parent_managed": false,
+          "detection_technique": "dictionary",
+          "detection_sub_technique": null,
+          "dictionary_metadata": {
+            "number_of_keywords": 85,
+            "original_file_name": "",
+            "original_file_size_in_byte": 0
+          },
+          "keywords": null,
+          "tags": {
+            "classification": [
+              "pab"
+            ]
+          },
+          "attributes": null,
+          "audit_metadata": {
+            "created_at": 1761657319488,
+            "created_by": null,
+            "updated_at": 1761657319488,
+            "updated_by": null
+          }
+        }
+    - note: YAML output
+      input: airs runtime dlp dictionaries get 000000000000000000000001 --output yaml
+      output: |
+        id: 000000000000000000000001
+        name: Allergy
+        description: Most common allergies
+        category: Medical
+        region_name: GLOBAL
+        type: predefined
+        is_case_sensitive: false
+        is_parent_managed: false
+        detection_technique: dictionary
+        detection_sub_technique: null
+        dictionary_metadata:
+          number_of_keywords: 85
+          original_file_name: ''
+          original_file_size_in_byte: 0
+        keywords: null
+        tags:
+          classification:
+            - pab
+        attributes: null
+        audit_metadata:
+          created_at: 1761657319488
+          created_by: null
+          updated_at: 1761657319488
+          updated_by: null
+
+"runtime dlp dictionaries delete":
+  examples:
+    - note: Soft-delete a dictionary by id (API returns 204; CLI prints confirmation)
+      input: airs runtime dlp dictionaries delete 000000000000000000000001
+      output: |
+        deleted 000000000000000000000001

--- a/docs/cli/runtime/dlp/dictionaries.md
+++ b/docs/cli/runtime/dlp/dictionaries.md
@@ -21,8 +21,281 @@ airs runtime dlp dictionaries list [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default — JSON envelope)*
+
+```bash
+airs runtime dlp dictionaries list --size 2 --sort name,asc
+```
+
+```text
+{
+  "content": [
+    {
+      "id": "000000000000000000000001",
+      "name": "Allergy",
+      "description": "Most common allergies",
+      "category": "Medical",
+      "region_name": "GLOBAL",
+      "type": "predefined",
+      "is_case_sensitive": false,
+      "is_parent_managed": false,
+      "detection_technique": "dictionary",
+      "detection_sub_technique": null,
+      "dictionary_metadata": {
+        "number_of_keywords": 0,
+        "original_file_name": "",
+        "original_file_size_in_byte": 0
+      },
+      "keywords": null,
+      "tags": {
+        "classification": [
+          "pab"
+        ]
+      },
+      "attributes": null,
+      "audit_metadata": {
+        "created_at": 1761657319488,
+        "created_by": "System",
+        "updated_at": 1761657319488,
+        "updated_by": "System"
+      }
+    },
+    {
+      "id": "000000000000000000000002",
+      "name": "Auto Insurance Providers",
+      "description": "List of most used auto insurance providers",
+      "category": "Insurance Providers",
+      "region_name": "GLOBAL",
+      "type": "predefined",
+      "is_case_sensitive": false,
+      "is_parent_managed": false,
+      "detection_technique": "dictionary",
+      "detection_sub_technique": null,
+      "dictionary_metadata": {
+        "number_of_keywords": 0,
+        "original_file_name": "",
+        "original_file_size_in_byte": 0
+      },
+      "keywords": null,
+      "tags": {
+        "classification": [
+          "pab"
+        ]
+      },
+      "attributes": null,
+      "audit_metadata": {
+        "created_at": 1761657319489,
+        "created_by": "System",
+        "updated_at": 1761657319489,
+        "updated_by": "System"
+      }
+    }
+  ],
+  "empty": false,
+  "first": true,
+  "last": false,
+  "number": 0,
+  "pageable": {
+    "offset": 0,
+    "paged": true,
+    "unpaged": false,
+    "sort": {
+      "empty": true,
+      "sorted": false,
+      "unsorted": true
+    },
+    "page_number": 0,
+    "page_size": 2
+  },
+  "size": 2,
+  "sort": {
+    "empty": true,
+    "sorted": false,
+    "unsorted": true
+  },
+  "total_pages": 16,
+  "number_of_elements": 2,
+  "total_elements": 31
+}
+```
+
+*JSON output (explicit)*
+
+```bash
+airs runtime dlp dictionaries list --size 2 --sort name,asc --output json
+```
+
+```text
+{
+  "content": [
+    {
+      "id": "000000000000000000000001",
+      "name": "Allergy",
+      "description": "Most common allergies",
+      "category": "Medical",
+      "region_name": "GLOBAL",
+      "type": "predefined",
+      "is_case_sensitive": false,
+      "is_parent_managed": false,
+      "detection_technique": "dictionary",
+      "detection_sub_technique": null,
+      "dictionary_metadata": {
+        "number_of_keywords": 0,
+        "original_file_name": "",
+        "original_file_size_in_byte": 0
+      },
+      "keywords": null,
+      "tags": {
+        "classification": [
+          "pab"
+        ]
+      },
+      "attributes": null,
+      "audit_metadata": {
+        "created_at": 1761657319488,
+        "created_by": "System",
+        "updated_at": 1761657319488,
+        "updated_by": "System"
+      }
+    },
+    {
+      "id": "000000000000000000000002",
+      "name": "Auto Insurance Providers",
+      "description": "List of most used auto insurance providers",
+      "category": "Insurance Providers",
+      "region_name": "GLOBAL",
+      "type": "predefined",
+      "is_case_sensitive": false,
+      "is_parent_managed": false,
+      "detection_technique": "dictionary",
+      "detection_sub_technique": null,
+      "dictionary_metadata": {
+        "number_of_keywords": 0,
+        "original_file_name": "",
+        "original_file_size_in_byte": 0
+      },
+      "keywords": null,
+      "tags": {
+        "classification": [
+          "pab"
+        ]
+      },
+      "attributes": null,
+      "audit_metadata": {
+        "created_at": 1761657319489,
+        "created_by": "System",
+        "updated_at": 1761657319489,
+        "updated_by": "System"
+      }
+    }
+  ],
+  "empty": false,
+  "first": true,
+  "last": false,
+  "number": 0,
+  "pageable": {
+    "offset": 0,
+    "paged": true,
+    "unpaged": false,
+    "sort": {
+      "empty": true,
+      "sorted": false,
+      "unsorted": true
+    },
+    "page_number": 0,
+    "page_size": 2
+  },
+  "size": 2,
+  "sort": {
+    "empty": true,
+    "sorted": false,
+    "unsorted": true
+  },
+  "total_pages": 16,
+  "number_of_elements": 2,
+  "total_elements": 31
+}
+```
+
+*YAML output*
+
+```bash
+airs runtime dlp dictionaries list --size 2 --sort name,asc --output yaml
+```
+
+```text
+content:
+  - id: 000000000000000000000001
+    name: Allergy
+    description: Most common allergies
+    category: Medical
+    region_name: GLOBAL
+    type: predefined
+    is_case_sensitive: false
+    is_parent_managed: false
+    detection_technique: dictionary
+    detection_sub_technique: null
+    dictionary_metadata:
+      number_of_keywords: 0
+      original_file_name: ''
+      original_file_size_in_byte: 0
+    keywords: null
+    tags:
+      classification:
+        - pab
+    attributes: null
+    audit_metadata:
+      created_at: 1761657319488
+      created_by: System
+      updated_at: 1761657319488
+      updated_by: System
+  - id: 000000000000000000000002
+    name: Auto Insurance Providers
+    description: List of most used auto insurance providers
+    category: Insurance Providers
+    region_name: GLOBAL
+    type: predefined
+    is_case_sensitive: false
+    is_parent_managed: false
+    detection_technique: dictionary
+    detection_sub_technique: null
+    dictionary_metadata:
+      number_of_keywords: 0
+      original_file_name: ''
+      original_file_size_in_byte: 0
+    keywords: null
+    tags:
+      classification:
+        - pab
+    attributes: null
+    audit_metadata:
+      created_at: 1761657319489
+      created_by: System
+      updated_at: 1761657319489
+      updated_by: System
+empty: false
+first: true
+last: false
+number: 0
+pageable:
+  offset: 0
+  paged: true
+  unpaged: false
+  sort:
+    empty: true
+    sorted: false
+    unsorted: true
+  page_number: 0
+  page_size: 2
+size: 2
+sort:
+  empty: true
+  sorted: false
+  unsorted: true
+total_pages: 16
+number_of_elements: 2
+total_elements: 31
+```
 
 ---
 
@@ -75,8 +348,116 @@ airs runtime dlp dictionaries get [options] <id>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default — JSON object)*
+
+```bash
+airs runtime dlp dictionaries get 000000000000000000000001
+```
+
+```text
+{
+  "id": "000000000000000000000001",
+  "name": "Allergy",
+  "description": "Most common allergies",
+  "category": "Medical",
+  "region_name": "GLOBAL",
+  "type": "predefined",
+  "is_case_sensitive": false,
+  "is_parent_managed": false,
+  "detection_technique": "dictionary",
+  "detection_sub_technique": null,
+  "dictionary_metadata": {
+    "number_of_keywords": 85,
+    "original_file_name": "",
+    "original_file_size_in_byte": 0
+  },
+  "keywords": null,
+  "tags": {
+    "classification": [
+      "pab"
+    ]
+  },
+  "attributes": null,
+  "audit_metadata": {
+    "created_at": 1761657319488,
+    "created_by": null,
+    "updated_at": 1761657319488,
+    "updated_by": null
+  }
+}
+```
+
+*JSON output (explicit)*
+
+```bash
+airs runtime dlp dictionaries get 000000000000000000000001 --output json
+```
+
+```text
+{
+  "id": "000000000000000000000001",
+  "name": "Allergy",
+  "description": "Most common allergies",
+  "category": "Medical",
+  "region_name": "GLOBAL",
+  "type": "predefined",
+  "is_case_sensitive": false,
+  "is_parent_managed": false,
+  "detection_technique": "dictionary",
+  "detection_sub_technique": null,
+  "dictionary_metadata": {
+    "number_of_keywords": 85,
+    "original_file_name": "",
+    "original_file_size_in_byte": 0
+  },
+  "keywords": null,
+  "tags": {
+    "classification": [
+      "pab"
+    ]
+  },
+  "attributes": null,
+  "audit_metadata": {
+    "created_at": 1761657319488,
+    "created_by": null,
+    "updated_at": 1761657319488,
+    "updated_by": null
+  }
+}
+```
+
+*YAML output*
+
+```bash
+airs runtime dlp dictionaries get 000000000000000000000001 --output yaml
+```
+
+```text
+id: 000000000000000000000001
+name: Allergy
+description: Most common allergies
+category: Medical
+region_name: GLOBAL
+type: predefined
+is_case_sensitive: false
+is_parent_managed: false
+detection_technique: dictionary
+detection_sub_technique: null
+dictionary_metadata:
+  number_of_keywords: 85
+  original_file_name: ''
+  original_file_size_in_byte: 0
+keywords: null
+tags:
+  classification:
+    - pab
+attributes: null
+audit_metadata:
+  created_at: 1761657319488
+  created_by: null
+  updated_at: 1761657319488
+  updated_by: null
+```
 
 ---
 
@@ -153,5 +534,12 @@ airs runtime dlp dictionaries delete [options] <id>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Soft-delete a dictionary by id (API returns 204; CLI prints confirmation)*
+
+```bash
+airs runtime dlp dictionaries delete 000000000000000000000001
+```
+
+```text
+deleted 000000000000000000000001
+```


### PR DESCRIPTION
## Summary

- Sidecar entries in `docs/cli/examples/runtime.yaml` for `runtime dlp dictionaries list`, `get`, `delete`.
  - `list` and `get`: pretty / JSON / YAML
  - `delete`: single example (204 → CLI confirmation)
- `create`, `replace`, `patch` remain on `.missing-allowlist` with `# Blocked by upstream — see #99` comments.
- Regenerated `docs/cli/runtime/dlp/dictionaries.md` via `pnpm docs:gen`.
- `pnpm docs:check` passes (124 commands, 101 on allowlist).
- Changeset added (patch).

Captures done from `~/development/cdot65/prisma-airs-cli` (repo `.env` loaded). MongoDB ObjectIDs redacted to `000000000000000000000001..02`.

Closes #85. Part of epic #83.

## Test plan

- [x] `pnpm docs:gen` — regenerates only `dictionaries.md`
- [x] `pnpm format` — no fixes applied
- [x] `pnpm docs:check` — passes
- [ ] CI green