### PR TITLE
fix(redteam): suppress spurious multi_turn_error_message when multi_turn=false (#202)

### DIFF
--- a/.changeset/fix-redteam-targets-suppress-multi-turn-error.md
+++ b/.changeset/fix-redteam-targets-suppress-multi-turn-error.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Suppress the spurious `target_metadata.multi_turn_error_message` ("Multi turn configuration JSON not provided") that `airs redteam targets probe`, `create`, `update`, and `get` were showing whenever `multi_turn: false`. The field is only kept when `multi_turn: true`, where it indicates an actual misconfiguration.

--- a/src/airs/redteam.ts
+++ b/src/airs/redteam.ts
@@ -45,6 +45,22 @@ function normalizeJob(raw: Record<string, unknown>): RedTeamJob {
   };
 }
 
+/**
+ * Drop noisy "you didn't opt in" fields from `target_metadata` when the
+ * corresponding feature is disabled. `multi_turn_error_message` always comes
+ * back populated, but it's only a real error when `multi_turn === true`.
+ */
+export function sanitizeTargetMetadata<T extends Record<string, unknown> | undefined>(
+  metadata: T,
+): T {
+  if (!metadata) return metadata;
+  if (metadata.multi_turn === false && 'multi_turn_error_message' in metadata) {
+    const { multi_turn_error_message: _drop, ...rest } = metadata;
+    return rest as T;
+  }
+  return metadata;
+}
+
 /** Normalize an SDK target response into a RedTeamTargetDetail. */
 function normalizeTargetDetail(raw: Record<string, unknown>): RedTeamTargetDetail {
   return {
@@ -65,7 +81,7 @@ function normalizeTargetDetail(raw: Record<string, unknown>): RedTeamTargetDetai
     connectionParams: raw.connection_params as Record<string, unknown> | undefined,
     background: raw.target_background as RedTeamTargetDetail['background'],
     additionalContext: raw.additional_context as RedTeamTargetDetail['additionalContext'],
-    metadata: raw.target_metadata as RedTeamTargetDetail['metadata'],
+    metadata: sanitizeTargetMetadata(raw.target_metadata as RedTeamTargetDetail['metadata']),
   };
 }
 
@@ -274,7 +290,12 @@ export class SdkRedTeamService implements RedTeamService {
 
   async probeTarget(request: Record<string, unknown>): Promise<Record<string, unknown>> {
     const response = await this.client.targets.probe(request as never);
-    return response as unknown as Record<string, unknown>;
+    const raw = response as unknown as Record<string, unknown>;
+    const meta = raw.target_metadata;
+    if (meta && typeof meta === 'object') {
+      raw.target_metadata = sanitizeTargetMetadata(meta as Record<string, unknown>);
+    }
+    return raw;
   }
 
   async getTargetProfile(uuid: string): Promise<Record<string, unknown>> {

--- a/tests/unit/airs/redteam.spec.ts
+++ b/tests/unit/airs/redteam.spec.ts
@@ -753,6 +753,91 @@ describe('SdkRedTeamService', () => {
       expect(result).toEqual({ status: 'connected', latency_ms: 42 });
       expect(mockTargetsProbe).toHaveBeenCalledWith({ api_endpoint: 'https://example.com' });
     });
+
+    it('strips multi_turn_error_message from target_metadata when multi_turn is false', async () => {
+      mockTargetsProbe.mockResolvedValue({
+        status: 'connected',
+        target_metadata: {
+          multi_turn: false,
+          multi_turn_error_message: 'Multi turn configuration JSON not provided',
+          rate_limit: 50,
+        },
+      });
+      const result = await service.probeTarget({ api_endpoint: 'https://example.com' });
+      const meta = result.target_metadata as Record<string, unknown>;
+      expect(meta).not.toHaveProperty('multi_turn_error_message');
+      expect(meta.multi_turn).toBe(false);
+      expect(meta.rate_limit).toBe(50);
+    });
+
+    it('keeps multi_turn_error_message when multi_turn is true (real error)', async () => {
+      mockTargetsProbe.mockResolvedValue({
+        status: 'connected',
+        target_metadata: {
+          multi_turn: true,
+          multi_turn_error_message: 'something actually wrong',
+        },
+      });
+      const result = await service.probeTarget({ api_endpoint: 'https://example.com' });
+      const meta = result.target_metadata as Record<string, unknown>;
+      expect(meta.multi_turn_error_message).toBe('something actually wrong');
+    });
+  });
+
+  describe('multi_turn_error_message sanitization on normalized target paths', () => {
+    it('getTarget: drops multi_turn_error_message when multi_turn is false', async () => {
+      mockTargetsGet.mockResolvedValue({
+        uuid: 't-1',
+        name: 'Target',
+        status: 'active',
+        active: true,
+        target_metadata: {
+          multi_turn: false,
+          multi_turn_error_message: 'Multi turn configuration JSON not provided',
+          rate_limit: 25,
+        },
+      });
+      const result = await service.getTarget('t-1');
+      expect(result.metadata).not.toHaveProperty('multi_turn_error_message');
+      expect(result.metadata).toEqual({ multi_turn: false, rate_limit: 25 });
+    });
+
+    it('getTarget: keeps multi_turn_error_message when multi_turn is true', async () => {
+      mockTargetsGet.mockResolvedValue({
+        uuid: 't-1',
+        name: 'Target',
+        status: 'active',
+        active: true,
+        target_metadata: {
+          multi_turn: true,
+          multi_turn_error_message: 'real failure',
+        },
+      });
+      const result = await service.getTarget('t-1');
+      expect(result.metadata).toEqual({
+        multi_turn: true,
+        multi_turn_error_message: 'real failure',
+      });
+    });
+
+    it('createTarget: drops multi_turn_error_message when multi_turn is false', async () => {
+      mockTargetsCreate.mockResolvedValue({
+        uuid: 't-new',
+        name: 'New',
+        status: 'active',
+        active: true,
+        target_metadata: {
+          multi_turn: false,
+          multi_turn_error_message: 'Multi turn configuration JSON not provided',
+        },
+      });
+      const result = await service.createTarget({
+        name: 'New',
+        target_type: 'REST',
+        connection_params: {},
+      });
+      expect(result.metadata).toEqual({ multi_turn: false });
+    });
   });
 
   describe('getTargetProfile', () => {


### PR DESCRIPTION
## Summary

Closes #202.

Adds `sanitizeTargetMetadata()` at the SDK normalizer boundary plus the `probeTarget` path. `airs redteam targets probe / create / update / get` no longer surface `target_metadata.multi_turn_error_message: "Multi turn configuration JSON not provided"` when `multi_turn: false`. The field is preserved when `multi_turn: true`, where it reflects a real configuration error.

Single helper applied at two points:
- `normalizeTargetDetail()` — covers `get` / `create` / `update`
- `probeTarget()` — raw response path, not normalized

## Test plan

- [x] `pnpm test` — 666 tests, +5 new in `tests/unit/airs/redteam.spec.ts` covering probe/get/create false-case suppression + true-case retention
- [x] `pnpm lint`
- [x] `pnpm tsc --noEmit`
- [x] `pnpm docs:check`
- [ ] Manual: `airs redteam targets probe --config target.json` against a real tenant returns metadata without `multi_turn_error_message`
- [ ] Manual: `airs redteam targets create --config target.json` then `get <uuid>` — same