### PR TITLE
docs(runtime-misc): add live input/output examples

### DIFF
--- a/.changeset/docs-runtime-misc-examples.md
+++ b/.changeset/docs-runtime-misc-examples.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+docs(cli): live input/output examples for `runtime deployment-profiles list`, `runtime dlp-profiles list`, `runtime scan-logs query`, `runtime resume-poll`. `scan-logs query` example documents the four valid `(--interval, --unit)` pairs accepted by the upstream `/v1/mgmt/scanlogs` endpoint — `(1, hours)`, `(24, hours)`, `(7, days)`, `(30, days)` — anything else returns API 400.

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -8,12 +8,8 @@ runtime customer-apps list
 runtime customer-apps get
 runtime customer-apps update
 runtime customer-apps delete
-runtime deployment-profiles list
-runtime dlp-profiles list
 # Blocked by SDK — see https://github.com/cdot65/prisma-airs-sdk/issues/164
 runtime profiles delete
-runtime resume-poll
-runtime scan-logs query
 # Blocked by SDK — see https://github.com/cdot65/prisma-airs-sdk/issues/165
 runtime topics delete
 # Blocked by CLI bug — see https://github.com/cdot65/prisma-airs-cli/issues/105

--- a/docs/cli/examples/runtime.yaml
+++ b/docs/cli/examples/runtime.yaml
@@ -1322,3 +1322,145 @@
           size: 2
           total: 29
           returned: 2
+
+"runtime deployment-profiles list":
+  examples:
+    - note: Pretty output (default)
+      input: airs runtime deployment-profiles list
+      output: |
+        Prisma AIRS — Runtime Configuration
+        Security profile and topic management
+
+
+        Deployment Profiles:
+
+          example-deployment-profile-1  init  D0000001
+          example-deployment-profile-2  activated  D0000002
+          example-deployment-profile-3  activated  D0000003
+    - note: JSON output
+      input: airs runtime deployment-profiles list --output json
+      output: |
+        [
+          {
+            "name": "example-deployment-profile-1",
+            "status": "init",
+            "authCode": "D0000001"
+          },
+          {
+            "name": "example-deployment-profile-2",
+            "status": "activated",
+            "authCode": "D0000002"
+          },
+          {
+            "name": "example-deployment-profile-3",
+            "status": "activated",
+            "authCode": "D0000003"
+          }
+        ]
+    - note: YAML output
+      input: airs runtime deployment-profiles list --output yaml
+      output: |
+        name: example-deployment-profile-1
+        status: init
+        authCode: D0000001
+        ---
+        name: example-deployment-profile-2
+        status: activated
+        authCode: D0000002
+        ---
+        name: example-deployment-profile-3
+        status: activated
+        authCode: D0000003
+
+"runtime dlp-profiles list":
+  examples:
+    - note: Pretty output (default). Truncated — your tenant returns every predefined + custom DLP profile name.
+      input: airs runtime dlp-profiles list
+      output: |
+        Prisma AIRS — Runtime Configuration
+        Security profile and topic management
+
+
+        DLP Profiles:
+
+          Bulk CCN
+          CCPA
+          CommonwealthAustralia-PrivAct88
+          Corporate Financial Docs
+          Financial Information
+          GDPR
+          GLBA
+          HIPAA
+          ... (more predefined + any custom profiles)
+    - note: JSON output (truncated — `id` is currently empty for every entry from this endpoint)
+      input: airs runtime dlp-profiles list --output json
+      output: |
+        [
+          {
+            "id": "",
+            "name": "Bulk CCN"
+          },
+          {
+            "id": "",
+            "name": "CCPA"
+          },
+          {
+            "id": "",
+            "name": "CommonwealthAustralia-PrivAct88"
+          },
+          {
+            "id": "",
+            "name": "Corporate Financial Docs"
+          }
+        ]
+    - note: YAML output (truncated)
+      input: airs runtime dlp-profiles list --output yaml
+      output: |
+        id: ''
+        name: Bulk CCN
+        ---
+        id: ''
+        name: CCPA
+        ---
+        id: ''
+        name: CommonwealthAustralia-PrivAct88
+        ---
+        id: ''
+        name: Corporate Financial Docs
+
+"runtime scan-logs query":
+  examples:
+    - note: Empty result for a 24-hour window. The upstream `/v1/mgmt/scanlogs` endpoint only accepts a fixed set of (interval, unit) pairs — `(1, hours)`, `(24, hours)`, `(7, days)`, `(30, days)`. Anything else returns API 400.
+      input: airs runtime scan-logs query --interval 24 --unit hours --page-size 5
+      output: |
+        Prisma AIRS — Runtime Configuration
+        Security profile and topic management
+
+        No scan logs found.
+    - note: JSON output (the renderer short-circuits the empty case across all formats, so JSON returns the same status line, not `[]`)
+      input: airs runtime scan-logs query --interval 24 --unit hours --page-size 5 --output json
+      output: |
+        No scan logs found.
+    - note: YAML output (same empty-state shape as JSON)
+      input: airs runtime scan-logs query --interval 24 --unit hours --page-size 5 --output yaml
+      output: |
+        No scan logs found.
+
+"runtime resume-poll":
+  examples:
+    - note: Resume polling from a state file written by a prior `runtime bulk-scan` invocation. Output is text-only — there is no JSON/YAML mode. The CSV output path is controlled by `--output`.
+      input: airs runtime resume-poll ~/.prisma-airs/bulk-scans/2026-05-25T13-55-11-105Z.bulk-scan.json --output resume-out.csv
+      output: |
+        Prisma AIRS Resume Poll
+        Profile:  docs-example-profile
+        Scan IDs: 1
+        Prompts:  3
+
+        Polling for results...
+
+        Resume Poll Complete
+        ─────────────────────────
+        Total:   1
+        Blocked: 0
+        Allowed: 1
+        Output:  resume-out.csv

