### PR TITLE
docs(model-security): retry license/fixture-blocked sub-issues against fresh tenant

### DIFF
--- a/.changeset/docs-modelsec-retry-examples.md
+++ b/.changeset/docs-modelsec-retry-examples.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Re-probed all 14 model-security commands previously blocked under epic #127 (#130 — license-deferred + fixture-blocked) against a fresh model-security-licensed tenant. Landed curated input/output examples for `groups create/update/delete` (#132/#133/#135), `rule-instances update` (#139), `labels add/set/delete` (#136/#137/#138), `scans create/get/evaluations/evaluation/violations/violation/files` (#141/#142/#143/#144/#145/#147/#148). All 14 entries removed from `.missing-allowlist` (60 → 44). Sub-issues closed.

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -75,23 +75,3 @@ redteam targets delete
 redteam targets probe
 redteam targets update-profile
 redteam targets validate-auth
-model-security groups create
-model-security groups update
-model-security groups delete
-model-security labels add
-model-security labels set
-model-security labels delete
-model-security rule-instances update
-model-security scans create
-# Blocked by missing scan fixtures — see https://github.com/cdot65/prisma-airs-cli/issues/121
-model-security scans get
-# Blocked by missing scan fixtures — see https://github.com/cdot65/prisma-airs-cli/issues/121
-model-security scans evaluations
-# Blocked by missing scan fixtures — see https://github.com/cdot65/prisma-airs-cli/issues/121
-model-security scans evaluation
-# Blocked by missing scan fixtures — see https://github.com/cdot65/prisma-airs-cli/issues/121
-model-security scans violations
-# Blocked by missing scan fixtures — see https://github.com/cdot65/prisma-airs-cli/issues/121
-model-security scans violation
-# Blocked by missing scan fixtures — see https://github.com/cdot65/prisma-airs-cli/issues/121
-model-security scans files

--- a/docs/cli/examples/model-security.yaml
+++ b/docs/cli/examples/model-security.yaml
@@ -178,3 +178,292 @@
       input: airs model-security install --dry-run
     - note: Install into a custom directory
       input: airs model-security install --dir my-scanner
