### PR TITLE
docs(runtime): retry safety-defer/upstream sub-issues against fresh tenant

### DIFF
--- a/.changeset/docs-runtime-retry-examples.md
+++ b/.changeset/docs-runtime-retry-examples.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+docs(cli): live examples for `runtime api-keys create` and `runtime api-keys regenerate` against a fresh-tenant retry. Burns two entries off the docs allowlist. Re-tags remaining runtime allowlist entries to new tracking issues: `runtime api-keys delete` and `runtime customer-apps delete` against new SDK bugs (server-side succeeds, SDK schema rejects string-body 200), and `runtime customer-apps update` against a new upstream 503.

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -1,12 +1,12 @@
 # Commands awaiting curated input/output examples. Burn this list down to zero,
 # then flip docs:check to hard-fail in CI (remove the allowlist read).
-# Blocked by upstream — see https://github.com/cdot65/prisma-airs-cli/issues/116
-runtime api-keys create
-runtime api-keys regenerate
+# Blocked by SDK — see https://github.com/cdot65/prisma-airs-sdk/issues/166
 runtime api-keys delete
 # Blocked by upstream — see https://github.com/cdot65/prisma-airs-cli/issues/115
 runtime customer-apps get
+# Blocked by upstream API 503 — see https://github.com/cdot65/prisma-airs-cli/issues/193
 runtime customer-apps update
+# Blocked by SDK — see https://github.com/cdot65/prisma-airs-sdk/issues/167
 runtime customer-apps delete
 # Blocked by SDK — see https://github.com/cdot65/prisma-airs-sdk/issues/164
 runtime profiles delete

--- a/docs/cli/examples/runtime.yaml
+++ b/docs/cli/examples/runtime.yaml
@@ -1552,3 +1552,38 @@
         id:
         name: example-other-app
         description:
+
+"runtime api-keys create":
+  examples:
+    - note: Create a new API key from a config fixture (no JSON output flag — pretty only). The full secret is echoed exactly once; subsequent `list` only shows `last8`.
+      input: airs runtime api-keys create --config docs/cli/examples/runtime/api-keys-create.json
+      output: |
+          Prisma AIRS — Runtime Configuration
+          Security profile and topic management
+
+          API key created: 00000000-0000-0000-0000-000000000001
+
+
+          API Key Detail:
+
+            ID:      00000000-0000-0000-0000-000000000001
+            Name:    docs-example-key
+            Key:     EXAMPLEKEYREDACTEDFORDOCSDONOTUSEEXAMPLEKEYREDA
+
+"runtime api-keys regenerate":
+  examples:
+    - note: Regenerate by api-key UUID. Returns a NEW UUID and a NEW secret — the old key is invalidated. No JSON output flag — pretty only.
+      input: airs runtime api-keys regenerate 00000000-0000-0000-0000-000000000001 --interval 90 --unit days --updated-by user@example.com
+      output: |
+          Prisma AIRS — Runtime Configuration
+          Security profile and topic management
+
+          API key regenerated: 00000000-0000-0000-0000-000000000002
+
+
+          API Key Detail:
+
+            ID:      00000000-0000-0000-0000-000000000002
+            Name:    docs-example-key
+            Key:     EXAMPLEROTATEDKEYREDACTEDFORDOCSDONOTUSEEXAMPLE
+

--- a/docs/cli/examples/runtime/api-keys-create.json
+++ b/docs/cli/examples/runtime/api-keys-create.json
@@ -1,0 +1,9 @@
+{
+  "api_key_name": "docs-example-key",
+  "auth_code": "D5901742",
+  "cust_app": "CLI",
+  "created_by": "user@example.com",
+  "revoked": false,
+  "rotation_time_interval": 90,
+  "rotation_time_unit": "days"
+}

--- a/docs/cli/runtime/api-keys.md
+++ b/docs/cli/runtime/api-keys.md
@@ -99,8 +99,25 @@ airs runtime api-keys create [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Create a new API key from a config fixture (no JSON output flag — pretty only). The full secret is echoed exactly once; subsequent `list` only shows `last8`.*
+
+```bash
+airs runtime api-keys create --config docs/cli/examples/runtime/api-keys-create.json
+```
+
+```text
+Prisma AIRS — Runtime Configuration
+Security profile and topic management
+
+API key created: 00000000-0000-0000-0000-000000000001
+
+
+API Key Detail:
+
+  ID:      00000000-0000-0000-0000-000000000001
+  Name:    docs-example-key
+  Key:     EXAMPLEKEYREDACTEDFORDOCSDONOTUSEEXAMPLEKEYREDA
+```
 
 ---
 
@@ -126,8 +143,25 @@ airs runtime api-keys regenerate [options] <apiKeyId>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Regenerate by api-key UUID. Returns a NEW UUID and a NEW secret — the old key is invalidated. No JSON output flag — pretty only.*
+
+```bash
+airs runtime api-keys regenerate 00000000-0000-0000-0000-000000000001 --interval 90 --unit days --updated-by user@example.com
+```
+
+```text
+Prisma AIRS — Runtime Configuration
+Security profile and topic management
+
+API key regenerated: 00000000-0000-0000-0000-000000000002
+
+
+API Key Detail:
+
+  ID:      00000000-0000-0000-0000-000000000002
+  Name:    docs-example-key
+  Key:     EXAMPLEROTATEDKEYREDACTEDFORDOCSDONOTUSEEXAMPLE
+```
 
 ---
 


### PR DESCRIPTION
Closes the runtime sub-issues under epic #127 that landed examples. Updates #131. Part of epic #127.

## Summary
- Landed live examples for `runtime api-keys create` and `runtime api-keys regenerate` (closes #134, #140) on tenant 1852583913.
- Re-probed 6 still-blocked commands; classified root cause and filed/re-tagged tracking:
  - `api-keys delete` → sdk#166 (new): server-side OK, SDK schema rejects string body.
  - `customer-apps get` → upstream #115 (OPA 403, unchanged).
  - `customer-apps update` → upstream #193 (new): 503 NoActiveTargets on PUT.
  - `customer-apps delete` → sdk#167 (new): same family as #164/#165/#166.
  - `profiles delete` → sdk#164 (unchanged).
  - `topics delete` → sdk#165 (unchanged).
- Allowlist: 61 → 59.

## Test plan
- [x] `pnpm docs:gen`
- [x] `pnpm format`
- [x] `pnpm docs:check` — passes, 59 allowlist entries
- [x] Tenant 1852583913 verified clean: no `-docs-test` resources remain