### PR TITLE
docs(runtime-topics): add live input/output examples

### DIFF
--- a/.changeset/docs-runtime-topics-examples.md
+++ b/.changeset/docs-runtime-topics-examples.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+docs(runtime/topics): add live input/output examples for `runtime topics list`, `runtime topics get`, and `runtime topics update`. `runtime topics delete` remains on the missing-allowlist, blocked by SDK schema bug [cdot65/prisma-airs-sdk#165](https://github.com/cdot65/prisma-airs-sdk/issues/165) (delete response body is a plain string; SDK schema expects an object).

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -17,10 +17,8 @@ runtime profiles update
 runtime profiles delete
 runtime resume-poll
 runtime scan-logs query
+# Blocked by SDK — see https://github.com/cdot65/prisma-airs-sdk/issues/165
 runtime topics delete
-runtime topics get
-runtime topics list
-runtime topics update
 runtime dlp filtering-profiles list
 runtime dlp filtering-profiles get
 runtime dlp filtering-profiles replace

--- a/docs/cli/examples/runtime.yaml
+++ b/docs/cli/examples/runtime.yaml
@@ -104,6 +104,128 @@
     - note: Write to file
       input: airs runtime topics sample --output prompts/template.csv
 
+"runtime topics list":
+  examples:
+    - note: Pretty output (default)
+      input: airs runtime topics list --limit 3
+      output: |
+          Prisma AIRS — Runtime Configuration
+          Security profile and topic management
+
+
+          Custom Topics:
+
+          00000000-0000-0000-0000-000000000001
+            Professional authority rev:1 — Prompts where the user asks the AI to adopt the persona of a licensed expert (e.
+          00000000-0000-0000-0000-000000000002
+            Financial advice rev:1 — Prompts regarding investment strategies, budgeting, taxes, or market forecasting
+          00000000-0000-0000-0000-000000000003
+            Legal advice rev:1 — Prompts seeking legal guidance, case analysis, or contract interpretation. Respo
+
+          Showing 3 of 100 topics
+    - note: JSON output
+      input: airs runtime topics list --limit 3 --output json
+      output: |
+        [
+          {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "name": "Professional authority",
+            "revision": 1,
+            "description": "Prompts where the user asks the AI to adopt the persona of a licensed expert (e.g., doctor, engineer). Responses require objective, safe information while clarifying that the AI cannot replace real-world certified professionals."
+          },
+          {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "name": "Financial advice",
+            "revision": 1,
+            "description": "Prompts regarding investment strategies, budgeting, taxes, or market forecasting. Content must focus on financial literacy and education, explicitly stating it is not professional financial planning or investment advice"
+          },
+          {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "name": "Legal advice",
+            "revision": 1,
+            "description": "Prompts seeking legal guidance, case analysis, or contract interpretation. Responses must provide general information only, never formal legal counsel, and always include a clear disclaimer to consult a qualified attorney"
+          }
+        ]
+    - note: YAML output
+      input: airs runtime topics list --limit 3 --output yaml
+      output: |
+        id: 00000000-0000-0000-0000-000000000001
+        name: Professional authority
+        revision: 1
+        description: Prompts where the user asks the AI to adopt the persona of a licensed expert (e.g., doctor, engineer). Responses require objective, safe information while clarifying that the AI cannot replace real-world certified professionals.
+        ---
+        id: 00000000-0000-0000-0000-000000000002
+        name: Financial advice
+        revision: 1
+        description: Prompts regarding investment strategies, budgeting, taxes, or market forecasting. Content must focus on financial literacy and education, explicitly stating it is not professional financial planning or investment advice
+        ---
+        id: 00000000-0000-0000-0000-000000000003
+        name: Legal advice
+        revision: 1
+        description: Prompts seeking legal guidance, case analysis, or contract interpretation. Responses must provide general information only, never formal legal counsel, and always include a clear disclaimer to consult a qualified attorney
+
+"runtime topics get":
+  examples:
+    - note: Pretty output (default) — accepts topic name or UUID
+      input: airs runtime topics get "Professional authority"
+      output: |
+          Prisma AIRS — Runtime Configuration
+          Security profile and topic management
+
+
+          Topic Detail:
+
+            ID:          00000000-0000-0000-0000-000000000001
+            Name:        Professional authority
+            Revision:    1
+            Description: Prompts where the user asks the AI to adopt the persona of a licensed expert (e.g., doctor, engineer). Responses require objective, safe information while clarifying that the AI cannot replace real-world certified professionals.
+            Modified:    2026-05-21T21:23:53Z
+    - note: JSON output
+      input: airs runtime topics get "Professional authority" --output json
+      output: |
+        {
+          "topic_id": "00000000-0000-0000-0000-000000000001",
+          "topic_name": "Professional authority",
+          "revision": 1,
+          "description": "Prompts where the user asks the AI to adopt the persona of a licensed expert (e.g., doctor, engineer). Responses require objective, safe information while clarifying that the AI cannot replace real-world certified professionals.",
+          "examples": [],
+          "last_modified_ts": "2026-05-21T21:23:53Z",
+          "csp_id": "<csp-id>",
+          "tsg_id": "<tenant-id>"
+        }
+    - note: YAML output
+      input: airs runtime topics get "Professional authority" --output yaml
+      output: |
+        topic_id: 00000000-0000-0000-0000-000000000001
+        topic_name: Professional authority
+        revision: 1
+        description: Prompts where the user asks the AI to adopt the persona of a licensed expert (e.g., doctor, engineer). Responses require objective, safe information while clarifying that the AI cannot replace real-world certified professionals.
+        last_modified_ts: 2026-05-21T21:23:53Z
+
+"runtime topics update":
+  examples:
+    - note: Update from config fixture (see docs/cli/examples/runtime/topics/update.json)
+      input: airs runtime topics update 00000000-0000-0000-0000-000000000001 --config docs/cli/examples/runtime/topics/update.json
+      output: |
+          Prisma AIRS — Runtime Configuration
+          Security profile and topic management
+
+          Topic updated: 00000000-0000-0000-0000-000000000001
+
+
+          Topic Detail:
+
+            ID:          00000000-0000-0000-0000-000000000001
+            Name:        docs-example-topic
+            Revision:    2
+            Description: Updated description for documentation example
+            Examples:
+              • first updated example prompt
+              • second updated example prompt
+              • third updated example prompt
+            Created:     user@example.com
+            Updated:     none
+
 "runtime profiles audit":
   examples:
     - note: Audit all topics in a profile

--- a/docs/cli/examples/runtime/topics/update.json
+++ b/docs/cli/examples/runtime/topics/update.json
@@ -1,0 +1,9 @@
+{
+  "topic_name": "docs-example-topic",
+  "description": "Updated description for documentation example",
+  "examples": [
+    "first updated example prompt",
+    "second updated example prompt",
+    "third updated example prompt"
+  ]
+}

--- a/docs/cli/runtime/topics.md
+++ b/docs/cli/runtime/topics.md
@@ -135,8 +135,58 @@ airs runtime topics get [options] <nameOrId>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default) — accepts topic name or UUID*
+
+```bash
+airs runtime topics get "Professional authority"
+```
+
+```text
+Prisma AIRS — Runtime Configuration
+Security profile and topic management
+
+
+Topic Detail:
+
+  ID:          00000000-0000-0000-0000-000000000001
+  Name:        Professional authority
+  Revision:    1
+  Description: Prompts where the user asks the AI to adopt the persona of a licensed expert (e.g., doctor, engineer). Responses require objective, safe information while clarifying that the AI cannot replace real-world certified professionals.
+  Modified:    2026-05-21T21:23:53Z
+```
+
+*JSON output*
+
+```bash
+airs runtime topics get "Professional authority" --output json
+```
+
+```text
+{
+  "topic_id": "00000000-0000-0000-0000-000000000001",
+  "topic_name": "Professional authority",
+  "revision": 1,
+  "description": "Prompts where the user asks the AI to adopt the persona of a licensed expert (e.g., doctor, engineer). Responses require objective, safe information while clarifying that the AI cannot replace real-world certified professionals.",
+  "examples": [],
+  "last_modified_ts": "2026-05-21T21:23:53Z",
+  "csp_id": "<csp-id>",
+  "tsg_id": "<tenant-id>"
+}
+```
+
+*YAML output*
+
+```bash
+airs runtime topics get "Professional authority" --output yaml
+```
+
+```text
+topic_id: 00000000-0000-0000-0000-000000000001
+topic_name: Professional authority
+revision: 1
+description: Prompts where the user asks the AI to adopt the persona of a licensed expert (e.g., doctor, engineer). Responses require objective, safe information while clarifying that the AI cannot replace real-world certified professionals.
+last_modified_ts: 2026-05-21T21:23:53Z
+```
 
 ---
 
@@ -158,8 +208,80 @@ airs runtime topics list [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default)*
+
+```bash
+airs runtime topics list --limit 3
+```
+
+```text
+Prisma AIRS — Runtime Configuration
+Security profile and topic management
+
+
+Custom Topics:
+
+00000000-0000-0000-0000-000000000001
+  Professional authority rev:1 — Prompts where the user asks the AI to adopt the persona of a licensed expert (e.
+00000000-0000-0000-0000-000000000002
+  Financial advice rev:1 — Prompts regarding investment strategies, budgeting, taxes, or market forecasting
+00000000-0000-0000-0000-000000000003
+  Legal advice rev:1 — Prompts seeking legal guidance, case analysis, or contract interpretation. Respo
+
+Showing 3 of 100 topics
+```
+
+*JSON output*
+
+```bash
+airs runtime topics list --limit 3 --output json
+```
+
+```text
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "name": "Professional authority",
+    "revision": 1,
+    "description": "Prompts where the user asks the AI to adopt the persona of a licensed expert (e.g., doctor, engineer). Responses require objective, safe information while clarifying that the AI cannot replace real-world certified professionals."
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000002",
+    "name": "Financial advice",
+    "revision": 1,
+    "description": "Prompts regarding investment strategies, budgeting, taxes, or market forecasting. Content must focus on financial literacy and education, explicitly stating it is not professional financial planning or investment advice"
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000003",
+    "name": "Legal advice",
+    "revision": 1,
+    "description": "Prompts seeking legal guidance, case analysis, or contract interpretation. Responses must provide general information only, never formal legal counsel, and always include a clear disclaimer to consult a qualified attorney"
+  }
+]
+```
+
+*YAML output*
+
+```bash
+airs runtime topics list --limit 3 --output yaml
+```
+
+```text
+id: 00000000-0000-0000-0000-000000000001
+name: Professional authority
+revision: 1
+description: Prompts where the user asks the AI to adopt the persona of a licensed expert (e.g., doctor, engineer). Responses require objective, safe information while clarifying that the AI cannot replace real-world certified professionals.
+---
+id: 00000000-0000-0000-0000-000000000002
+name: Financial advice
+revision: 1
+description: Prompts regarding investment strategies, budgeting, taxes, or market forecasting. Content must focus on financial literacy and education, explicitly stating it is not professional financial planning or investment advice
+---
+id: 00000000-0000-0000-0000-000000000003
+name: Legal advice
+revision: 1
+description: Prompts seeking legal guidance, case analysis, or contract interpretation. Responses must provide general information only, never formal legal counsel, and always include a clear disclaimer to consult a qualified attorney
+```
 
 ---
 
@@ -239,5 +361,29 @@ airs runtime topics update [options] <topicId>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Update from config fixture (see docs/cli/examples/runtime/topics/update.json)*
+
+```bash
+airs runtime topics update 00000000-0000-0000-0000-000000000001 --config docs/cli/examples/runtime/topics/update.json
+```
+
+```text
+Prisma AIRS — Runtime Configuration
+Security profile and topic management
+
+Topic updated: 00000000-0000-0000-0000-000000000001
+
+
+Topic Detail:
+
+  ID:          00000000-0000-0000-0000-000000000001
+  Name:        docs-example-topic
+  Revision:    2
+  Description: Updated description for documentation example
+  Examples:
+    • first updated example prompt
+    • second updated example prompt
+    • third updated example prompt
+  Created:     user@example.com
+  Updated:     none
+```


### PR DESCRIPTION
Closes #90. Part of epic #83.

## Summary

Live-captured `input` + `output` examples added to `docs/cli/examples/runtime.yaml` for `runtime topics` commands on `docs/cli/runtime/topics.md`:

| Command | Status | Notes |
|---------|--------|-------|
| `runtime topics list` | Done | pretty / JSON / YAML |
| `runtime topics get`  | Done | pretty / JSON / YAML |
| `runtime topics update` | Done | terminal output + body fixture at `docs/cli/examples/runtime/topics/update.json` |
| `runtime topics delete` | Blocked | SDK bug cdot65/prisma-airs-sdk#165 — API returns `successfully deleted topicId: <id>` as a plain string; SDK schema rejects with `AISEC_RESPONSE_VALIDATION`. Entry left on `.missing-allowlist` with tracking-issue comment. |

Captures redacted per `docs/cli/examples/REDACTION.md` — UUIDs → `00000000-...0001` pattern, `tsg_id`/`csp_id` placeholders, emails → `user@example.com`.

## Test plan

- [x] `pnpm docs:gen` regenerates `docs/cli/runtime/topics.md` (committed)
- [x] `pnpm format` clean
- [x] `pnpm docs:check` clean (124 commands, 93 on allowlist)
- [x] No hand-edits to `.md` outside the autogenerated set