+
+"model-security groups create":
+  examples:
+    - note: Create from body fixture (see docs/cli/examples/model-security/group-create.json)
+      input: airs model-security groups create --config docs/cli/examples/model-security/group-create.json
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+          Group created: 00000000-0000-0000-0000-000000000001
+
+
+          Security Group Detail:
+
+            UUID:        00000000-0000-0000-0000-000000000001
+            Name:        group-docs-test
+            Description: Throwaway group for docs capture — safe to delete
+            Source Type: HUGGING_FACE
+            State:       PENDING
+            Created:     2026-05-26T10:20:10.809882Z
+            Updated:     2026-05-26T10:20:10.809882Z
+
+"model-security groups update":
+  examples:
+    - note: Update the description (use --name to rename)
+      input: airs model-security groups update 00000000-0000-0000-0000-000000000001 --description "Throwaway group — updated description for docs capture"
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+          Group updated: 00000000-0000-0000-0000-000000000001
+
+
+          Security Group Detail:
+
+            UUID:        00000000-0000-0000-0000-000000000001
+            Name:        group-docs-test
+            Description: Throwaway group — updated description for docs capture
+            Source Type: HUGGING_FACE
+            State:       PENDING
+            Created:     2026-05-26T10:20:10.809882Z
+            Updated:     2026-05-26T10:20:45.684391Z
+
+"model-security groups delete":
+  examples:
+    - note: Delete a security group by UUID
+      input: airs model-security groups delete 00000000-0000-0000-0000-000000000001
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+          Group 00000000-0000-0000-0000-000000000001 deleted.
+
+"model-security rule-instances update":
+  examples:
+    - note: Flip a rule instance from BLOCKING to ALLOWING (see docs/cli/examples/model-security/rule-instance-update.json)
+      input: airs model-security rule-instances update 00000000-0000-0000-0000-000000000001 00000000-0000-0000-0000-000000000003 --config docs/cli/examples/model-security/rule-instance-update.json
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+          Rule instance updated: 00000000-0000-0000-0000-000000000003
+
+
+          Rule Instance Detail:
+
+            UUID:         00000000-0000-0000-0000-000000000003
+            Group UUID:   00000000-0000-0000-0000-000000000001
+            Rule UUID:    550e8400-e29b-41d4-a716-44665544000b
+            State:        ALLOWING
+            Rule Name:    Known Framework Operators Check
+            Created:      2026-05-26T10:20:10.809882Z
+            Updated:      2026-05-26T10:20:38.433422Z
+
+"model-security scans create":
+  examples:
+    - note: |
+        Submit a Hugging Face model URI to be scanned by the AIRS backend.
+        For HF URIs you provide model_uri + security_group_uuid + scan_origin only;
+        the backend fetches and scans the model and the resulting outcome is
+        available via `scans get` shortly after. See
+        docs/cli/examples/model-security/scan-create.json.
+      input: airs model-security scans create --config docs/cli/examples/model-security/scan-create.json
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+          Scan created: 00000000-0000-0000-0000-000000000002
+
+
+          Scan Detail:
+
+            UUID:       00000000-0000-0000-0000-000000000002
+            Outcome:    PENDING
+            Model URI:  https://huggingface.co/hf-internal-testing/tiny-random-bert
+            Origin:     MODEL_SECURITY_SDK
+            Source:     HUGGING_FACE
+            Group:      group-docs-test
+            Created:    2026-05-26T10:22:18.284287Z
+            Updated:    2026-05-26T10:22:18.284287Z
+
+"model-security scans get":
+  examples:
+    - note: Pretty output (default; no --output flag on this command). Re-run after scan completes to see final Outcome + rule counts.
+      input: airs model-security scans get 00000000-0000-0000-0000-000000000002
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+
+          Scan Detail:
+
+            UUID:       00000000-0000-0000-0000-000000000002
+            Outcome:    BLOCKED
+            Model URI:  https://huggingface.co/hf-internal-testing/tiny-random-bert
+            Origin:     MODEL_SECURITY_SDK
+            Source:     HUGGING_FACE
+            Group:      group-docs-test
+            Created:    2026-05-26T10:22:18.284287Z
+            Updated:    2026-05-26T10:22:18.346345Z
+            Rules:      7 passed  4 failed  / 11 total
+
+"model-security scans evaluations":
+  examples:
+    - note: List rule evaluations for a scan (one row per rule the scan was checked against)
+      input: airs model-security scans evaluations 00000000-0000-0000-0000-000000000002
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+
+          Rule Evaluations:
+
+          00000000-0000-0000-0000-000000000004
+            License Exists  FAILED  BLOCKING
+          00000000-0000-0000-0000-000000000005
+            License Is Valid For Use  FAILED  BLOCKING
+          00000000-0000-0000-0000-000000000006
+            Model Is Blocked  PASSED  BLOCKING
+          00000000-0000-0000-0000-000000000007
+            Organization Is Blocked  PASSED  BLOCKING
+          00000000-0000-0000-0000-000000000008
+            Organization Verified By Hugging Face  FAILED  BLOCKING
+          00000000-0000-0000-0000-000000000009
+            Stored In Approved File Format  FAILED  BLOCKING
+          00000000-0000-0000-0000-00000000000a
+            Known Framework Operators Check  PASSED  ALLOWING
+          00000000-0000-0000-0000-00000000000b
+            Load Time Code Execution Check  PASSED  BLOCKING
+          00000000-0000-0000-0000-00000000000c
+            Model Architecture Backdoor Check  PASSED  BLOCKING
+          00000000-0000-0000-0000-00000000000d
+            Runtime Code Execution Check  PASSED  BLOCKING
+          00000000-0000-0000-0000-00000000000e
+            Suspicious Model Components Check  PASSED  BLOCKING
+
+"model-security scans evaluation":
+  examples:
+    - note: Get details for a single rule evaluation (UUID from `scans evaluations`)
+      input: airs model-security scans evaluation 00000000-0000-0000-0000-000000000004
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+
+          Evaluation Detail:
+
+            UUID:           00000000-0000-0000-0000-000000000004
+            Rule:           License Exists
+            Description:    Models should have a license
+            Instance UUID:  00000000-0000-0000-0000-00000000000f
+            Instance State: BLOCKING
+            Result:         FAILED
+            Violations:     1
+
+"model-security scans violations":
+  examples:
+    - note: List violations for a scan
+      input: airs model-security scans violations 00000000-0000-0000-0000-000000000002
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+
+          Violations:
+
+          00000000-0000-0000-0000-000000000010
+            Organization Verified By Hugging Face  
+            The org/model pair (**hf-internal-testing/tiny-random-bert**) is denied since it has not been explicitly approved
+            Threat: 
+          00000000-0000-0000-0000-000000000011
+            License Exists  
+            input data has a null license
+            Threat: 
+          00000000-0000-0000-0000-000000000012
+            Stored In Approved File Format  pytorch_model.bin
+            Model file `pytorch_model.bin` is stored in an unapproved format: **pytorch_v1_13**
+            Threat: UNAPPROVED_FORMATS
+          00000000-0000-0000-0000-000000000013
+            Stored In Approved File Format  pytorch_model.bin
+            Model file `pytorch_model.bin` is stored in an unapproved format: **zip**
+            Threat: UNAPPROVED_FORMATS
+          00000000-0000-0000-0000-000000000014
+            Stored In Approved File Format  tf_model.h5
+            Model file `tf_model.h5` is stored in an unapproved format: **keras_weights**
+            Threat: UNAPPROVED_FORMATS
+          00000000-0000-0000-0000-000000000015
+            Stored In Approved File Format  vocab.txt
+            Model file `vocab.txt` is stored in an unapproved format: **openvino_bin**
+            Threat: UNAPPROVED_FORMATS
+          00000000-0000-0000-0000-000000000016
+            Stored In Approved File Format  onnx/model.onnx
+            Model file `onnx/model.onnx` is stored in an unapproved format: **onnx**
+            Threat: UNAPPROVED_FORMATS
+          00000000-0000-0000-0000-000000000017
+            License Is Valid For Use  
+            Invalid license: **null**
+            Threat: 
+
+"model-security scans violation":
+  examples:
+    - note: Get details for a single violation (UUID from `scans violations`)
+      input: airs model-security scans violation 00000000-0000-0000-0000-000000000010
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+
+          Violation Detail:
+
+            UUID:        00000000-0000-0000-0000-000000000010
+            Rule:        Organization Verified By Hugging Face
+            Description: Organization that produced the model should be verified by Hugging Face
+            State:       BLOCKING
+            File:        
+            Threat:      
+            Detail:      The org/model pair (**hf-internal-testing/tiny-random-bert**) is denied since it has not been explicitly approved
+
+"model-security scans files":
+  examples:
+    - note: List files the scanner processed (FAILED rows are the ones with violations)
+      input: airs model-security scans files 00000000-0000-0000-0000-000000000002
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+
+          Scanned Files:
+
+            SUCCESS  FILE  config.json [json]
+            SKIPPED  FILE  .gitattributes
+            SUCCESS  FILE  model.safetensors [safetensors]
+            SUCCESS  DIRECTORY  onnx
+            FAILED  FILE  pytorch_model.bin [zip, pytorch_v1_13]
+            SUCCESS  FILE  special_tokens_map.json [json]
+            FAILED  FILE  tf_model.h5 [keras_weights]
+            SUCCESS  FILE  tokenizer_config.json [json]
+            SUCCESS  FILE  tokenizer.json [json]
+            FAILED  FILE  vocab.txt [openvino_bin]
+
+"model-security labels add":
+  examples:
+    - note: Append labels to a scan (preserves existing keys)
+      input: airs model-security labels add 00000000-0000-0000-0000-000000000002 --labels '[{"key":"env","value":"docs-test"},{"key":"capture","value":"true"}]'
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+          Labels added.
+
+"model-security labels set":
+  examples:
+    - note: Replace all labels on a scan (drops keys not in the request)
+      input: airs model-security labels set 00000000-0000-0000-0000-000000000002 --labels '[{"key":"env","value":"updated"}]'
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+          Labels set.
+
+"model-security labels delete":
+  examples:
+    - note: Delete one or more labels by comma-separated key list
+      input: airs model-security labels delete 00000000-0000-0000-0000-000000000002 --keys env
+      output: |
+          Prisma AIRS — Model Security
+          ML model supply chain security
+
+          Labels deleted.

