### PR TITLE
chore(deps): bump SDK to ^0.10.0

### DIFF
--- a/.changeset/0021-sdk-bump-0.10.0.md
+++ b/.changeset/0021-sdk-bump-0.10.0.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Bump @cdot65/prisma-airs-sdk to ^0.10.0 to pick up the DLP get-by-ID schema fix and other upstream improvements.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/vertex-sdk": "^0.14.4",
-    "@cdot65/prisma-airs-sdk": "^0.9.2",
+    "@cdot65/prisma-airs-sdk": "^0.10.0",
     "@inquirer/prompts": "^8.3.0",
     "@langchain/anthropic": "^1.3.25",
     "@langchain/aws": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.14.4
         version: 0.14.4(zod@3.25.76)
       '@cdot65/prisma-airs-sdk':
-        specifier: ^0.9.2
-        version: 0.9.2
+        specifier: ^0.10.0
+        version: 0.10.0
       '@inquirer/prompts':
         specifier: ^8.3.0
         version: 8.3.0(@types/node@22.19.13)
@@ -331,8 +331,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cdot65/prisma-airs-sdk@0.9.2':
-    resolution: {integrity: sha512-J0W28DK3RLTi38r+G3MMS3mWF3wUAHBqIM2yIwm6bXXL4GF85aFaHJJeRH2KKWkQzrMLd4VoZGsb+5UWZT3AHQ==}
+  '@cdot65/prisma-airs-sdk@0.10.0':
+    resolution: {integrity: sha512-nRTfxduC69kGfdJd5xTYZN5VuaH8Qq0ZjgtadVaQynygvlF8RFU4f2bNUEK9Y3iLiBF/KguuzbKCOAsg8tRyrg==}
     engines: {node: '>=18'}
 
   '@cfworker/json-schema@4.1.1':
@@ -2760,7 +2760,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.5':
     optional: true
 
-  '@cdot65/prisma-airs-sdk@0.9.2':
+  '@cdot65/prisma-airs-sdk@0.10.0':
     dependencies:
       zod: 3.25.76
 


### PR DESCRIPTION
## Summary
- Bumps `@cdot65/prisma-airs-sdk` from `^0.9.2` to `^0.10.0`
- Picks up the DLP get-by-ID schema fix that unblocks issues #181–#192

## Test plan
- [x] `pnpm install`
- [x] `pnpm tsc --noEmit`
- [x] `pnpm test` — 656 pass
- [x] `pnpm lint`
- [x] `pnpm docs:check` (124 cmds, 30 allowlist)
- [ ] Live: `airs runtime dlp profiles get <id>` returns parsed object (post-merge)