### PR TITLE
fix(redteam): render attack subcategory display name in report

### DIFF
--- a/.changeset/fix-redteam-report-attacks-subcategory.md
+++ b/.changeset/fix-redteam-report-attacks-subcategory.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Fix `airs redteam report <jobId> --attacks` printing `undefined` for every attack's subcategory. The renderer now reads `sub_category_display_name` (preferred) with `sub_category` raw value as fallback, and prints an em-dash (`—`) when neither is present. Lifts `subCategoryDisplayName` into the normalized `RedTeamAttack` shape at the SDK boundary.

--- a/src/airs/redteam.ts
+++ b/src/airs/redteam.ts
@@ -463,6 +463,7 @@ export class SdkRedTeamService implements RedTeamService {
         severity: a.severity as string | undefined,
         category: a.category as string | undefined,
         subCategory: a.sub_category as string | undefined,
+        subCategoryDisplayName: a.sub_category_display_name as string | undefined,
         successful: a.successful as boolean,
       }),
     );

--- a/src/airs/types.ts
+++ b/src/airs/types.ts
@@ -306,6 +306,7 @@ export interface RedTeamAttack {
   severity?: string;
   category?: string;
   subCategory?: string;
+  subCategoryDisplayName?: string;
   successful: boolean;
 }
 

--- a/src/cli/renderer/redteam.ts
+++ b/src/cli/renderer/redteam.ts
@@ -202,9 +202,11 @@ export function renderCustomReport(report: {
 /** Render attack list with severity coloring. */
 export function renderAttackList(
   attacks: Array<{
-    name: string;
+    name?: string;
     severity?: string;
     category?: string;
+    subCategory?: string;
+    subCategoryDisplayName?: string;
     successful: boolean;
   }>,
 ): void {
@@ -218,9 +220,8 @@ export function renderAttackList(
       ? severityColor(a.severity)(a.severity.padEnd(10))
       : chalk.dim('N/A'.padEnd(10));
     const result = a.successful ? chalk.red('BYPASSED') : chalk.green('BLOCKED');
-    console.log(
-      `    ${sev} ${result}  ${a.name}${a.category ? chalk.dim(` [${a.category}]`) : ''}`,
-    );
+    const label = a.subCategoryDisplayName ?? a.subCategory ?? '—';
+    console.log(`    ${sev} ${result}  ${label}${a.category ? chalk.dim(` [${a.category}]`) : ''}`);
   }
   console.log();
 }

--- a/tests/unit/airs/redteam.spec.ts
+++ b/tests/unit/airs/redteam.spec.ts
@@ -550,6 +550,42 @@ describe('SdkRedTeamService', () => {
       const result = await service.listAttacks('job-1');
       expect(result).toEqual([]);
     });
+
+    it('lifts sub_category_display_name into subCategoryDisplayName', async () => {
+      mockReportsListAttacks.mockResolvedValue({
+        data: [
+          {
+            uuid: 'atk-1',
+            severity: 'CRITICAL',
+            category: 'SECURITY',
+            category_display_name: 'Security',
+            sub_category: 'JAILBREAK',
+            sub_category_display_name: 'Jailbreak',
+            successful: true,
+          },
+        ],
+      });
+      const result = await service.listAttacks('job-1');
+      expect(result[0].subCategoryDisplayName).toBe('Jailbreak');
+      expect(result[0].subCategory).toBe('JAILBREAK');
+    });
+
+    it('leaves subCategoryDisplayName undefined when API omits it', async () => {
+      mockReportsListAttacks.mockResolvedValue({
+        data: [
+          {
+            uuid: 'atk-1',
+            severity: 'HIGH',
+            category: 'SECURITY',
+            sub_category: 'JAILBREAK',
+            successful: false,
+          },
+        ],
+      });
+      const result = await service.listAttacks('job-1');
+      expect(result[0].subCategoryDisplayName).toBeUndefined();
+      expect(result[0].subCategory).toBe('JAILBREAK');
+    });
   });
 
   describe('listCustomAttacks', () => {

--- a/tests/unit/cli/redteam-attacks-renderer.spec.ts
+++ b/tests/unit/cli/redteam-attacks-renderer.spec.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let output: string[];
+const originalLog = console.log;
+
+describe('renderAttackList', () => {
+  beforeEach(() => {
+    output = [];
+    console.log = (...args: unknown[]) => output.push(args.join(' '));
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+  });
+
+  it('prints subCategoryDisplayName when provided', async () => {
+    const { renderAttackList } = await import('../../../src/cli/renderer/redteam.js');
+    renderAttackList([
+      {
+        id: 'atk-1',
+        name: undefined as unknown as string,
+        severity: 'CRITICAL',
+        category: 'SECURITY',
+        subCategory: 'JAILBREAK',
+        subCategoryDisplayName: 'Jailbreak',
+        successful: false,
+      },
+    ]);
+    const text = output.join('\n');
+    expect(text).toContain('Jailbreak');
+    expect(text).not.toContain('undefined');
+  });
+
+  it('falls back to subCategory raw value when display name missing', async () => {
+    const { renderAttackList } = await import('../../../src/cli/renderer/redteam.js');
+    renderAttackList([
+      {
+        id: 'atk-1',
+        name: undefined as unknown as string,
+        severity: 'HIGH',
+        category: 'SECURITY',
+        subCategory: 'JAILBREAK',
+        successful: false,
+      },
+    ]);
+    const text = output.join('\n');
+    expect(text).toContain('JAILBREAK');
+    expect(text).not.toContain('undefined');
+  });
+
+  it('prints em-dash when neither subcategory field is present', async () => {
+    const { renderAttackList } = await import('../../../src/cli/renderer/redteam.js');
+    renderAttackList([
+      {
+        id: 'atk-1',
+        name: undefined as unknown as string,
+        severity: 'MEDIUM',
+        category: 'SECURITY',
+        successful: false,
+      },
+    ]);
+    const text = output.join('\n');
+    expect(text).toContain('—');
+    expect(text).not.toContain('undefined');
+  });
+});


### PR DESCRIPTION
## Summary

- `airs redteam report <jobId> --attacks` was printing `undefined` for every attack's subcategory because the renderer read `a.name` (lifted from a no-longer-returned `attack_name` field).
- Normalizer at `src/airs/redteam.ts:454` now lifts `sub_category_display_name` into the `subCategoryDisplayName` field on `RedTeamAttack`.
- Renderer at `src/cli/renderer/redteam.ts:203` now prints `subCategoryDisplayName ?? subCategory ?? '—'` — readable display name preferred, raw value fallback, em-dash if neither.
- Unknown rows render `—` instead of literal `undefined`.

## Test plan

- [x] RED: 5 new tests across normalizer (`tests/unit/airs/redteam.spec.ts`: lifts display name, undefined when omitted) and renderer (`tests/unit/cli/redteam-attacks-renderer.spec.ts`: display-name, raw fallback, em-dash) — all failed before implementation
- [x] GREEN: 682/682 tests pass
- [x] `pnpm lint` clean
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` 682 passed
- [x] `pnpm docs:check` clean

Closes #204