### PR TITLE
docs(dlp-filtering-profiles): add live input/output examples

### DIFF
--- a/.changeset/docs-dlp-filtering-profiles-examples.md
+++ b/.changeset/docs-dlp-filtering-profiles-examples.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+docs(cli): live input/output examples for `runtime dlp filtering-profiles list`. `get` and `replace` remain on the missing-allowlist with comments linking the tracking issues ([#105](https://github.com/cdot65/prisma-airs-cli/issues/105) for `get` JSON/YAML key-mangling, [#107](https://github.com/cdot65/prisma-airs-cli/issues/107) for `replace` upstream API 400) — those page sections keep the "Example needed" placeholder until the bugs ship fixes.

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -16,8 +16,9 @@ runtime resume-poll
 runtime scan-logs query
 # Blocked by SDK — see https://github.com/cdot65/prisma-airs-sdk/issues/165
 runtime topics delete
-runtime dlp filtering-profiles list
+# Blocked by CLI bug — see https://github.com/cdot65/prisma-airs-cli/issues/105
 runtime dlp filtering-profiles get
+# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/107
 runtime dlp filtering-profiles replace
 # Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/80
 runtime dlp patterns get

--- a/docs/cli/examples/runtime.yaml
+++ b/docs/cli/examples/runtime.yaml
@@ -1258,3 +1258,67 @@
                           }
                         ]
                       }
+
+"runtime dlp filtering-profiles list":
+  examples:
+    - note: Pretty output (default)
+      input: airs runtime dlp filtering-profiles list --size 2 --sort name,asc
+      output: |
+        Data Filtering Profiles:
+
+        000000000000000000000001
+          Bulk CCN  predefined dir:c2s sev:low v1
+        000000000000000000000002
+          CCPA  predefined dir:c2s sev:low v1
+
+        page=0 size=2 returned=2 total=29
+    - note: JSON output
+      input: airs runtime dlp filtering-profiles list --size 2 --sort name,asc --output json
+      output: |
+        {
+          "items": [
+            {
+              "id": "000000000000000000000001",
+              "name": "Bulk CCN",
+              "type": "predefined",
+              "direction": "c2s",
+              "severity": "low",
+              "version": 1
+            },
+            {
+              "id": "000000000000000000000002",
+              "name": "CCPA",
+              "type": "predefined",
+              "direction": "c2s",
+              "severity": "low",
+              "version": 1
+            }
+          ],
+          "page": {
+            "number": 0,
+            "size": 2,
+            "total": 29,
+            "returned": 2
+          }
+        }
+    - note: YAML output
+      input: airs runtime dlp filtering-profiles list --size 2 --sort name,asc --output yaml
+      output: |
+        items:
+          - id: '000000000000000000000001'
+            name: Bulk CCN
+            type: predefined
+            direction: c2s
+            severity: low
+            version: 1
+          - id: '000000000000000000000002'
+            name: CCPA
+            type: predefined
+            direction: c2s
+            severity: low
+            version: 1
+        page:
+          number: 0
+          size: 2
+          total: 29
+          returned: 2

--- a/docs/cli/runtime/dlp/filtering-profiles.md
+++ b/docs/cli/runtime/dlp/filtering-profiles.md
@@ -19,8 +19,84 @@ airs runtime dlp filtering-profiles list [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default)*
+
+```bash
+airs runtime dlp filtering-profiles list --size 2 --sort name,asc
+```
+
+```text
+Data Filtering Profiles:
+
+000000000000000000000001
+  Bulk CCN  predefined dir:c2s sev:low v1
+000000000000000000000002
+  CCPA  predefined dir:c2s sev:low v1
+
+page=0 size=2 returned=2 total=29
+```
+
+*JSON output*
+
+```bash
+airs runtime dlp filtering-profiles list --size 2 --sort name,asc --output json
+```
+
+```text
+{
+  "items": [
+    {
+      "id": "000000000000000000000001",
+      "name": "Bulk CCN",
+      "type": "predefined",
+      "direction": "c2s",
+      "severity": "low",
+      "version": 1
+    },
+    {
+      "id": "000000000000000000000002",
+      "name": "CCPA",
+      "type": "predefined",
+      "direction": "c2s",
+      "severity": "low",
+      "version": 1
+    }
+  ],
+  "page": {
+    "number": 0,
+    "size": 2,
+    "total": 29,
+    "returned": 2
+  }
+}
+```
+
+*YAML output*
+
+```bash
+airs runtime dlp filtering-profiles list --size 2 --sort name,asc --output yaml
+```
+
+```text
+items:
+  - id: '000000000000000000000001'
+    name: Bulk CCN
+    type: predefined
+    direction: c2s
+    severity: low
+    version: 1
+  - id: '000000000000000000000002'
+    name: CCPA
+    type: predefined
+    direction: c2s
+    severity: low
+    version: 1
+page:
+  number: 0
+  size: 2
+  total: 29
+  returned: 2
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #88. Part of epic #83.

- `runtime dlp filtering-profiles list`: pretty + JSON + YAML sidecar entries
- `runtime dlp filtering-profiles get`: blocked by CLI bug [#105](https://github.com/cdot65/prisma-airs-cli/issues/105) (JSON/YAML output key-mangling — `datarofile`, `scanype`, etc.); allowlist entry kept with comment, placeholder preserved
- `runtime dlp filtering-profiles replace`: blocked by upstream API 400 ([#107](https://github.com/cdot65/prisma-airs-cli/issues/107)); allowlist entry kept with comment, placeholder preserved

IDs redacted per `docs/cli/examples/REDACTION.md` (real UUIDs → `000000000000000000000001`/`...0002`). Predefined profile names (`Bulk CCN`, `CCPA`) kept — public Palo Alto product names.

## Test plan

- [x] `pnpm docs:gen` regenerates `docs/cli/runtime/dlp/filtering-profiles.md` with 3 list examples + 2 "Example needed" placeholders
- [x] `pnpm format` clean
- [x] `pnpm docs:check` OK — 124 commands, 100 on allowlist
- [x] Changeset added (patch)