### PR TITLE
docs(model-security): add live input/output examples

### DIFF
--- a/.changeset/docs-model-security-examples.md
+++ b/.changeset/docs-model-security-examples.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+docs(model-security): add live input/output examples for read-only commands — `groups get`, `rules get`, `rule-instances get`, `labels keys`, `labels values`, `pypi-auth`. Filed tracking issue #121 for scan-detail commands (`scans get`/`evaluations`/`evaluation`/`violations`/`violation`/`files`) that need scan fixtures on a docs-capture tenant. Destructive ops (`groups create`/`update`/`delete`, `labels add`/`set`/`delete`, `rule-instances update`, `scans create`) remain on the allowlist, deferred for safety on the shared QA tenant.

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -77,23 +77,23 @@ redteam targets init
 redteam targets templates
 redteam targets backup
 redteam targets restore
-model-security groups get
 model-security groups create
 model-security groups update
 model-security groups delete
 model-security labels add
 model-security labels set
 model-security labels delete
-model-security labels keys
-model-security labels values
-model-security pypi-auth
-model-security rule-instances get
 model-security rule-instances update
-model-security rules get
-model-security scans get
 model-security scans create
+# Blocked by missing scan fixtures — see https://github.com/cdot65/prisma-airs-cli/issues/121
+model-security scans get
+# Blocked by missing scan fixtures — see https://github.com/cdot65/prisma-airs-cli/issues/121
 model-security scans evaluations
+# Blocked by missing scan fixtures — see https://github.com/cdot65/prisma-airs-cli/issues/121
 model-security scans evaluation
+# Blocked by missing scan fixtures — see https://github.com/cdot65/prisma-airs-cli/issues/121
 model-security scans violations
+# Blocked by missing scan fixtures — see https://github.com/cdot65/prisma-airs-cli/issues/121
 model-security scans violation
+# Blocked by missing scan fixtures — see https://github.com/cdot65/prisma-airs-cli/issues/121
 model-security scans files

--- a/docs/cli/examples/model-security.yaml
+++ b/docs/cli/examples/model-security.yaml
@@ -68,6 +68,106 @@
           /Users/cdot/models/qwen3-0.6b-saffron-merged
           Rules: 6 passed  0 failed  / 6 total
 
+"model-security groups get":
+  examples:
+    - note: Pretty output (default; no --output flag on this command)
+      input: airs model-security groups get 00000000-0000-0000-0000-000000000001
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+
+          Security Group Detail:
+
+            UUID:        00000000-0000-0000-0000-000000000001
+            Name:        Default HUGGING_FACE
+            Description: Auto-created default security group for HUGGING_FACE models
+            Source Type: HUGGING_FACE
+            State:       ACTIVE
+            Created:     2025-11-24T15:44:39.596957Z
+            Updated:     2025-11-24T15:44:48.852089Z
+
+"model-security rules get":
+  examples:
+    - note: Pretty output (default; no --output flag on this command)
+      input: airs model-security rules get 550e8400-e29b-41d4-a716-44665544000b
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+
+          Security Rule Detail:
+
+            UUID:          550e8400-e29b-41d4-a716-44665544000b
+            Name:          Known Framework Operators Check
+            Description:   Model artifacts should only contain known safe TensorFlow operators
+            Rule Type:     ARTIFACT
+            Default State: BLOCKING
+            Sources:       ALL
+
+            Remediation:
+              Ensure that the model does not contain any custom TensorFlow operators that can execute arbitrary code
+              • Review the violation details to understand which operators were flagged.
+              • This rule cannot allowlist individual operators - it either blocks or allows all unknown operators. If your environment regularly uses trusted custom operators, set this rule to Allowing mode in the security group that scanned this model.
+              • If the operators are unknown or untrusted, do not use the model and source an alternative that uses only standard framework operators.
+              https://docs.paloaltonetworks.com/ai-runtime-security/ai-model-security/model-security-to-secure-your-ai-models/understanding-ai-model-security-rules#concept-rrb_bqp_xgc
+
+"model-security rule-instances get":
+  examples:
+    - note: Pretty output (default; no --output flag on this command)
+      input: airs model-security rule-instances get 00000000-0000-0000-0000-000000000001 00000000-0000-0000-0000-000000000002
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+
+          Rule Instance Detail:
+
+            UUID:         00000000-0000-0000-0000-000000000002
+            Group UUID:   00000000-0000-0000-0000-000000000001
+            Rule UUID:    550e8400-e29b-41d4-a716-44665544000b
+            State:        BLOCKING
+            Rule Name:    Known Framework Operators Check
+            Created:      2025-11-24T15:44:39.596957Z
+            Updated:      2025-11-24T15:44:39.596957Z
+
+"model-security labels keys":
+  examples:
+    - note: Empty result — no scan labels have been created yet
+      input: airs model-security labels keys
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+          No label keys found.
+
+"model-security labels values":
+  examples:
+    - note: Empty result — no values for an unknown key
+      input: airs model-security labels values example-key
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+          No values for key "example-key".
+
+"model-security pypi-auth":
+  examples:
+    - note: |
+        Fetches a short-lived OAuth-based PyPI index URL for the AIRS Model
+        Security private registry. The token in the URL is redacted here; in
+        real output it is a Google OAuth access token valid until `Expires`.
+      input: airs model-security pypi-auth
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+
+          PyPI Authentication:
+
+            URL:     https://oauth2accesstoken:ya29.<redacted-oauth-token>@us-west1-python.pkg.dev/pairs-modelsec-prd-l9mu/ms-prod-usw1-mp-main-pypi/simple/
+            Expires: 2026-05-25T15:06:25
+
 "model-security install":
   examples:
     - note: Install with all extras (auto-detects uv or pip)