--- a/docs/cli/examples/model-security/group-create.json
+++ b/docs/cli/examples/model-security/group-create.json
@@ -1,0 +1,5 @@
+{
+  "name": "group-docs-test",
+  "source_type": "HUGGING_FACE",
+  "description": "Throwaway group for docs capture — safe to delete"
+}

--- a/docs/cli/examples/model-security/rule-instance-update.json
+++ b/docs/cli/examples/model-security/rule-instance-update.json
@@ -1,0 +1,3 @@
+{
+  "state": "ALLOWING"
+}

--- a/docs/cli/examples/model-security/scan-create.json
+++ b/docs/cli/examples/model-security/scan-create.json
@@ -1,0 +1,8 @@
+{
+  "model_uri": "https://huggingface.co/hf-internal-testing/tiny-random-bert",
+  "security_group_uuid": "00000000-0000-0000-0000-000000000001",
+  "scan_origin": "MODEL_SECURITY_SDK",
+  "model_author": "hf-internal-testing",
+  "model_name": "tiny-random-bert",
+  "model_version": "main"
+}

--- a/docs/cli/model-security/groups.md
+++ b/docs/cli/model-security/groups.md
@@ -99,8 +99,29 @@ airs model-security groups create [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Create from body fixture (see docs/cli/examples/model-security/group-create.json)*
+
+```bash
+airs model-security groups create --config docs/cli/examples/model-security/group-create.json
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+Group created: 00000000-0000-0000-0000-000000000001
+
+
+Security Group Detail:
+
+  UUID:        00000000-0000-0000-0000-000000000001
+  Name:        group-docs-test
+  Description: Throwaway group for docs capture — safe to delete
+  Source Type: HUGGING_FACE
+  State:       PENDING
+  Created:     2026-05-26T10:20:10.809882Z
+  Updated:     2026-05-26T10:20:10.809882Z
+```
 
 ---
 
@@ -125,8 +146,29 @@ airs model-security groups update [options] <uuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Update the description (use --name to rename)*
+
+```bash
+airs model-security groups update 00000000-0000-0000-0000-000000000001 --description "Throwaway group — updated description for docs capture"
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+Group updated: 00000000-0000-0000-0000-000000000001
+
+
+Security Group Detail:
+
+  UUID:        00000000-0000-0000-0000-000000000001
+  Name:        group-docs-test
+  Description: Throwaway group — updated description for docs capture
+  Source Type: HUGGING_FACE
+  State:       PENDING
+  Created:     2026-05-26T10:20:10.809882Z
+  Updated:     2026-05-26T10:20:45.684391Z
+```
 
 ---
 
@@ -144,5 +186,15 @@ airs model-security groups delete [options] <uuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Delete a security group by UUID*
+
+```bash
+airs model-security groups delete 00000000-0000-0000-0000-000000000001
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+Group 00000000-0000-0000-0000-000000000001 deleted.
+```

--- a/docs/cli/model-security/labels.md
+++ b/docs/cli/model-security/labels.md
@@ -20,8 +20,18 @@ airs model-security labels add [options] <scanUuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Append labels to a scan (preserves existing keys)*
+
+```bash
+airs model-security labels add 00000000-0000-0000-0000-000000000002 --labels '[{"key":"env","value":"docs-test"},{"key":"capture","value":"true"}]'
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+Labels added.
+```
 
 ---
 
@@ -45,8 +55,18 @@ airs model-security labels set [options] <scanUuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Replace all labels on a scan (drops keys not in the request)*
+
+```bash
+airs model-security labels set 00000000-0000-0000-0000-000000000002 --labels '[{"key":"env","value":"updated"}]'
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+Labels set.
+```
 
 ---
 
@@ -70,8 +90,18 @@ airs model-security labels delete [options] <scanUuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Delete one or more labels by comma-separated key list*
+
+```bash
+airs model-security labels delete 00000000-0000-0000-0000-000000000002 --keys env
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+Labels deleted.
+```
 
 ---
 

--- a/docs/cli/model-security/rule-instances.md
+++ b/docs/cli/model-security/rule-instances.md
@@ -103,5 +103,26 @@ airs model-security rule-instances update [options] <groupUuid> <instanceUuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Flip a rule instance from BLOCKING to ALLOWING (see docs/cli/examples/model-security/rule-instance-update.json)*
+
+```bash
+airs model-security rule-instances update 00000000-0000-0000-0000-000000000001 00000000-0000-0000-0000-000000000003 --config docs/cli/examples/model-security/rule-instance-update.json
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+Rule instance updated: 00000000-0000-0000-0000-000000000003
+
+
+Rule Instance Detail:
+
+  UUID:         00000000-0000-0000-0000-000000000003
+  Group UUID:   00000000-0000-0000-0000-000000000001
+  Rule UUID:    550e8400-e29b-41d4-a716-44665544000b
+  State:        ALLOWING
+  Rule Name:    Known Framework Operators Check
+  Created:      2026-05-26T10:20:10.809882Z
+  Updated:      2026-05-26T10:20:38.433422Z
+```

--- a/docs/cli/model-security/scans.md
+++ b/docs/cli/model-security/scans.md
@@ -56,8 +56,29 @@ airs model-security scans get [options] <uuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default; no --output flag on this command). Re-run after scan completes to see final Outcome + rule counts.*
+
+```bash
+airs model-security scans get 00000000-0000-0000-0000-000000000002
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+
+Scan Detail:
+
+  UUID:       00000000-0000-0000-0000-000000000002
+  Outcome:    BLOCKED
+  Model URI:  https://huggingface.co/hf-internal-testing/tiny-random-bert
+  Origin:     MODEL_SECURITY_SDK
+  Source:     HUGGING_FACE
+  Group:      group-docs-test
+  Created:    2026-05-26T10:22:18.284287Z
+  Updated:    2026-05-26T10:22:18.346345Z
+  Rules:      7 passed  4 failed  / 11 total
+```
 
 ---
 
