### PR TITLE
docs(runtime/dlp): real get-by-ID input/output examples (post SDK ^0.10.0)

### DIFF
--- a/.changeset/0022-docs-dlp-get-examples.md
+++ b/.changeset/0022-docs-dlp-get-examples.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+docs(runtime/dlp): real input/output examples for `patterns`, `profiles`, and `filtering-profiles` `get` — unblocked by SDK ^0.10.0. Drops stale upstream-400 warning on patterns/profiles. Flags the remaining snake_case JSON mangling (#105) on profiles + filtering-profiles.

--- a/docs/runtime/dlp/filtering-profiles.md
+++ b/docs/runtime/dlp/filtering-profiles.md
@@ -52,11 +52,33 @@ Use `get <id>` for the full nested fields (`file_type`, `criteria_details`, `exc
 Retrieve a single filtering profile by ID.
 
 ```bash
-airs runtime dlp filtering-profiles get 6a10...
-airs runtime dlp filtering-profiles get 6a10... --output json
+airs runtime dlp filtering-profiles get 6a146fe17e175b786523c03a
+airs runtime dlp filtering-profiles get 6a146fe17e175b786523c03a --output json
 ```
 
-**Output** — same shape as a single `content[]` entry from `list`:
+**Pretty output:**
+
+```
+  Data Filtering Profile:
+
+    ID              6a146fe17e175b786523c03a
+    Name            SOX
+    Type            predefined
+    Data Profile    11995027
+    Direction       c2s
+    Severity        low
+    Scan Type       include
+    File Based      yes
+    Non-File Based  no
+    Version         3
+    File Types      35
+    Updated         2026-05-25T17:06:36.032Z
+```
+
+!!! warning "Snake-case mangling on JSON/YAML (issue #105)"
+    The JSON shape below is the **intended** SDK contract. The current CLI snake_case transformer drops the character after each camelCase boundary, so the actual live output renders `datarofile` / `scanype` / `fileased` / `nonileased` / `fileypes` instead of `data_profile` / `scan_type` / `file_based` / `non_file_based` / `file_types`. Use `pretty` until [#105](https://github.com/cdot65/prisma-airs-cli/issues/105) lands.
+
+**JSON output (target shape):**
 
 ```json
 {

--- a/docs/runtime/dlp/patterns.md
+++ b/docs/runtime/dlp/patterns.md
@@ -119,17 +119,44 @@ Body shape matches the API request — `{ name, type, detection_config, matching
 
 ## get
 
-Retrieve a single pattern by ID.
+Retrieve a single pattern by ID. Requires `@cdot65/prisma-airs-sdk@^0.10.0` or newer (earlier versions hit a 400 against the upstream).
 
 ```bash
-airs runtime dlp patterns get 6990...
-airs runtime dlp patterns get 6990... --output json
+airs runtime dlp patterns get 6a06d3cf7e175b786523b8e5
+airs runtime dlp patterns get 6a06d3cf7e175b786523b8e5 --output json
 ```
 
-**Output** — same shape as a single `content[]` entry from `list`.
+**Pretty output:**
 
-!!! warning "Known issue (2026-05-23)"
-    The DLP API currently returns HTTP 400 for `GET /v2/api/data-patterns/{id}` against live tenants, even with valid IDs from the `list` response. This is a server-side issue, not a CLI or SDK bug — reproducible via `curl` with the same credentials. Use `list` and filter client-side until the upstream is fixed.
+```
+  Data Pattern:
+
+    ID           6a06d3cf7e175b786523b8e5
+    Name         Driver License - Cyprus
+    Description  This data pattern identifies a driver license issued by Cyprus.
+    Type         predefined
+    Status       active
+    Technique    regex
+    Confidence   high, low
+    Version      1
+    Updated      2026-05-25T15:50:58.037Z
+```
+
+**JSON output:**
+
+```json
+{
+  "id": "6a06d3cf7e175b786523b8e5",
+  "name": "Driver License - Cyprus",
+  "description": "This data pattern identifies a driver license issued by Cyprus.",
+  "type": "predefined",
+  "status": "active",
+  "technique": "regex",
+  "confidence": "high, low",
+  "version": 1,
+  "updated": "2026-05-25T15:50:58.037Z"
+}
+```
 
 ## replace
 

--- a/docs/runtime/dlp/profiles.md
+++ b/docs/runtime/dlp/profiles.md
@@ -140,17 +140,45 @@ Multi-profile compositions auto-promote `profile_type` to `advanced`.
 
 ## get
 
-Retrieve a single profile by ID.
+Retrieve a single profile by ID. Requires `@cdot65/prisma-airs-sdk@^0.10.0` or newer (earlier versions hit a 400 against the upstream).
 
 ```bash
-airs runtime dlp profiles get 1234567890
-airs runtime dlp profiles get 1234567890 --output json
+airs runtime dlp profiles get 11995028
+airs runtime dlp profiles get 11995028 --output json
 ```
 
-**Output** — same shape as a single `content[]` entry from `list`.
+**Pretty output:**
 
-!!! warning "Known issue (2026-05-23)"
-    The DLP API currently returns HTTP 400 for `GET /v2/api/data-profiles/{id}` against live tenants, even with valid IDs from the `list` response. This is a server-side issue, not a CLI or SDK bug — reproducible via `curl` with the same credentials. Use `list` and filter client-side until the upstream is fixed.
+```
+  Data Profile:
+
+    ID            11995028
+    Name          U.K. PIOCP
+    Description   Default profile for U.K. PIOCP
+    Type          predefined
+    Profile Type  basic
+    Status        active
+    Version       1
+    Updated       2026-05-15T08:05:35.633Z
+```
+
+**JSON output:**
+
+```json
+{
+  "id": "11995028",
+  "name": "U.K. PIOCP",
+  "description": "Default profile for U.K. PIOCP",
+  "type": "predefined",
+  "profileype": "basic",
+  "status": "active",
+  "version": 1,
+  "updated": "2026-05-15T08:05:35.633Z"
+}
+```
+
+!!! warning "Snake-case mangling on JSON/YAML (issue #105)"
+    The JSON output above shows `profileype` instead of `profile_type` — the CLI's camelCase→snake_case transformer drops the character after each boundary. Use `pretty` until [#105](https://github.com/cdot65/prisma-airs-cli/issues/105) lands.
 
 ## replace
 


### PR DESCRIPTION
## Summary
- Replaces aspirational `## get` sections in `patterns.md`, `profiles.md`, `filtering-profiles.md` with real live-tenant input/output examples
- Drops the stale "upstream returns 400" warning on patterns + profiles (fixed by SDK ^0.10.0 / PR #212)
- Flags the remaining JSON snake_case mangling bug (#105) on `profiles get` and `filtering-profiles get` so users know to use `pretty` until that fix lands

## Issues addressed
- Closes #181 (patterns get) — now works end-to-end
- Updates #184 (profiles get) — pretty works; JSON tracked under #105
- Updates #188 (filtering-profiles get) — pretty works; JSON tracked under #105

## Test plan
- [x] Live-tested all three `get` commands against tenant 1852583913 with `node dist/cli/index.js runtime dlp ...`
- [x] `pnpm docs:check` (124 commands, 30 allowlist)