### PR TITLE
docs(redteam-scan-lifecycle): add live input/output examples

### DIFF
--- a/.changeset/docs-redteam-scan-lifecycle-examples.md
+++ b/.changeset/docs-redteam-scan-lifecycle-examples.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+docs(redteam/scan-lifecycle): add live input/output examples for `redteam status` and `redteam report` (two variants: full report + attack list filtered by severity). `redteam abort` remains on the missing-allowlist, blocked by tenant license restriction (see [cdot65/prisma-airs-cli#111](https://github.com/cdot65/prisma-airs-cli/issues/111)). Separately filed [cdot65/prisma-airs-cli#112](https://github.com/cdot65/prisma-airs-cli/issues/112) for `redteam report` routing DYNAMIC scans to the static endpoint and 500-ing — does not block these docs since the live example uses a STATIC scan.

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -40,6 +40,7 @@ runtime dlp dictionaries create
 runtime dlp dictionaries replace
 # Blocked by upstream — see https://github.com/cdot65/prisma-airs-cli/issues/99
 runtime dlp dictionaries patch
+# Blocked by tenant license (read-only) — see https://github.com/cdot65/prisma-airs-cli/issues/111
 redteam abort
 redteam eula status
 redteam eula content
@@ -67,8 +68,6 @@ redteam properties list
 redteam properties create
 redteam properties values
 redteam properties add-value
-redteam report
-redteam status
 redteam targets get
 redteam targets create
 redteam targets update

--- a/docs/cli/examples/redteam.yaml
+++ b/docs/cli/examples/redteam.yaml
@@ -84,3 +84,88 @@
           • MITRE ATLAS — MITRE Adversarial Tactics, Techniques, and Common Knowledge
           • NIST AI-RMF — National Institute of Standards and Technology Cybersecurity Framework
           ...
+
+"redteam status":
+  examples:
+    - note: Check progress / final score for any scan (STATIC / DYNAMIC / CUSTOM)
+      input: airs redteam status 00000000-0000-0000-0000-000000000001
+      output: |
+          Prisma AIRS — AI Red Team
+          Adversarial scan operations
+
+          Scan Status:
+            ID:      00000000-0000-0000-0000-000000000001
+            Name:    Example Static Scan
+            Type:    STATIC
+            Target:  Example Target
+            Status:  COMPLETED
+            Progress: 1454/1464
+            Score:   2.76
+            ASR:     3.2%
+
+"redteam report":
+  examples:
+    - note: Full scan report (STATIC scan — score, severity breakdown, categories, summary, recommendations)
+      input: airs redteam report 00000000-0000-0000-0000-000000000001
+      output: |
+          Prisma AIRS — AI Red Team
+          Adversarial scan operations
+
+          Scan Status:
+            ID:      00000000-0000-0000-0000-000000000001
+            Name:    Example Static Scan
+            Type:    STATIC
+            Target:  Example Target
+            Status:  COMPLETED
+            Progress: 1454/1464
+            Score:   2.76
+            ASR:     3.2%
+
+
+          Static Scan Report:
+            Score: 2.76
+            ASR:   3.2%
+
+          Severity Breakdown:
+            LOW        32 bypassed  616 blocked
+            MEDIUM     45 bypassed  1431 blocked
+            HIGH       57 bypassed  1797 blocked
+            CRITICAL   6 bypassed  378 blocked
+
+          Categories:
+            Adversarial Suffix             ASR: 4.3%  (6/138)
+            Evasion                        ASR: 1.4%  (8/564)
+            Indirect Prompt Injection      ASR: 0.0%  (0/60)
+            Jailbreak                      ASR: 4.5%  (47/1044)
+            Prompt Injection               ASR: 4.2%  (27/648)
+            Remote Code Execution          ASR: 2.8%  (1/36)
+            System Prompt leak             ASR: 0.4%  (1/264)
+            Tool Leak                      ASR: 0.9%  (1/114)
+            Malware Generation             ASR: 6.9%  (5/72)
+
+          Summary:
+            In this Attack Library Scan, the target was tested for Brand, Compliance, Safety and Security risks.
+
+          ### Summary
+          The application has low risk with an overall Risk Score of 2.76/100.
+
+          ### Recommendations
+
+          **1. Enforcing Least Privilege Access Control**:
+          Grant your AI application only the minimum permissions necessary to perform its intended functions. Limit access to sensitive resources, APIs, and data.
+
+          **2. Paraphrasing**:
+          Implement paraphrasing techniques to disrupt potential manipulation attempts by restructuring and reinterpreting input data.
+
+          **3. Runtime Execution Constraints**:
+          Set time limits and resource consumption thresholds for code execution.
+    - note: Attack list filtered by severity
+      input: airs redteam report 00000000-0000-0000-0000-000000000001 --attacks --severity CRITICAL --limit 3
+      output: |
+          ... (report summary as above) ...
+
+          Attacks:
+
+            CRITICAL   BLOCKED  undefined [SECURITY]
+            CRITICAL   BLOCKED  undefined [SECURITY]
+            CRITICAL   BLOCKED  undefined [SECURITY]

--- a/docs/cli/redteam/report.md
+++ b/docs/cli/redteam/report.md
@@ -22,5 +22,78 @@ airs redteam report [options] <jobId>
 
 ### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Full scan report (STATIC scan — score, severity breakdown, categories, summary, recommendations)*
+
+```bash
+airs redteam report 00000000-0000-0000-0000-000000000001
+```
+
+```text
+Prisma AIRS — AI Red Team
+Adversarial scan operations
+
+Scan Status:
+  ID:      00000000-0000-0000-0000-000000000001
+  Name:    Example Static Scan
+  Type:    STATIC
+  Target:  Example Target
+  Status:  COMPLETED
+  Progress: 1454/1464
+  Score:   2.76
+  ASR:     3.2%
+
+
+Static Scan Report:
+  Score: 2.76
+  ASR:   3.2%
+
+Severity Breakdown:
+  LOW        32 bypassed  616 blocked
+  MEDIUM     45 bypassed  1431 blocked
+  HIGH       57 bypassed  1797 blocked
+  CRITICAL   6 bypassed  378 blocked
+
+Categories:
+  Adversarial Suffix             ASR: 4.3%  (6/138)
+  Evasion                        ASR: 1.4%  (8/564)
+  Indirect Prompt Injection      ASR: 0.0%  (0/60)
+  Jailbreak                      ASR: 4.5%  (47/1044)
+  Prompt Injection               ASR: 4.2%  (27/648)
+  Remote Code Execution          ASR: 2.8%  (1/36)
+  System Prompt leak             ASR: 0.4%  (1/264)
+  Tool Leak                      ASR: 0.9%  (1/114)
+  Malware Generation             ASR: 6.9%  (5/72)
+
+Summary:
+  In this Attack Library Scan, the target was tested for Brand, Compliance, Safety and Security risks.
+
+### Summary
+The application has low risk with an overall Risk Score of 2.76/100.
+
+### Recommendations
+
+**1. Enforcing Least Privilege Access Control**:
+Grant your AI application only the minimum permissions necessary to perform its intended functions. Limit access to sensitive resources, APIs, and data.
+
+**2. Paraphrasing**:
+Implement paraphrasing techniques to disrupt potential manipulation attempts by restructuring and reinterpreting input data.
+
+**3. Runtime Execution Constraints**:
+Set time limits and resource consumption thresholds for code execution.
+```
+
+*Attack list filtered by severity*
+
+```bash
+airs redteam report 00000000-0000-0000-0000-000000000001 --attacks --severity CRITICAL --limit 3
+```
+
+```text
+... (report summary as above) ...
+
+Attacks:
+
+  CRITICAL   BLOCKED  undefined [SECURITY]
+  CRITICAL   BLOCKED  undefined [SECURITY]
+  CRITICAL   BLOCKED  undefined [SECURITY]
+```

--- a/docs/cli/redteam/status.md
+++ b/docs/cli/redteam/status.md
@@ -14,5 +14,23 @@ airs redteam status [options] <jobId>
 
 ### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Check progress / final score for any scan (STATIC / DYNAMIC / CUSTOM)*
+
+```bash
+airs redteam status 00000000-0000-0000-0000-000000000001
+```
+
+```text
+Prisma AIRS — AI Red Team
+Adversarial scan operations
+
+Scan Status:
+  ID:      00000000-0000-0000-0000-000000000001
+  Name:    Example Static Scan
+  Type:    STATIC
+  Target:  Example Target
+  Status:  COMPLETED
+  Progress: 1454/1464
+  Score:   2.76
+  ASR:     3.2%
+```


### PR DESCRIPTION
Closes #93. Part of epic #83.

## Summary

Live-captured input + output examples added to `docs/cli/examples/redteam.yaml` for the scan-lifecycle commands on `docs/cli/redteam/{abort,status,report}.md`:

| Command | Status | Notes |
|---------|--------|-------|
| `redteam status` | Done | Single entry — `redteam status <jobId>` shows progress + final score for any scan type |
| `redteam report` | Done | Two entries — full STATIC scan report; attack list filtered by `--severity CRITICAL --limit 3` |
| `redteam abort` | Blocked | Tenant license is read-only — `AISEC_CLIENT_SIDE_ERROR:License has expired`. Cannot start nor abort any scan from this tenant. Tracking: cdot65/prisma-airs-cli#111. Entry left on `.missing-allowlist` with comment. |

### Related CLI bug surfaced while capturing

`airs redteam report <jobId>` 500s for DYNAMIC scans because the CLI routes everything-not-CUSTOM to `getStaticReport()` (hits `/v1/report/static/...`) instead of `getDynamicReport()` (`/v1/report/dynamic/...`). Filed as cdot65/prisma-airs-cli#112. **Does not block this PR** — the live example uses a STATIC scan which works correctly.

Captures redacted per `docs/cli/examples/REDACTION.md` — UUIDs → `00000000-...0001` pattern, scan/target names → generic placeholders.

## Test plan

- [x] `pnpm docs:gen` regenerates `docs/cli/redteam/{status,report}.md` (committed)
- [x] `pnpm format` clean
- [x] `pnpm docs:check` clean (124 commands, 86 on allowlist — down from 88)
- [x] No hand-edits to `.md` outside the autogenerated set