### PR TITLE
fix(dlp): lazy-load docx to silence localStorage warning on every command

### DIFF
--- a/.changeset/lazy-load-docx.md
+++ b/.changeset/lazy-load-docx.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Lazy-load the `docx` dependency so it only loads when generating DOCX output. Previously `docx` was imported eagerly, pulling in browserify polyfills whose `util-deprecate` shim reads `localStorage` at import time and triggered a Node Web Storage warning (`--localstorage-file was provided without a valid path`) on every command. The import is now deferred into the DOCX builders, so unrelated commands (scan, profiles, etc.) no longer emit the warning and start slightly faster.

--- a/src/dlp/embed/docx.ts
+++ b/src/dlp/embed/docx.ts
@@ -1,15 +1,8 @@
-import { Document, HeadingLevel, Packer, Paragraph, TextRun } from 'docx';
 import { lorem } from '../lorem.js';
 import { makeRng } from '../rng.js';
 import type { PayloadValue, Technique } from '../types.js';
 
 const join = (p: PayloadValue[]): string => p.map((v) => `${v.category}: ${v.value}`).join(' | ');
-
-function bodyParagraphs(): Paragraph[] {
-  return lorem(makeRng(1), 2)
-    .split('\n\n')
-    .map((t) => new Paragraph({ children: [new TextRun(t)] }));
-}
 
 interface Core {
   title?: string;
@@ -17,7 +10,30 @@ interface Core {
   keywords?: string;
 }
 
-async function build(extra: Paragraph[], core: Core = {}): Promise<Buffer> {
+/** Technique-specific body content, constructed lazily once docx is loaded. */
+type Extra =
+  | { kind: 'none' }
+  | { kind: 'hidden'; text: string }
+  | { kind: 'visible'; text: string };
+
+async function build(extra: Extra, core: Core = {}): Promise<Buffer> {
+  // Lazy-load docx: importing it eagerly pulls in browserify polyfills whose
+  // util-deprecate shim reads localStorage at import time, triggering a Node
+  // Web Storage warning on every CLI command. Deferring the import to here
+  // means docx (and the warning) only loads when DOCX output is actually built.
+  const { Document, HeadingLevel, Packer, Paragraph, TextRun } = await import('docx');
+
+  const body = lorem(makeRng(1), 2)
+    .split('\n\n')
+    .map((t) => new Paragraph({ children: [new TextRun(t)] }));
+
+  const extraParagraphs =
+    extra.kind === 'hidden'
+      ? [new Paragraph({ children: [new TextRun({ text: extra.text, vanish: true })] })]
+      : extra.kind === 'visible'
+        ? [new Paragraph({ children: [new TextRun(extra.text)] })]
+        : [];
+
   const doc = new Document({
     title: core.title,
     subject: core.subject,
@@ -26,8 +42,8 @@ async function build(extra: Paragraph[], core: Core = {}): Promise<Buffer> {
       {
         children: [
           new Paragraph({ text: 'Generated Document', heading: HeadingLevel.HEADING_1 }),
-          ...bodyParagraphs(),
-          ...extra,
+          ...body,
+          ...extraParagraphs,
         ],
       },
     ],
@@ -40,19 +56,19 @@ export const docxTechniques: Record<string, Technique> = {
     id: 'core-props',
     format: 'docx',
     label: 'core document properties',
-    embed: (_clean, p) => build([], { title: join(p), subject: join(p), keywords: join(p) }),
+    embed: (_clean, p) =>
+      build({ kind: 'none' }, { title: join(p), subject: join(p), keywords: join(p) }),
   },
   'hidden-run': {
     id: 'hidden-run',
     format: 'docx',
     label: 'hidden (vanish) run',
-    embed: (_clean, p) =>
-      build([new Paragraph({ children: [new TextRun({ text: join(p), vanish: true })] })]),
+    embed: (_clean, p) => build({ kind: 'hidden', text: join(p) }),
   },
   visible: {
     id: 'visible',
     format: 'docx',
     label: 'visible body line',
-    embed: (_clean, p) => build([new Paragraph({ children: [new TextRun(join(p))] })]),
+    embed: (_clean, p) => build({ kind: 'visible', text: join(p) }),
   },
 };

--- a/src/dlp/generate/docx.ts
+++ b/src/dlp/generate/docx.ts
@@ -1,8 +1,12 @@
-import { Document, HeadingLevel, Packer, Paragraph, TextRun } from 'docx';
 import { lorem } from '../lorem.js';
 
 /** Generate a valid DOCX (zip) filled with lorem ipsum. */
 export async function docx(rng: () => number): Promise<Buffer> {
+  // Lazy-load docx: importing it eagerly pulls in browserify polyfills whose
+  // util-deprecate shim reads localStorage at import time, triggering a Node
+  // Web Storage warning on every CLI command. Deferring the import to here
+  // means docx (and the warning) only loads when DOCX output is actually built.
+  const { Document, HeadingLevel, Packer, Paragraph, TextRun } = await import('docx');
   const paragraphs = lorem(rng, 3)
     .split('\n\n')
     .map((p) => new Paragraph({ children: [new TextRun(p)] }));


### PR DESCRIPTION
## What

Lazy-load the `docx` dependency so it only loads when DOCX output is actually generated.

## Why

`docx` was imported eagerly in `src/dlp/generate/docx.ts` and `src/dlp/embed/docx.ts`. Because the command tree is built at startup, `docx` loaded on **every** `airs` command. Its bundled browserify polyfills pull in `util-deprecate`'s browser shim, which reads `localStorage` at import time. On Node 22+ (seen on Node 25) that triggers:

```
(node:NNNN) Warning: `--localstorage-file` was provided without a valid path
```

so the warning printed on every command (scan, profiles, redteam, etc.), not just DLP file generation.

## Fix

Defer the `docx` import into the DOCX builders via `await import('docx')`:

- `src/dlp/generate/docx.ts` - import moved inside the (already-async) `docx()` builder.
- `src/dlp/embed/docx.ts` - import moved inside `build()`; the technique embedders now pass plain data instead of pre-constructed `Paragraph`s, so no module-level `docx` reference remains.

`docx` (and the warning) now load only when `dlp-gen` actually produces DOCX. Unrelated commands are warning-free and start slightly faster.

## Testing

- `pnpm build` clean, `pnpm lint` (biome) clean
- `pnpm test`: full unit suite passes
- Verified `airs runtime profiles list` and `runtime scan` emit 0 localStorage warnings; `dlp-gen` DOCX output still works and the DOCX unit tests pass

Changeset included (patch).
