### PR TITLE
fix(redteam): properties add-value send property_name/property_value

### DIFF
--- a/.changeset/0020-fix-redteam-properties-add-value.md
+++ b/.changeset/0020-fix-redteam-properties-add-value.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Fixed `airs redteam properties add-value` returning HTTP 422 by sending `property_name`/`property_value` (matching the SDK schema) instead of `name`/`value`.

--- a/src/airs/promptsets.ts
+++ b/src/airs/promptsets.ts
@@ -162,7 +162,10 @@ export class SdkPromptSetService implements PromptSetService {
   }
 
   async createPropertyValue(name: string, value: string): Promise<PropertyValue> {
-    const response = await this.client.customAttacks.createPropertyValue({ name, value } as never);
+    const response = await this.client.customAttacks.createPropertyValue({
+      property_name: name,
+      property_value: value,
+    });
     return response as unknown as PropertyValue;
   }
 }

--- a/tests/unit/airs/promptsets.spec.ts
+++ b/tests/unit/airs/promptsets.spec.ts
@@ -410,13 +410,13 @@ describe('SdkPromptSetService', () => {
   });
 
   describe('createPropertyValue', () => {
-    it('creates and returns property value', async () => {
+    it('sends property_name/property_value matching SDK schema', async () => {
       mockCreatePropertyValue.mockResolvedValue({ name: 'category', value: 'compliance' });
       const result = await service.createPropertyValue('category', 'compliance');
       expect(result).toEqual({ name: 'category', value: 'compliance' });
       expect(mockCreatePropertyValue).toHaveBeenCalledWith({
-        name: 'category',
-        value: 'compliance',
+        property_name: 'category',
+        property_value: 'compliance',
       });
     });
   });


### PR DESCRIPTION
## Summary

- `airs redteam properties add-value` was sending `{name, value}` and getting HTTP 422 from upstream
- SDK schema (`PropertyValueCreateRequestSchema`) expects `{property_name, property_value}`
- Fix renames the request body fields and drops the `as never` cast that was masking the type mismatch

Closes #197

## Test plan

- [x] Unit test in `tests/unit/airs/promptsets.spec.ts` asserts request body shape
- [x] `pnpm lint && pnpm tsc --noEmit && pnpm test && pnpm docs:check` all pass
- [ ] Manual: `airs redteam properties add-value --name <prop> --value <v>` returns 200 against live tenant