--- a/docs/cli/runtime/deployment-profiles.md
+++ b/docs/cli/runtime/deployment-profiles.md
@@ -17,5 +17,66 @@ airs runtime deployment-profiles list [options]
 
 ### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default)*
+
+```bash
+airs runtime deployment-profiles list
+```
+
+```text
+Prisma AIRS — Runtime Configuration
+Security profile and topic management
+
+
+Deployment Profiles:
+
+  example-deployment-profile-1  init  D0000001
+  example-deployment-profile-2  activated  D0000002
+  example-deployment-profile-3  activated  D0000003
+```
+
+*JSON output*
+
+```bash
+airs runtime deployment-profiles list --output json
+```
+
+```text
+[
+  {
+    "name": "example-deployment-profile-1",
+    "status": "init",
+    "authCode": "D0000001"
+  },
+  {
+    "name": "example-deployment-profile-2",
+    "status": "activated",
+    "authCode": "D0000002"
+  },
+  {
+    "name": "example-deployment-profile-3",
+    "status": "activated",
+    "authCode": "D0000003"
+  }
+]
+```
+
+*YAML output*
+
+```bash
+airs runtime deployment-profiles list --output yaml
+```
+
+```text
+name: example-deployment-profile-1
+status: init
+authCode: D0000001
+---
+name: example-deployment-profile-2
+status: activated
+authCode: D0000002
+---
+name: example-deployment-profile-3
+status: activated
+authCode: D0000003
+```

--- a/docs/cli/runtime/dlp-profiles.md
+++ b/docs/cli/runtime/dlp-profiles.md
@@ -16,5 +16,73 @@ airs runtime dlp-profiles list [options]
 
 ### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default). Truncated — your tenant returns every predefined + custom DLP profile name.*
+
+```bash
+airs runtime dlp-profiles list
+```
+
+```text
+Prisma AIRS — Runtime Configuration
+Security profile and topic management
+
+
+DLP Profiles:
+
+  Bulk CCN
+  CCPA
+  CommonwealthAustralia-PrivAct88
+  Corporate Financial Docs
+  Financial Information
+  GDPR
+  GLBA
+  HIPAA
+  ... (more predefined + any custom profiles)
+```
+
+*JSON output (truncated — `id` is currently empty for every entry from this endpoint)*
+
+```bash
+airs runtime dlp-profiles list --output json
+```
+
+```text
+[
+  {
+    "id": "",
+    "name": "Bulk CCN"
+  },
+  {
+    "id": "",
+    "name": "CCPA"
+  },
+  {
+    "id": "",
+    "name": "CommonwealthAustralia-PrivAct88"
+  },
+  {
+    "id": "",
+    "name": "Corporate Financial Docs"
+  }
+]
+```
+
+*YAML output (truncated)*
+
+```bash
+airs runtime dlp-profiles list --output yaml
+```
+
+```text
+id: ''
+name: Bulk CCN
+---
+id: ''
+name: CCPA
+---
+id: ''
+name: CommonwealthAustralia-PrivAct88
+---
+id: ''
+name: Corporate Financial Docs
+```

