### PR TITLE
docs(runtime-api-customer): add live input/output examples

### DIFF
--- a/.changeset/docs-runtime-api-customer-examples.md
+++ b/.changeset/docs-runtime-api-customer-examples.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+docs(runtime): add live input/output examples for `api-keys list` and `customer-apps list`. Tracked blockers for `api-keys create` (upstream 503, #116) and `customer-apps get` (upstream 403, #115); destructive ops (`api-keys regenerate`/`delete`, `customer-apps update`/`delete`) deferred for safety on the shared tenant.

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -1,10 +1,10 @@
 # Commands awaiting curated input/output examples. Burn this list down to zero,
 # then flip docs:check to hard-fail in CI (remove the allowlist read).
-runtime api-keys list
+# Blocked by upstream — see https://github.com/cdot65/prisma-airs-cli/issues/116
 runtime api-keys create
 runtime api-keys regenerate
 runtime api-keys delete
-runtime customer-apps list
+# Blocked by upstream — see https://github.com/cdot65/prisma-airs-cli/issues/115
 runtime customer-apps get
 runtime customer-apps update
 runtime customer-apps delete

--- a/docs/cli/examples/runtime.yaml
+++ b/docs/cli/examples/runtime.yaml
@@ -1464,3 +1464,91 @@
         Blocked: 0
         Allowed: 1
         Output:  resume-out.csv
+
+"runtime api-keys list":
+  examples:
+    - note: Pretty output (default) — `last8` is the trailing 8 chars of the secret; full key is only echoed on create / regenerate
+      input: airs runtime api-keys list --limit 2
+      output: |
+          Prisma AIRS — Runtime Configuration
+          Security profile and topic management
+
+
+          API Keys:
+
+          00000000-0000-0000-0000-000000000001
+            docs-example-key key: …ABCD1234
+          00000000-0000-0000-0000-000000000002
+            docs-other-example-key key: …EFGH5678
+    - note: JSON output
+      input: airs runtime api-keys list --limit 2 --output json
+      output: |
+        [
+          {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "name": "docs-example-key",
+            "last8": "ABCD1234",
+            "createdAt": "",
+            "expiresAt": ""
+          },
+          {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "name": "docs-other-example-key",
+            "last8": "EFGH5678",
+            "createdAt": "",
+            "expiresAt": ""
+          }
+        ]
+    - note: YAML output (multi-doc stream — one document per key)
+      input: airs runtime api-keys list --limit 2 --output yaml
+      output: |
+        id: 00000000-0000-0000-0000-000000000001
+        name: docs-example-key
+        last8: ABCD1234
+        createdAt:
+        expiresAt:
+        ---
+        id: 00000000-0000-0000-0000-000000000002
+        name: docs-other-example-key
+        last8: EFGH5678
+        createdAt:
+        expiresAt:
+
+"runtime customer-apps list":
+  examples:
+    - note: Pretty output (default) — only `name` is rendered; richer detail requires `customer-apps get` (currently blocked, see cdot65/prisma-airs-cli#115)
+      input: airs runtime customer-apps list --limit 2
+      output: |
+          Prisma AIRS — Runtime Configuration
+          Security profile and topic management
+
+
+          Customer Apps:
+
+            example-app
+            example-other-app
+    - note: JSON output — `id` and `description` are empty in the list response (the list endpoint only returns names)
+      input: airs runtime customer-apps list --limit 2 --output json
+      output: |
+        [
+          {
+            "id": "",
+            "name": "example-app",
+            "description": ""
+          },
+          {
+            "id": "",
+            "name": "example-other-app",
+            "description": ""
+          }
+        ]
+    - note: YAML output (multi-doc stream — one document per app)
+      input: airs runtime customer-apps list --limit 2 --output yaml
+      output: |
+        id:
+        name: example-app
+        description:
+        ---
+        id:
+        name: example-other-app
+        description:

--- a/docs/cli/runtime/api-keys.md
+++ b/docs/cli/runtime/api-keys.md
@@ -17,8 +17,69 @@ airs runtime api-keys list [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default) — `last8` is the trailing 8 chars of the secret; full key is only echoed on create / regenerate*
+
+```bash
+airs runtime api-keys list --limit 2
+```
+
+```text
+Prisma AIRS — Runtime Configuration
+Security profile and topic management
+
+
+API Keys:
+
+00000000-0000-0000-0000-000000000001
+  docs-example-key key: …ABCD1234
+00000000-0000-0000-0000-000000000002
+  docs-other-example-key key: …EFGH5678
+```
+
+*JSON output*
+
+```bash
+airs runtime api-keys list --limit 2 --output json
+```
+
+```text
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "name": "docs-example-key",
+    "last8": "ABCD1234",
+    "createdAt": "",
+    "expiresAt": ""
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000002",
+    "name": "docs-other-example-key",
+    "last8": "EFGH5678",
+    "createdAt": "",
+    "expiresAt": ""
+  }
+]
+```
+
+*YAML output (multi-doc stream — one document per key)*
+
+```bash
+airs runtime api-keys list --limit 2 --output yaml
+```
+
+```text
+id: 00000000-0000-0000-0000-000000000001
+name: docs-example-key
+last8: ABCD1234
+createdAt:
+expiresAt:
+---
+id: 00000000-0000-0000-0000-000000000002
+name: docs-other-example-key
+last8: EFGH5678
+createdAt:
+expiresAt:
+```
 
 ---
 

--- a/docs/cli/runtime/customer-apps.md
+++ b/docs/cli/runtime/customer-apps.md
@@ -17,8 +17,59 @@ airs runtime customer-apps list [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default) — only `name` is rendered; richer detail requires `customer-apps get` (currently blocked, see cdot65/prisma-airs-cli#115)*
+
+```bash
+airs runtime customer-apps list --limit 2
+```
+
+```text
+Prisma AIRS — Runtime Configuration
+Security profile and topic management
+
+
+Customer Apps:
+
+  example-app
+  example-other-app
+```
+
+*JSON output — `id` and `description` are empty in the list response (the list endpoint only returns names)*
+
+```bash
+airs runtime customer-apps list --limit 2 --output json
+```
+
+```text
+[
+  {
+    "id": "",
+    "name": "example-app",
+    "description": ""
+  },
+  {
+    "id": "",
+    "name": "example-other-app",
+    "description": ""
+  }
+]
+```
+
+*YAML output (multi-doc stream — one document per app)*
+
+```bash
+airs runtime customer-apps list --limit 2 --output yaml
+```
+
+```text
+id:
+name: example-app
+description:
+---
+id:
+name: example-other-app
+description:
+```
 
 ---
 


### PR DESCRIPTION
Closes #91. Part of epic #83.

## Scope landed

- `runtime api-keys list` — pretty/json/yaml captures
- `runtime customer-apps list` — pretty/json/yaml captures

## Blocked (tracked)

- `runtime api-keys create` — upstream returns 503 NoActiveTargets — see #116
- `runtime customer-apps get` — upstream returns 403 Forbidden — see #115

## Deferred for safety

Destructive ops on the shared tenant deferred without exercise:
`api-keys regenerate`, `api-keys delete`, `customer-apps update`, `customer-apps delete`. These remain on `.missing-allowlist` without a Blocked comment.

## Verify

- [x] `pnpm docs:gen`
- [x] `pnpm format`
- [x] `pnpm docs:check` — 124 commands, 86 on allowlist