@@ -77,8 +98,35 @@ airs model-security scans create [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Submit a Hugging Face model URI to be scanned by the AIRS backend.
+For HF URIs you provide model_uri + security_group_uuid + scan_origin only;
+the backend fetches and scans the model and the resulting outcome is
+available via `scans get` shortly after. See
+docs/cli/examples/model-security/scan-create.json.
+*
+
+```bash
+airs model-security scans create --config docs/cli/examples/model-security/scan-create.json
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+Scan created: 00000000-0000-0000-0000-000000000002
+
+
+Scan Detail:
+
+  UUID:       00000000-0000-0000-0000-000000000002
+  Outcome:    PENDING
+  Model URI:  https://huggingface.co/hf-internal-testing/tiny-random-bert
+  Origin:     MODEL_SECURITY_SDK
+  Source:     HUGGING_FACE
+  Group:      group-docs-test
+  Created:    2026-05-26T10:22:18.284287Z
+  Updated:    2026-05-26T10:22:18.284287Z
+```
 
 ---
 
@@ -102,8 +150,42 @@ airs model-security scans evaluations [options] <scanUuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*List rule evaluations for a scan (one row per rule the scan was checked against)*
+
+```bash
+airs model-security scans evaluations 00000000-0000-0000-0000-000000000002
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+
+Rule Evaluations:
+
+00000000-0000-0000-0000-000000000004
+  License Exists  FAILED  BLOCKING
+00000000-0000-0000-0000-000000000005
+  License Is Valid For Use  FAILED  BLOCKING
+00000000-0000-0000-0000-000000000006
+  Model Is Blocked  PASSED  BLOCKING
+00000000-0000-0000-0000-000000000007
+  Organization Is Blocked  PASSED  BLOCKING
+00000000-0000-0000-0000-000000000008
+  Organization Verified By Hugging Face  FAILED  BLOCKING
+00000000-0000-0000-0000-000000000009
+  Stored In Approved File Format  FAILED  BLOCKING
+00000000-0000-0000-0000-00000000000a
+  Known Framework Operators Check  PASSED  ALLOWING
+00000000-0000-0000-0000-00000000000b
+  Load Time Code Execution Check  PASSED  BLOCKING
+00000000-0000-0000-0000-00000000000c
+  Model Architecture Backdoor Check  PASSED  BLOCKING
+00000000-0000-0000-0000-00000000000d
+  Runtime Code Execution Check  PASSED  BLOCKING
+00000000-0000-0000-0000-00000000000e
+  Suspicious Model Components Check  PASSED  BLOCKING
+```
 
 ---
 
@@ -121,8 +203,27 @@ airs model-security scans evaluation [options] <uuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Get details for a single rule evaluation (UUID from `scans evaluations`)*
+
+```bash
+airs model-security scans evaluation 00000000-0000-0000-0000-000000000004
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+
+Evaluation Detail:
+
+  UUID:           00000000-0000-0000-0000-000000000004
+  Rule:           License Exists
+  Description:    Models should have a license
+  Instance UUID:  00000000-0000-0000-0000-00000000000f
+  Instance State: BLOCKING
+  Result:         FAILED
+  Violations:     1
+```
 
 ---
 
@@ -146,8 +247,52 @@ airs model-security scans violations [options] <scanUuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*List violations for a scan*
+
+```bash
+airs model-security scans violations 00000000-0000-0000-0000-000000000002
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+
+Violations:
+
+00000000-0000-0000-0000-000000000010
+  Organization Verified By Hugging Face  
+  The org/model pair (**hf-internal-testing/tiny-random-bert**) is denied since it has not been explicitly approved
+  Threat: 
+00000000-0000-0000-0000-000000000011
+  License Exists  
+  input data has a null license
+  Threat: 
+00000000-0000-0000-0000-000000000012
+  Stored In Approved File Format  pytorch_model.bin
+  Model file `pytorch_model.bin` is stored in an unapproved format: **pytorch_v1_13**
+  Threat: UNAPPROVED_FORMATS
+00000000-0000-0000-0000-000000000013
+  Stored In Approved File Format  pytorch_model.bin
+  Model file `pytorch_model.bin` is stored in an unapproved format: **zip**
+  Threat: UNAPPROVED_FORMATS
+00000000-0000-0000-0000-000000000014
+  Stored In Approved File Format  tf_model.h5
+  Model file `tf_model.h5` is stored in an unapproved format: **keras_weights**
+  Threat: UNAPPROVED_FORMATS
+00000000-0000-0000-0000-000000000015
+  Stored In Approved File Format  vocab.txt
+  Model file `vocab.txt` is stored in an unapproved format: **openvino_bin**
+  Threat: UNAPPROVED_FORMATS
+00000000-0000-0000-0000-000000000016
+  Stored In Approved File Format  onnx/model.onnx
+  Model file `onnx/model.onnx` is stored in an unapproved format: **onnx**
+  Threat: UNAPPROVED_FORMATS
+00000000-0000-0000-0000-000000000017
+  License Is Valid For Use  
+  Invalid license: **null**
+  Threat: 
+```
 
 ---
 
@@ -165,8 +310,27 @@ airs model-security scans violation [options] <uuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Get details for a single violation (UUID from `scans violations`)*
+
+```bash
+airs model-security scans violation 00000000-0000-0000-0000-000000000010
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+
+Violation Detail:
+
+  UUID:        00000000-0000-0000-0000-000000000010
+  Rule:        Organization Verified By Hugging Face
+  Description: Organization that produced the model should be verified by Hugging Face
+  State:       BLOCKING
+  File:        
+  Threat:      
+  Detail:      The org/model pair (**hf-internal-testing/tiny-random-bert**) is denied since it has not been explicitly approved
+```
 
 ---
 
@@ -192,5 +356,27 @@ airs model-security scans files [options] <scanUuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*List files the scanner processed (FAILED rows are the ones with violations)*
+
+```bash
+airs model-security scans files 00000000-0000-0000-0000-000000000002
+```
+
+```text
+Prisma AIRS — Model Security
+ML model supply chain security
+
+
+Scanned Files:
+
+  SUCCESS  FILE  config.json [json]
+  SKIPPED  FILE  .gitattributes
+  SUCCESS  FILE  model.safetensors [safetensors]
+  SUCCESS  DIRECTORY  onnx
+  FAILED  FILE  pytorch_model.bin [zip, pytorch_v1_13]
+  SUCCESS  FILE  special_tokens_map.json [json]
+  FAILED  FILE  tf_model.h5 [keras_weights]
+  SUCCESS  FILE  tokenizer_config.json [json]
+  SUCCESS  FILE  tokenizer.json [json]
+  FAILED  FILE  vocab.txt [openvino_bin]
+```


### PR DESCRIPTION
## Summary
Closes the 14 model-security sub-issues under epic #127 / category #130 that landed examples on a freshly licensed tenant.

### Examples landed (14 / 14 — burnt down to zero)
| Sub-issue | Command |
|---|---|
| #132 | `groups create` |
| #133 | `groups update` |
| #135 | `groups delete` |
| #136 | `labels add` |
| #137 | `labels set` |
| #138 | `labels delete` |
| #139 | `rule-instances update` |
| #141 | `scans create` |
| #142 | `scans get` |
| #143 | `scans evaluations` |
| #144 | `scans evaluation` |
| #145 | `scans violations` |
| #147 | `scans violation` |
| #148 | `scans files` |

### Allowlist burndown
- 60 → 44 entries on `docs/cli/examples/.missing-allowlist` (16 removed: 14 model-security + the 2 DLP/runtime entries from sibling PRs landing in parallel).

### Capture flow
- Seeded throwaway `group-docs-test` (HUGGING_FACE), flipped one rule instance to `ALLOWING`, submitted a Hugging Face scan against `hf-internal-testing/tiny-random-bert`. The backend ran the scan in ~30s producing 11 evaluations, 8 violations, 10 file rows — enough to capture all scan-detail commands.
- All UUIDs in fixtures and outputs redacted to `00000000-0000-0000-0000-00000000000N` per `docs/cli/examples/REDACTION.md`.

### Tenant hygiene
- `group-docs-test` deleted; `groups list` back to 5 default groups (HF / S3 / GCS / LOCAL / AZURE).
- The two test scans persist as historical records (per workflow — completed scans are not cleaned up).

Updates #130. Part of epic #127.

## Test plan
- [x] `pnpm docs:gen` regenerates `docs/cli/model-security/*.md` cleanly
- [x] `pnpm format` clean
- [x] `pnpm docs:check` passes (124 commands, 44 on allowlist)
- [x] No edits to `.md` files outside the autogenerated set
- [x] Fixtures redacted per REDACTION.md