--- a/docs/cli/runtime/resume-poll.md
+++ b/docs/cli/runtime/resume-poll.md
@@ -20,5 +20,24 @@ airs runtime resume-poll [options] <stateFile>
 
 ### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Resume polling from a state file written by a prior `runtime bulk-scan` invocation. Output is text-only — there is no JSON/YAML mode. The CSV output path is controlled by `--output`.*
+
+```bash
+airs runtime resume-poll ~/.prisma-airs/bulk-scans/2026-05-25T13-55-11-105Z.bulk-scan.json --output resume-out.csv
+```
+
+```text
+Prisma AIRS Resume Poll
+Profile:  docs-example-profile
+Scan IDs: 1
+Prompts:  3
+
+Polling for results...
+
+Resume Poll Complete
+─────────────────────────
+Total:   1
+Blocked: 0
+Allowed: 1
+Output:  resume-out.csv
+```

--- a/docs/cli/runtime/scan-logs.md
+++ b/docs/cli/runtime/scan-logs.md
@@ -21,5 +21,35 @@ airs runtime scan-logs query [options]
 
 ### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Empty result for a 24-hour window. The upstream `/v1/mgmt/scanlogs` endpoint only accepts a fixed set of (interval, unit) pairs — `(1, hours)`, `(24, hours)`, `(7, days)`, `(30, days)`. Anything else returns API 400.*
+
+```bash
+airs runtime scan-logs query --interval 24 --unit hours --page-size 5
+```
+
+```text
+Prisma AIRS — Runtime Configuration
+Security profile and topic management
+
+No scan logs found.
+```
+
+*JSON output (the renderer short-circuits the empty case across all formats, so JSON returns the same status line, not `[]`)*
+
+```bash
+airs runtime scan-logs query --interval 24 --unit hours --page-size 5 --output json
+```
+
+```text
+No scan logs found.
+```
+
+*YAML output (same empty-state shape as JSON)*
+
+```bash
+airs runtime scan-logs query --interval 24 --unit hours --page-size 5 --output yaml
+```
+
+```text
+No scan logs found.
+```


### PR DESCRIPTION
Closes #92. Part of epic #83.

## Summary

Live input/output examples for the four pages under `docs/cli/runtime/` that had no examples:

- **`runtime deployment-profiles list`** — pretty + JSON + YAML. Profile names and authCodes redacted to `example-deployment-profile-1..3` / `D0000001..3`.
- **`runtime dlp-profiles list`** — pretty + JSON + YAML. Output truncated to first 4 predefined Palo Alto profile names (`Bulk CCN`, `CCPA`, `CommonwealthAustralia-PrivAct88`, `Corporate Financial Docs`) with ellipsis marker. Notes that the endpoint currently returns empty `id` for every entry.
- **`runtime scan-logs query`** — pretty + JSON + YAML showing the **empty-state** path. Note documents the four valid `(--interval, --unit)` pairs accepted by the upstream `/v1/mgmt/scanlogs` endpoint — `(1, hours)`, `(24, hours)`, `(7, days)`, `(30, days)` — anything else returns API 400. Also notes that the renderer short-circuits the empty case across all formats (JSON returns the same text, not `[]`).
- **`runtime resume-poll`** — single text-only example (no JSON/YAML mode exists). Captured by running `runtime bulk-scan` to produce a state file, then replaying it through `resume-poll`.

## Test plan

- [x] `pnpm docs:gen` regenerates 4 pages with sidecar entries; 0 `Example needed` placeholders remaining for in-scope commands
- [x] `pnpm format` clean
- [x] `pnpm docs:check` OK — 124 commands, 84 on allowlist (down from 88; 4 entries removed, no new blocked-by entries)
- [x] Changeset added (patch)