### PR TITLE
docs(dlp): retry upstream-blocked sub-issues against fresh tenant

### DIFF
--- a/.changeset/docs-dlp-retry-examples.md
+++ b/.changeset/docs-dlp-retry-examples.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Re-probed the 12 DLP commands previously blocked under epic #127 against a fresh DLP-licensed tenant. Landed a curated input/output example for `runtime dlp filtering-profiles replace` (closes #189) and removed it from `.missing-allowlist`. The other 11 (#181-#188, #190-#192) still fail with the same upstream 400s (#80, #98, #99, #101) or CLI key-mangling bug (#105) on the new tenant; their `.missing-allowlist` entries and tracking links are kept and each sub-issue body is updated with fresh retry evidence.

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -14,8 +14,6 @@ runtime profiles delete
 runtime topics delete
 # Blocked by CLI bug — see https://github.com/cdot65/prisma-airs-cli/issues/105
 runtime dlp filtering-profiles get
-# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/107
-runtime dlp filtering-profiles replace
 # Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/80
 runtime dlp patterns get
 # Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/98

--- a/docs/cli/examples/dlp/filtering-profiles/replace.json
+++ b/docs/cli/examples/dlp/filtering-profiles/replace.json
@@ -1,0 +1,10 @@
+{
+  "name": "example-filtering-profile",
+  "data_profile_id": 1,
+  "direction": "c2s",
+  "file_based": true,
+  "non_file_based": false,
+  "log_severity": "low",
+  "scan_type": "include",
+  "file_type": ["pdf", "doc", "docx"]
+}

--- a/docs/cli/examples/runtime.yaml
+++ b/docs/cli/examples/runtime.yaml
@@ -1323,6 +1323,19 @@
           total: 29
           returned: 2
 
+"runtime dlp filtering-profiles replace":
+  examples:
+    - note: Replace a filtering profile from a body fixture (see docs/cli/examples/dlp/filtering-profiles/replace.json). The API returns the new version on success.
+      input: airs runtime dlp filtering-profiles replace 000000000000000000000001 --body-file docs/cli/examples/dlp/filtering-profiles/replace.json --output json
+      output: |
+        {
+          "action": "replaced",
+          "id": "000000000000000000000001",
+          "name": "example-filtering-profile",
+          "type": "predefined",
+          "version": 2
+        }
+
 "runtime deployment-profiles list":
   examples:
     - note: Pretty output (default)

--- a/docs/cli/runtime/dlp/filtering-profiles.md
+++ b/docs/cli/runtime/dlp/filtering-profiles.md
@@ -158,5 +158,18 @@ airs runtime dlp filtering-profiles replace [options] <id>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Replace a filtering profile from a body fixture (see docs/cli/examples/dlp/filtering-profiles/replace.json). The API returns the new version on success.*
+
+```bash
+airs runtime dlp filtering-profiles replace 000000000000000000000001 --body-file docs/cli/examples/dlp/filtering-profiles/replace.json --output json
+```
+
+```text
+{
+  "action": "replaced",
+  "id": "000000000000000000000001",
+  "name": "example-filtering-profile",
+  "type": "predefined",
+  "version": 2
+}
+```


### PR DESCRIPTION
## Summary

- Re-probed 12 DLP sub-issues under epic #127 / category #128 against fresh DLP-licensed tenant (1852583913).
- Landed a curated input/output example for `runtime dlp filtering-profiles replace` (closes #189) + JSON body fixture; removed from `.missing-allowlist`.
- Verified the other 11 sub-issues (#181–#188, #190–#192) still reproduce the same upstream 400s (#80, #98, #99, #101) and CLI key-mangling bug (#105) on the fresh tenant; bodies updated with fresh retry evidence and `.missing-allowlist` entries retained with tracking links.

Closes #189. Updates #128. Part of epic #127.

## Test plan

- [x] `pnpm docs:gen` regenerates `docs/cli/runtime/dlp/filtering-profiles.md` with the new example
- [x] `pnpm format` clean
- [x] `pnpm docs:check` passes (124 commands, 60 on allowlist — one less than before)
- [x] Live capture against tenant 1852583913 verified against `airs --debug` API log
- [x] Tenant cleanup: seed `pattern-docs-test` archived; no `*-docs-test` resources active; predefined SOX filtering profile restored to canonical 35 file_types