### PR TITLE
docs(runtime-profiles): add live input/output examples

### DIFF
--- a/.changeset/docs-runtime-profiles-examples.md
+++ b/.changeset/docs-runtime-profiles-examples.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Add live input/output examples to the `airs runtime profiles` reference page. `list` and `get` now render Pretty + JSON + YAML captures from a live tenant; `create` and `update` render the pretty Profile Detail output (these commands have no `--output` flag). `delete` stays on the `.missing-allowlist` with an inline comment linking SDK tracking issue [prisma-airs-sdk#164](https://github.com/cdot65/prisma-airs-sdk/issues/164) — the management API returns a plain-string body that fails the SDK response schema; once SDK is patched the example will land.

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -10,10 +10,7 @@ runtime customer-apps update
 runtime customer-apps delete
 runtime deployment-profiles list
 runtime dlp-profiles list
-runtime profiles list
-runtime profiles get
-runtime profiles create
-runtime profiles update
+# Blocked by SDK — see https://github.com/cdot65/prisma-airs-sdk/issues/164
 runtime profiles delete
 runtime resume-poll
 runtime scan-logs query

--- a/docs/cli/examples/runtime.yaml
+++ b/docs/cli/examples/runtime.yaml
@@ -757,3 +757,382 @@
           airs runtime dlp profiles get 00000001 --output json
           airs runtime dlp profiles patch 00000001 --set profile_status='"deleted"' \
             --set name='"<existing-name>"' --set profile_type='"<existing-type>"'
+
+"runtime profiles list":
+  examples:
+    - note: Pretty output (default)
+      input: airs runtime profiles list --limit 2
+      output: |
+          Prisma AIRS — Runtime Configuration
+          Security profile and topic management
+
+
+          Security Profiles:
+
+          00000000-0000-0000-0000-000000000001
+            docs-example-profile  active rev:1
+          00000000-0000-0000-0000-000000000002
+            example-other-profile  active rev:6
+
+          Next offset: 2
+    - note: JSON output
+      input: airs runtime profiles list --limit 2 --output json
+      output: |
+        [
+          {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "name": "docs-example-profile",
+            "status": "active",
+            "revision": 1
+          },
+          {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "name": "example-other-profile",
+            "status": "active",
+            "revision": 6
+          }
+        ]
+    - note: YAML output (multi-doc stream — one document per profile)
+      input: airs runtime profiles list --limit 2 --output yaml
+      output: |
+        id: 00000000-0000-0000-0000-000000000001
+        name: docs-example-profile
+        status: active
+        revision: 1
+        ---
+        id: 00000000-0000-0000-0000-000000000002
+        name: example-other-profile
+        status: active
+        revision: 6
+
+"runtime profiles get":
+  examples:
+    - note: Pretty output (default)
+      input: airs runtime profiles get docs-example-profile
+      output: |
+          Prisma AIRS — Runtime Configuration
+          Security profile and topic management
+
+
+          Profile Detail:
+
+            ID:       00000000-0000-0000-0000-000000000001
+            Name:     docs-example-profile
+            Status:   active
+            Revision: 1
+            Created:  user@example.com
+            Updated:  user@example.com
+            Modified: 2026-05-25T13:38:21Z
+            Policy:   {
+                        "ai-security-profiles": [
+                          {
+                            "model-type": "default",
+                            "model-configuration": {
+                              "mask-data-in-storage": false,
+                              "latency": {
+                                "inline-timeout-action": "block",
+                                "max-inline-latency": 5
+                              },
+                              "data-protection": {
+                                "data-leak-detection": {
+                                  "member": null,
+                                  "action": "",
+                                  "mask-data-inline": false
+                                },
+                                "database-security": null
+                              },
+                              "app-protection": {
+                                "default-url-category": {
+                                  "member": null
+                                },
+                                "url-detected-action": "block",
+                                "malicious-code-protection": {
+                                  "name": "malicious-code-detection",
+                                  "action": "block"
+                                }
+                              },
+                              "model-protection": [
+                                {
+                                  "name": "prompt-injection",
+                                  "action": "block"
+                                },
+                                {
+                                  "name": "toxic-content",
+                                  "action": "high:block, moderate:alert"
+                                }
+                              ],
+                              "agent-protection": [
+                                {
+                                  "name": "agent-security",
+                                  "action": "block"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+    - note: JSON output (flattens management response — `profileId` / `profileName` keys)
+      input: airs runtime profiles get docs-example-profile --output json
+      output: |
+        {
+          "profileId": "00000000-0000-0000-0000-000000000001",
+          "profileName": "docs-example-profile",
+          "revision": 1,
+          "active": true,
+          "createdBy": "user@example.com",
+          "updatedBy": "user@example.com",
+          "lastModifiedTs": "2026-05-25T13:38:21Z",
+          "policy": {
+            "ai-security-profiles": [
+              {
+                "model-type": "default",
+                "model-configuration": {
+                  "mask-data-in-storage": false,
+                  "latency": {
+                    "inline-timeout-action": "block",
+                    "max-inline-latency": 5
+                  },
+                  "data-protection": {
+                    "data-leak-detection": {
+                      "member": null,
+                      "action": "",
+                      "mask-data-inline": false
+                    },
+                    "database-security": null
+                  },
+                  "app-protection": {
+                    "default-url-category": {
+                      "member": null
+                    },
+                    "url-detected-action": "block",
+                    "malicious-code-protection": {
+                      "name": "malicious-code-detection",
+                      "action": "block"
+                    }
+                  },
+                  "model-protection": [
+                    {
+                      "name": "prompt-injection",
+                      "action": "block"
+                    },
+                    {
+                      "name": "toxic-content",
+                      "action": "high:block, moderate:alert"
+                    }
+                  ],
+                  "agent-protection": [
+                    {
+                      "name": "agent-security",
+                      "action": "block"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+    - note: YAML output (the nested `policy` is emitted as inline JSON, not converted to YAML)
+      input: airs runtime profiles get docs-example-profile --output yaml
+      output: |
+        profileId: 00000000-0000-0000-0000-000000000001
+        profileName: docs-example-profile
+        revision: 1
+        active: true
+        createdBy: user@example.com
+        updatedBy: user@example.com
+        lastModifiedTs: 2026-05-25T13:38:21Z
+        policy: {
+          "ai-security-profiles": [
+            {
+              "model-type": "default",
+              "model-configuration": {
+                "mask-data-in-storage": false,
+                "latency": {
+                  "inline-timeout-action": "block",
+                  "max-inline-latency": 5
+                },
+                "data-protection": {
+                  "data-leak-detection": {
+                    "member": null,
+                    "action": "",
+                    "mask-data-inline": false
+                  },
+                  "database-security": null
+                },
+                "app-protection": {
+                  "default-url-category": {
+                    "member": null
+                  },
+                  "url-detected-action": "block",
+                  "malicious-code-protection": {
+                    "name": "malicious-code-detection",
+                    "action": "block"
+                  }
+                },
+                "model-protection": [
+                  {
+                    "name": "prompt-injection",
+                    "action": "block"
+                  },
+                  {
+                    "name": "toxic-content",
+                    "action": "high:block, moderate:alert"
+                  }
+                ],
+                "agent-protection": [
+                  {
+                    "name": "agent-security",
+                    "action": "block"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+
+"runtime profiles create":
+  examples:
+    - note: Create with protection flags (no JSON output flag — pretty only)
+      input: |
+        airs runtime profiles create \
+          --name docs-example-profile \
+          --prompt-injection block \
+          --toxic-content "high:block, moderate:alert" \
+          --malicious-code block \
+          --agent-security block \
+          --url-action block
+      output: |
+          Prisma AIRS — Runtime Configuration
+          Security profile and topic management
+
+          Profile created: 00000000-0000-0000-0000-000000000001
+
+
+          Profile Detail:
+
+            ID:       00000000-0000-0000-0000-000000000001
+            Name:     docs-example-profile
+            Status:   active
+            Revision: 1
+            Created:  user@example.com
+            Updated:  user@example.com
+            Modified: 2026-05-25T13:38:21Z
+            Policy:   {
+                        "ai-security-profiles": [
+                          {
+                            "model-type": "default",
+                            "model-configuration": {
+                              "mask-data-in-storage": false,
+                              "latency": {
+                                "inline-timeout-action": "block",
+                                "max-inline-latency": 5
+                              },
+                              "data-protection": {
+                                "data-leak-detection": {
+                                  "member": null,
+                                  "action": "",
+                                  "mask-data-inline": false
+                                },
+                                "database-security": null
+                              },
+                              "app-protection": {
+                                "default-url-category": {
+                                  "member": null
+                                },
+                                "url-detected-action": "block",
+                                "malicious-code-protection": {
+                                  "name": "malicious-code-detection",
+                                  "action": "block"
+                                }
+                              },
+                              "model-protection": [
+                                {
+                                  "name": "prompt-injection",
+                                  "action": "block"
+                                },
+                                {
+                                  "name": "toxic-content",
+                                  "action": "high:block, moderate:alert"
+                                }
+                              ],
+                              "agent-protection": [
+                                {
+                                  "name": "agent-security",
+                                  "action": "block"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+
+"runtime profiles update":
+  examples:
+    - note: Read-modify-write — only the flags you pass change; existing protections are preserved. New revision id returned.
+      input: |
+        airs runtime profiles update docs-example-profile \
+          --prompt-injection alert
+      output: |
+          Prisma AIRS — Runtime Configuration
+          Security profile and topic management
+
+          Profile updated: 00000000-0000-0000-0000-000000000002
+
+
+          Profile Detail:
+
+            ID:       00000000-0000-0000-0000-000000000002
+            Name:     docs-example-profile
+            Status:   active
+            Revision: 2
+            Created:  user@example.com
+            Updated:  none
+            Modified: 2026-05-25T13:39:05Z
+            Policy:   {
+                        "ai-security-profiles": [
+                          {
+                            "model-type": "default",
+                            "model-configuration": {
+                              "mask-data-in-storage": false,
+                              "latency": {
+                                "inline-timeout-action": "block",
+                                "max-inline-latency": 5
+                              },
+                              "data-protection": {
+                                "data-leak-detection": {
+                                  "member": null,
+                                  "action": "",
+                                  "mask-data-inline": false
+                                },
+                                "database-security": null
+                              },
+                              "app-protection": {
+                                "default-url-category": {
+                                  "member": null
+                                },
+                                "url-detected-action": "block",
+                                "malicious-code-protection": {
+                                  "name": "malicious-code-detection",
+                                  "action": "block"
+                                }
+                              },
+                              "model-protection": [
+                                {
+                                  "name": "prompt-injection",
+                                  "action": "alert"
+                                },
+                                {
+                                  "name": "toxic-content",
+                                  "action": "high:block, moderate:alert"
+                                }
+                              ],
+                              "agent-protection": [
+                                {
+                                  "name": "agent-security",
+                                  "action": "block"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }

--- a/docs/cli/runtime/profiles.md
+++ b/docs/cli/runtime/profiles.md
@@ -18,8 +18,67 @@ airs runtime profiles list [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default)*
+
+```bash
+airs runtime profiles list --limit 2
+```
+
+```text
+Prisma AIRS — Runtime Configuration
+Security profile and topic management
+
+
+Security Profiles:
+
+00000000-0000-0000-0000-000000000001
+  docs-example-profile  active rev:1
+00000000-0000-0000-0000-000000000002
+  example-other-profile  active rev:6
+
+Next offset: 2
+```
+
+*JSON output*
+
+```bash
+airs runtime profiles list --limit 2 --output json
+```
+
+```text
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "name": "docs-example-profile",
+    "status": "active",
+    "revision": 1
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000002",
+    "name": "example-other-profile",
+    "status": "active",
+    "revision": 6
+  }
+]
+```
+
+*YAML output (multi-doc stream — one document per profile)*
+
+```bash
+airs runtime profiles list --limit 2 --output yaml
+```
+
+```text
+id: 00000000-0000-0000-0000-000000000001
+name: docs-example-profile
+status: active
+revision: 1
+---
+id: 00000000-0000-0000-0000-000000000002
+name: example-other-profile
+status: active
+revision: 6
+```
 
 ---
 
@@ -43,8 +102,205 @@ airs runtime profiles get [options] <nameOrId>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default)*
+
+```bash
+airs runtime profiles get docs-example-profile
+```
+
+```text
+Prisma AIRS — Runtime Configuration
+Security profile and topic management
+
+
+Profile Detail:
+
+  ID:       00000000-0000-0000-0000-000000000001
+  Name:     docs-example-profile
+  Status:   active
+  Revision: 1
+  Created:  user@example.com
+  Updated:  user@example.com
+  Modified: 2026-05-25T13:38:21Z
+  Policy:   {
+              "ai-security-profiles": [
+                {
+                  "model-type": "default",
+                  "model-configuration": {
+                    "mask-data-in-storage": false,
+                    "latency": {
+                      "inline-timeout-action": "block",
+                      "max-inline-latency": 5
+                    },
+                    "data-protection": {
+                      "data-leak-detection": {
+                        "member": null,
+                        "action": "",
+                        "mask-data-inline": false
+                      },
+                      "database-security": null
+                    },
+                    "app-protection": {
+                      "default-url-category": {
+                        "member": null
+                      },
+                      "url-detected-action": "block",
+                      "malicious-code-protection": {
+                        "name": "malicious-code-detection",
+                        "action": "block"
+                      }
+                    },
+                    "model-protection": [
+                      {
+                        "name": "prompt-injection",
+                        "action": "block"
+                      },
+                      {
+                        "name": "toxic-content",
+                        "action": "high:block, moderate:alert"
+                      }
+                    ],
+                    "agent-protection": [
+                      {
+                        "name": "agent-security",
+                        "action": "block"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+```
+
+*JSON output (flattens management response — `profileId` / `profileName` keys)*
+
+```bash
+airs runtime profiles get docs-example-profile --output json
+```
+
+```text
+{
+  "profileId": "00000000-0000-0000-0000-000000000001",
+  "profileName": "docs-example-profile",
+  "revision": 1,
+  "active": true,
+  "createdBy": "user@example.com",
+  "updatedBy": "user@example.com",
+  "lastModifiedTs": "2026-05-25T13:38:21Z",
+  "policy": {
+    "ai-security-profiles": [
+      {
+        "model-type": "default",
+        "model-configuration": {
+          "mask-data-in-storage": false,
+          "latency": {
+            "inline-timeout-action": "block",
+            "max-inline-latency": 5
+          },
+          "data-protection": {
+            "data-leak-detection": {
+              "member": null,
+              "action": "",
+              "mask-data-inline": false
+            },
+            "database-security": null
+          },
+          "app-protection": {
+            "default-url-category": {
+              "member": null
+            },
+            "url-detected-action": "block",
+            "malicious-code-protection": {
+              "name": "malicious-code-detection",
+              "action": "block"
+            }
+          },
+          "model-protection": [
+            {
+              "name": "prompt-injection",
+              "action": "block"
+            },
+            {
+              "name": "toxic-content",
+              "action": "high:block, moderate:alert"
+            }
+          ],
+          "agent-protection": [
+            {
+              "name": "agent-security",
+              "action": "block"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+*YAML output (the nested `policy` is emitted as inline JSON, not converted to YAML)*
+
+```bash
+airs runtime profiles get docs-example-profile --output yaml
+```
+
+```text
+profileId: 00000000-0000-0000-0000-000000000001
+profileName: docs-example-profile
+revision: 1
+active: true
+createdBy: user@example.com
+updatedBy: user@example.com
+lastModifiedTs: 2026-05-25T13:38:21Z
+policy: {
+  "ai-security-profiles": [
+    {
+      "model-type": "default",
+      "model-configuration": {
+        "mask-data-in-storage": false,
+        "latency": {
+          "inline-timeout-action": "block",
+          "max-inline-latency": 5
+        },
+        "data-protection": {
+          "data-leak-detection": {
+            "member": null,
+            "action": "",
+            "mask-data-inline": false
+          },
+          "database-security": null
+        },
+        "app-protection": {
+          "default-url-category": {
+            "member": null
+          },
+          "url-detected-action": "block",
+          "malicious-code-protection": {
+            "name": "malicious-code-detection",
+            "action": "block"
+          }
+        },
+        "model-protection": [
+          {
+            "name": "prompt-injection",
+            "action": "block"
+          },
+          {
+            "name": "toxic-content",
+            "action": "high:block, moderate:alert"
+          }
+        ],
+        "agent-protection": [
+          {
+            "name": "agent-security",
+            "action": "block"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
 
 ---
 
@@ -85,8 +341,83 @@ airs runtime profiles create [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Create with protection flags (no JSON output flag — pretty only)*
+
+```bash
+airs runtime profiles create \
+  --name docs-example-profile \
+  --prompt-injection block \
+  --toxic-content "high:block, moderate:alert" \
+  --malicious-code block \
+  --agent-security block \
+  --url-action block
+```
+
+```text
+Prisma AIRS — Runtime Configuration
+Security profile and topic management
+
+Profile created: 00000000-0000-0000-0000-000000000001
+
+
+Profile Detail:
+
+  ID:       00000000-0000-0000-0000-000000000001
+  Name:     docs-example-profile
+  Status:   active
+  Revision: 1
+  Created:  user@example.com
+  Updated:  user@example.com
+  Modified: 2026-05-25T13:38:21Z
+  Policy:   {
+              "ai-security-profiles": [
+                {
+                  "model-type": "default",
+                  "model-configuration": {
+                    "mask-data-in-storage": false,
+                    "latency": {
+                      "inline-timeout-action": "block",
+                      "max-inline-latency": 5
+                    },
+                    "data-protection": {
+                      "data-leak-detection": {
+                        "member": null,
+                        "action": "",
+                        "mask-data-inline": false
+                      },
+                      "database-security": null
+                    },
+                    "app-protection": {
+                      "default-url-category": {
+                        "member": null
+                      },
+                      "url-detected-action": "block",
+                      "malicious-code-protection": {
+                        "name": "malicious-code-detection",
+                        "action": "block"
+                      }
+                    },
+                    "model-protection": [
+                      {
+                        "name": "prompt-injection",
+                        "action": "block"
+                      },
+                      {
+                        "name": "toxic-content",
+                        "action": "high:block, moderate:alert"
+                      }
+                    ],
+                    "agent-protection": [
+                      {
+                        "name": "agent-security",
+                        "action": "block"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+```
 
 ---
 
@@ -132,8 +463,78 @@ airs runtime profiles update [options] <nameOrId>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Read-modify-write — only the flags you pass change; existing protections are preserved. New revision id returned.*
+
+```bash
+airs runtime profiles update docs-example-profile \
+  --prompt-injection alert
+```
+
+```text
+Prisma AIRS — Runtime Configuration
+Security profile and topic management
+
+Profile updated: 00000000-0000-0000-0000-000000000002
+
+
+Profile Detail:
+
+  ID:       00000000-0000-0000-0000-000000000002
+  Name:     docs-example-profile
+  Status:   active
+  Revision: 2
+  Created:  user@example.com
+  Updated:  none
+  Modified: 2026-05-25T13:39:05Z
+  Policy:   {
+              "ai-security-profiles": [
+                {
+                  "model-type": "default",
+                  "model-configuration": {
+                    "mask-data-in-storage": false,
+                    "latency": {
+                      "inline-timeout-action": "block",
+                      "max-inline-latency": 5
+                    },
+                    "data-protection": {
+                      "data-leak-detection": {
+                        "member": null,
+                        "action": "",
+                        "mask-data-inline": false
+                      },
+                      "database-security": null
+                    },
+                    "app-protection": {
+                      "default-url-category": {
+                        "member": null
+                      },
+                      "url-detected-action": "block",
+                      "malicious-code-protection": {
+                        "name": "malicious-code-detection",
+                        "action": "block"
+                      }
+                    },
+                    "model-protection": [
+                      {
+                        "name": "prompt-injection",
+                        "action": "alert"
+                      },
+                      {
+                        "name": "toxic-content",
+                        "action": "high:block, moderate:alert"
+                      }
+                    ],
+                    "agent-protection": [
+                      {
+                        "name": "agent-security",
+                        "action": "block"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+```
 
 ---
 


### PR DESCRIPTION
Closes #89. Part of epic #83.

## Summary

- `runtime profiles list` — Pretty + JSON + YAML (multi-doc stream) live captures
- `runtime profiles get` — Pretty + JSON + YAML; YAML note flags the inline-JSON `policy` quirk
- `runtime profiles create` — pretty Profile Detail (no `--output` flag on this command)
- `runtime profiles update` — pretty Profile Detail; note explains read-modify-write + new revision id
- `runtime profiles delete` — **blocked** by SDK validation bug, allowlist entry kept

## Blocked

Filed [cdot65/prisma-airs-sdk#164](https://github.com/cdot65/prisma-airs-sdk/issues/164): the DELETE `/aisec/v1/mgmt/profile/{id}` endpoint returns a plain-string success body (`successfully force deleted profileId: ...`) which fails the SDK response schema (`expected object, received string`). Deletion succeeds server-side but CLI exits 1. Once SDK is patched, the example will land.

## Verification

- `pnpm docs:gen` → 37 files generated
- `pnpm format` → no fixes
- `pnpm docs:check` → OK — 124 commands, 92 on allowlist (-4 vs main: list/get/create/update removed)