### PR TITLE
docs(dlp-profiles-docs): add live input/output examples

### DIFF
--- a/.changeset/docs-dlp-profiles-docs-examples.md
+++ b/.changeset/docs-dlp-profiles-docs-examples.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Add live input/output examples to the `airs runtime dlp profiles` reference page. `list` now renders Pretty + JSON + YAML captures from a live tenant; `delete` shows the CLI stub output describing the soft-delete patch idiom. `create`, `replace`, `patch`, and `get` remain on the `.missing-allowlist` with inline comments linking the upstream tracking issues (#101 for create/replace/patch, #80 for get) — examples will land when the upstream DLP API stops returning 400 on those endpoints.

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -30,12 +30,14 @@ runtime dlp patterns get
 runtime dlp patterns replace
 # Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/98
 runtime dlp patterns patch
-runtime dlp profiles list
+# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/101
 runtime dlp profiles create
+# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/80
 runtime dlp profiles get
+# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/101
 runtime dlp profiles replace
+# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/101
 runtime dlp profiles patch
-runtime dlp profiles delete
 # Blocked by upstream — see https://github.com/cdot65/prisma-airs-cli/issues/99
 runtime dlp dictionaries create
 # Blocked by upstream — see https://github.com/cdot65/prisma-airs-cli/issues/99

--- a/docs/cli/examples/runtime.yaml
+++ b/docs/cli/examples/runtime.yaml
@@ -572,3 +572,188 @@
       input: airs runtime dlp dictionaries delete 000000000000000000000001
       output: |
         deleted 000000000000000000000001
+
+"runtime dlp profiles list":
+  examples:
+    - note: Pretty output (default — DLP profiles list has no custom renderer, so pretty == JSON)
+      input: airs runtime dlp profiles list --size 2 --sort id,asc
+      output: |
+        {
+          "content": [
+            {
+              "id": "00000001",
+              "name": "Bulk CCN",
+              "description": "Default profile for Bulk CCN",
+              "tenant_id": "<tenant-id>",
+              "type": "predefined",
+              "profile_status": "active",
+              "profile_type": "basic",
+              "is_granular_data_profile": false,
+              "is_parent_managed": false,
+              "version": 1,
+              "advance_data_patterns_rule_request": null,
+              "detection_rules": null,
+              "audit_metadata": {
+                "created_at": 1761657319421,
+                "created_by": "System",
+                "updated_at": 1761657319421,
+                "updated_by": "System"
+              }
+            },
+            {
+              "id": "00000002",
+              "name": "CCPA",
+              "description": "Default profile for CCPA",
+              "tenant_id": "<tenant-id>",
+              "type": "predefined",
+              "profile_status": "active",
+              "profile_type": "advanced",
+              "is_granular_data_profile": false,
+              "is_parent_managed": false,
+              "version": 1,
+              "advance_data_patterns_rule_request": [
+                "(Tax Id - US - TIN high more_than_equal_to 1) or (Credit Card Number high more_than_equal_to 1 and Magnetic Stripe Information high more_than_equal_to 1) or (National Id - US Social Security Number - SSN high more_than_equal_to 1)"
+              ],
+              "detection_rules": null,
+              "audit_metadata": {
+                "created_at": 1761657319427,
+                "created_by": "System",
+                "updated_at": 1761657319427,
+                "updated_by": "System"
+              }
+            }
+          ],
+          "page": {
+            "number": 0,
+            "size": 2,
+            "total_pages": 15,
+            "total_elements": 30,
+            "number_of_elements": 2,
+            "first": true,
+            "last": false,
+            "empty": false
+          }
+        }
+    - note: JSON output
+      input: airs runtime dlp profiles list --size 2 --sort id,asc --output json
+      output: |
+        {
+          "content": [
+            {
+              "id": "00000001",
+              "name": "Bulk CCN",
+              "description": "Default profile for Bulk CCN",
+              "tenant_id": "<tenant-id>",
+              "type": "predefined",
+              "profile_status": "active",
+              "profile_type": "basic",
+              "is_granular_data_profile": false,
+              "is_parent_managed": false,
+              "version": 1,
+              "advance_data_patterns_rule_request": null,
+              "detection_rules": null,
+              "audit_metadata": {
+                "created_at": 1761657319421,
+                "created_by": "System",
+                "updated_at": 1761657319421,
+                "updated_by": "System"
+              }
+            },
+            {
+              "id": "00000002",
+              "name": "CCPA",
+              "description": "Default profile for CCPA",
+              "tenant_id": "<tenant-id>",
+              "type": "predefined",
+              "profile_status": "active",
+              "profile_type": "advanced",
+              "is_granular_data_profile": false,
+              "is_parent_managed": false,
+              "version": 1,
+              "advance_data_patterns_rule_request": [
+                "(Tax Id - US - TIN high more_than_equal_to 1) or (Credit Card Number high more_than_equal_to 1 and Magnetic Stripe Information high more_than_equal_to 1) or (National Id - US Social Security Number - SSN high more_than_equal_to 1)"
+              ],
+              "detection_rules": null,
+              "audit_metadata": {
+                "created_at": 1761657319427,
+                "created_by": "System",
+                "updated_at": 1761657319427,
+                "updated_by": "System"
+              }
+            }
+          ],
+          "page": {
+            "number": 0,
+            "size": 2,
+            "total_pages": 15,
+            "total_elements": 30,
+            "number_of_elements": 2,
+            "first": true,
+            "last": false,
+            "empty": false
+          }
+        }
+    - note: YAML output
+      input: airs runtime dlp profiles list --size 2 --sort id,asc --output yaml
+      output: |
+        content:
+          - id: '00000001'
+            name: Bulk CCN
+            description: Default profile for Bulk CCN
+            tenant_id: <tenant-id>
+            type: predefined
+            profile_status: active
+            profile_type: basic
+            is_granular_data_profile: false
+            is_parent_managed: false
+            version: 1
+            advance_data_patterns_rule_request: null
+            detection_rules: null
+            audit_metadata:
+              created_at: 1761657319421
+              created_by: System
+              updated_at: 1761657319421
+              updated_by: System
+          - id: '00000002'
+            name: CCPA
+            description: Default profile for CCPA
+            tenant_id: <tenant-id>
+            type: predefined
+            profile_status: active
+            profile_type: advanced
+            is_granular_data_profile: false
+            is_parent_managed: false
+            version: 1
+            advance_data_patterns_rule_request:
+              - >-
+                (Tax Id - US - TIN high more_than_equal_to 1) or (Credit Card
+                Number high more_than_equal_to 1 and Magnetic Stripe Information
+                high more_than_equal_to 1) or (National Id - US Social Security
+                Number - SSN high more_than_equal_to 1)
+            detection_rules: null
+            audit_metadata:
+              created_at: 1761657319427
+              created_by: System
+              updated_at: 1761657319427
+              updated_by: System
+        page:
+          number: 0
+          size: 2
+          total_pages: 15
+          total_elements: 30
+          number_of_elements: 2
+          first: true
+          last: false
+          empty: false
+
+"runtime dlp profiles delete":
+  examples:
+    - note: Stub — DLP data profiles have no DELETE endpoint; soft-delete via patch
+      input: airs runtime dlp profiles delete 00000001
+      output: |
+        This DLP API has no DELETE for data profiles.
+        To soft-delete, fetch the profile to get its name + profile_type, then patch:
+
+          airs runtime dlp profiles get 00000001 --output json
+          airs runtime dlp profiles patch 00000001 --set profile_status='"deleted"' \
+            --set name='"<existing-name>"' --set profile_type='"<existing-type>"'

--- a/docs/cli/runtime/dlp/profiles.md
+++ b/docs/cli/runtime/dlp/profiles.md
@@ -19,8 +19,193 @@ airs runtime dlp profiles list [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default — DLP profiles list has no custom renderer, so pretty == JSON)*
+
+```bash
+airs runtime dlp profiles list --size 2 --sort id,asc
+```
+
+```text
+{
+  "content": [
+    {
+      "id": "00000001",
+      "name": "Bulk CCN",
+      "description": "Default profile for Bulk CCN",
+      "tenant_id": "<tenant-id>",
+      "type": "predefined",
+      "profile_status": "active",
+      "profile_type": "basic",
+      "is_granular_data_profile": false,
+      "is_parent_managed": false,
+      "version": 1,
+      "advance_data_patterns_rule_request": null,
+      "detection_rules": null,
+      "audit_metadata": {
+        "created_at": 1761657319421,
+        "created_by": "System",
+        "updated_at": 1761657319421,
+        "updated_by": "System"
+      }
+    },
+    {
+      "id": "00000002",
+      "name": "CCPA",
+      "description": "Default profile for CCPA",
+      "tenant_id": "<tenant-id>",
+      "type": "predefined",
+      "profile_status": "active",
+      "profile_type": "advanced",
+      "is_granular_data_profile": false,
+      "is_parent_managed": false,
+      "version": 1,
+      "advance_data_patterns_rule_request": [
+        "(Tax Id - US - TIN high more_than_equal_to 1) or (Credit Card Number high more_than_equal_to 1 and Magnetic Stripe Information high more_than_equal_to 1) or (National Id - US Social Security Number - SSN high more_than_equal_to 1)"
+      ],
+      "detection_rules": null,
+      "audit_metadata": {
+        "created_at": 1761657319427,
+        "created_by": "System",
+        "updated_at": 1761657319427,
+        "updated_by": "System"
+      }
+    }
+  ],
+  "page": {
+    "number": 0,
+    "size": 2,
+    "total_pages": 15,
+    "total_elements": 30,
+    "number_of_elements": 2,
+    "first": true,
+    "last": false,
+    "empty": false
+  }
+}
+```
+
+*JSON output*
+
+```bash
+airs runtime dlp profiles list --size 2 --sort id,asc --output json
+```
+
+```text
+{
+  "content": [
+    {
+      "id": "00000001",
+      "name": "Bulk CCN",
+      "description": "Default profile for Bulk CCN",
+      "tenant_id": "<tenant-id>",
+      "type": "predefined",
+      "profile_status": "active",
+      "profile_type": "basic",
+      "is_granular_data_profile": false,
+      "is_parent_managed": false,
+      "version": 1,
+      "advance_data_patterns_rule_request": null,
+      "detection_rules": null,
+      "audit_metadata": {
+        "created_at": 1761657319421,
+        "created_by": "System",
+        "updated_at": 1761657319421,
+        "updated_by": "System"
+      }
+    },
+    {
+      "id": "00000002",
+      "name": "CCPA",
+      "description": "Default profile for CCPA",
+      "tenant_id": "<tenant-id>",
+      "type": "predefined",
+      "profile_status": "active",
+      "profile_type": "advanced",
+      "is_granular_data_profile": false,
+      "is_parent_managed": false,
+      "version": 1,
+      "advance_data_patterns_rule_request": [
+        "(Tax Id - US - TIN high more_than_equal_to 1) or (Credit Card Number high more_than_equal_to 1 and Magnetic Stripe Information high more_than_equal_to 1) or (National Id - US Social Security Number - SSN high more_than_equal_to 1)"
+      ],
+      "detection_rules": null,
+      "audit_metadata": {
+        "created_at": 1761657319427,
+        "created_by": "System",
+        "updated_at": 1761657319427,
+        "updated_by": "System"
+      }
+    }
+  ],
+  "page": {
+    "number": 0,
+    "size": 2,
+    "total_pages": 15,
+    "total_elements": 30,
+    "number_of_elements": 2,
+    "first": true,
+    "last": false,
+    "empty": false
+  }
+}
+```
+
+*YAML output*
+
+```bash
+airs runtime dlp profiles list --size 2 --sort id,asc --output yaml
+```
+
+```text
+content:
+  - id: '00000001'
+    name: Bulk CCN
+    description: Default profile for Bulk CCN
+    tenant_id: <tenant-id>
+    type: predefined
+    profile_status: active
+    profile_type: basic
+    is_granular_data_profile: false
+    is_parent_managed: false
+    version: 1
+    advance_data_patterns_rule_request: null
+    detection_rules: null
+    audit_metadata:
+      created_at: 1761657319421
+      created_by: System
+      updated_at: 1761657319421
+      updated_by: System
+  - id: '00000002'
+    name: CCPA
+    description: Default profile for CCPA
+    tenant_id: <tenant-id>
+    type: predefined
+    profile_status: active
+    profile_type: advanced
+    is_granular_data_profile: false
+    is_parent_managed: false
+    version: 1
+    advance_data_patterns_rule_request:
+      - >-
+        (Tax Id - US - TIN high more_than_equal_to 1) or (Credit Card
+        Number high more_than_equal_to 1 and Magnetic Stripe Information
+        high more_than_equal_to 1) or (National Id - US Social Security
+        Number - SSN high more_than_equal_to 1)
+    detection_rules: null
+    audit_metadata:
+      created_at: 1761657319427
+      created_by: System
+      updated_at: 1761657319427
+      updated_by: System
+page:
+  number: 0
+  size: 2
+  total_pages: 15
+  total_elements: 30
+  number_of_elements: 2
+  first: true
+  last: false
+  empty: false
+```
 
 ---
 
@@ -155,5 +340,17 @@ airs runtime dlp profiles delete [options] <id>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Stub — DLP data profiles have no DELETE endpoint; soft-delete via patch*
+
+```bash
+airs runtime dlp profiles delete 00000001
+```
+
+```text
+This DLP API has no DELETE for data profiles.
+To soft-delete, fetch the profile to get its name + profile_type, then patch:
+
+  airs runtime dlp profiles get 00000001 --output json
+  airs runtime dlp profiles patch 00000001 --set profile_status='"deleted"' \
+    --set name='"<existing-name>"' --set profile_type='"<existing-type>"'
+```


### PR DESCRIPTION
Closes #87. Part of epic #83.

## Summary
- `list`: pretty + JSON + YAML captures from a live tenant (Bulk CCN, CCPA — predefined profiles).
- `delete`: stub output documenting the soft-delete patch idiom (no DELETE endpoint upstream).
- `create`, `replace`, `patch` blocked by upstream API 400 — left on `.missing-allowlist` with comment linking #101.
- `get` blocked by upstream API 400 — left on `.missing-allowlist` with comment linking #80.

## Test plan
- [x] \`pnpm docs:gen\` clean
- [x] \`pnpm format\` clean
- [x] \`pnpm docs:check\` clean (124 commands, 99 on allowlist)
- [ ] CI green