--- a/docs/cli/model-security/groups.md
+++ b/docs/cli/model-security/groups.md
@@ -59,8 +59,27 @@ airs model-security groups get [options] <uuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default; no --output flag on this command)*
+
+```bash
+airs model-security groups get 00000000-0000-0000-0000-000000000001
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+
+Security Group Detail:
+
+  UUID:        00000000-0000-0000-0000-000000000001
+  Name:        Default HUGGING_FACE
+  Description: Auto-created default security group for HUGGING_FACE models
+  Source Type: HUGGING_FACE
+  State:       ACTIVE
+  Created:     2025-11-24T15:44:39.596957Z
+  Updated:     2025-11-24T15:44:48.852089Z
+```
 
 ---
 

--- a/docs/cli/model-security/labels.md
+++ b/docs/cli/model-security/labels.md
@@ -91,8 +91,18 @@ airs model-security labels keys [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Empty result — no scan labels have been created yet*
+
+```bash
+airs model-security labels keys
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+No label keys found.
+```
 
 ---
 
@@ -116,5 +126,15 @@ airs model-security labels values [options] <key>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Empty result — no values for an unknown key*
+
+```bash
+airs model-security labels values example-key
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+No values for key "example-key".
+```

--- a/docs/cli/model-security/pypi-auth.md
+++ b/docs/cli/model-security/pypi-auth.md
@@ -10,5 +10,22 @@ airs model-security pypi-auth [options]
 
 ### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Fetches a short-lived OAuth-based PyPI index URL for the AIRS Model
+Security private registry. The token in the URL is redacted here; in
+real output it is a Google OAuth access token valid until `Expires`.
+*
+
+```bash
+airs model-security pypi-auth
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+
+PyPI Authentication:
+
+  URL:     https://oauth2accesstoken:ya29.<redacted-oauth-token>@us-west1-python.pkg.dev/pairs-modelsec-prd-l9mu/ms-prod-usw1-mp-main-pypi/simple/
+  Expires: 2026-05-25T15:06:25
+```

--- a/docs/cli/model-security/rule-instances.md
+++ b/docs/cli/model-security/rule-instances.md
@@ -58,8 +58,27 @@ airs model-security rule-instances get [options] <groupUuid> <instanceUuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default; no --output flag on this command)*
+
+```bash
+airs model-security rule-instances get 00000000-0000-0000-0000-000000000001 00000000-0000-0000-0000-000000000002
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+
+Rule Instance Detail:
+
+  UUID:         00000000-0000-0000-0000-000000000002
+  Group UUID:   00000000-0000-0000-0000-000000000001
+  Rule UUID:    550e8400-e29b-41d4-a716-44665544000b
+  State:        BLOCKING
+  Rule Name:    Known Framework Operators Check
+  Created:      2025-11-24T15:44:39.596957Z
+  Updated:      2025-11-24T15:44:39.596957Z
+```
 
 ---
 

--- a/docs/cli/model-security/rules.md
+++ b/docs/cli/model-security/rules.md
@@ -58,5 +58,30 @@ airs model-security rules get [options] <uuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default; no --output flag on this command)*
+
+```bash
+airs model-security rules get 550e8400-e29b-41d4-a716-44665544000b
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+
+Security Rule Detail:
+
+  UUID:          550e8400-e29b-41d4-a716-44665544000b
+  Name:          Known Framework Operators Check
+  Description:   Model artifacts should only contain known safe TensorFlow operators
+  Rule Type:     ARTIFACT
+  Default State: BLOCKING
+  Sources:       ALL
+
+  Remediation:
+    Ensure that the model does not contain any custom TensorFlow operators that can execute arbitrary code
+    • Review the violation details to understand which operators were flagged.
+    • This rule cannot allowlist individual operators - it either blocks or allows all unknown operators. If your environment regularly uses trusted custom operators, set this rule to Allowing mode in the security group that scanned this model.
+    • If the operators are unknown or untrusted, do not use the model and source an alternative that uses only standard framework operators.
+    https://docs.paloaltonetworks.com/ai-runtime-security/ai-model-security/model-security-to-secure-your-ai-models/understanding-ai-model-security-rules#concept-rrb_bqp_xgc
+```


### PR DESCRIPTION
Closes #96. Part of epic #83.

## Scope landed

Pretty-output captures for the read-only commands that lack `--output` support:

- `model-security groups get <uuid>`
- `model-security rules get <uuid>`
- `model-security rule-instances get <groupUuid> <instanceUuid>`
- `model-security labels keys`
- `model-security labels values <key>`
- `model-security pypi-auth` (OAuth token redacted in fixture)

## Blocked (tracked)

`model-security scans` detail commands need a tenant with at least one scan record. Filed #121 and kept the entries on `.missing-allowlist` with `# Blocked by …` comments:

- `scans get`, `scans evaluations`, `scans evaluation`, `scans violations`, `scans violation`, `scans files`

## Deferred for safety

Destructive ops on the shared QA tenant deferred without exercise; entries kept on `.missing-allowlist` (no Blocked comment):

- `groups create`, `groups update`, `groups delete`
- `labels add`, `labels set`, `labels delete`
- `rule-instances update`
- `scans create`

## Verify

- [x] `pnpm docs:gen`
- [x] `pnpm format`
- [x] `pnpm docs:check` — 124 commands, 76 on allowlist (down from 86)