### PR TITLE
fix(redteam): derive attack successful from threat field

### DIFF
--- a/.changeset/fix-redteam-attacks-bypassed-from-threat.md
+++ b/.changeset/fix-redteam-attacks-bypassed-from-threat.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Fix `airs redteam report <jobId> --attacks` mis-labeling bypassed attacks as `BLOCKED`. The normalizer was reading a non-existent `successful` field; it now derives `successful` from the API's `threat` field, so rows with `threat: true` correctly render as `BYPASSED`.

--- a/src/airs/redteam.ts
+++ b/src/airs/redteam.ts
@@ -464,7 +464,7 @@ export class SdkRedTeamService implements RedTeamService {
         category: a.category as string | undefined,
         subCategory: a.sub_category as string | undefined,
         subCategoryDisplayName: a.sub_category_display_name as string | undefined,
-        successful: a.successful as boolean,
+        successful: (a.threat ?? false) as boolean,
       }),
     );
   }

--- a/tests/unit/airs/redteam.spec.ts
+++ b/tests/unit/airs/redteam.spec.ts
@@ -519,7 +519,7 @@ describe('SdkRedTeamService', () => {
             severity: 'HIGH',
             category: 'Security',
             sub_category: 'Prompt Injection',
-            successful: true,
+            threat: true,
           },
           {
             uuid: 'atk-2',
@@ -527,7 +527,7 @@ describe('SdkRedTeamService', () => {
             severity: 'MEDIUM',
             category: 'Safety',
             sub_category: 'Toxicity',
-            successful: false,
+            threat: false,
           },
         ],
       });
@@ -542,6 +542,7 @@ describe('SdkRedTeamService', () => {
         subCategory: 'Prompt Injection',
         successful: true,
       });
+      expect(result[1].successful).toBe(false);
       expect(mockReportsListAttacks).toHaveBeenCalledWith('job-1', { severity: 'HIGH', limit: 10 });
     });
 
@@ -568,6 +569,22 @@ describe('SdkRedTeamService', () => {
       const result = await service.listAttacks('job-1');
       expect(result[0].subCategoryDisplayName).toBe('Jailbreak');
       expect(result[0].subCategory).toBe('JAILBREAK');
+    });
+
+    it('treats missing threat as not successful (BLOCKED default)', async () => {
+      mockReportsListAttacks.mockResolvedValue({
+        data: [
+          {
+            uuid: 'atk-1',
+            severity: 'CRITICAL',
+            category: 'SECURITY',
+            sub_category: 'JAILBREAK',
+            status: 'INIT',
+          },
+        ],
+      });
+      const result = await service.listAttacks('job-1');
+      expect(result[0].successful).toBe(false);
     });
 
     it('leaves subCategoryDisplayName undefined when API omits it', async () => {

--- a/tests/unit/cli/redteam-attacks-renderer.spec.ts
+++ b/tests/unit/cli/redteam-attacks-renderer.spec.ts
@@ -48,6 +48,40 @@ describe('renderAttackList', () => {
     expect(text).not.toContain('undefined');
   });
 
+  it('renders BYPASSED when successful=true', async () => {
+    const { renderAttackList } = await import('../../../src/cli/renderer/redteam.js');
+    renderAttackList([
+      {
+        id: 'atk-1',
+        name: undefined as unknown as string,
+        severity: 'CRITICAL',
+        category: 'SECURITY',
+        subCategory: 'JAILBREAK',
+        successful: true,
+      },
+    ]);
+    const text = output.join('\n');
+    expect(text).toContain('BYPASSED');
+    expect(text).not.toContain('BLOCKED');
+  });
+
+  it('renders BLOCKED when successful=false', async () => {
+    const { renderAttackList } = await import('../../../src/cli/renderer/redteam.js');
+    renderAttackList([
+      {
+        id: 'atk-1',
+        name: undefined as unknown as string,
+        severity: 'HIGH',
+        category: 'SECURITY',
+        subCategory: 'JAILBREAK',
+        successful: false,
+      },
+    ]);
+    const text = output.join('\n');
+    expect(text).toContain('BLOCKED');
+    expect(text).not.toContain('BYPASSED');
+  });
+
   it('prints em-dash when neither subcategory field is present', async () => {
     const { renderAttackList } = await import('../../../src/cli/renderer/redteam.js');
     renderAttackList([


### PR DESCRIPTION
## Summary

- `airs redteam report <jobId> --attacks` printed `BLOCKED` for every attack regardless of outcome.
- Root cause: `listAttacks` normalizer at `src/airs/redteam.ts:467` lifted `a.successful` — a field the API doesn't return per `airs --debug` capture. Result was always `undefined` (falsy) → renderer always picked `BLOCKED`.
- Fix: derive `successful` from `a.threat` in the normalizer. Renderer logic unchanged (was already correct given a correct `successful` value).
- Updated existing `listAttacks` test mocks to reflect real API shape (`threat` instead of stale `successful`).

## Test plan

- [x] RED: existing `listAttacks` test now fails (mocks switched to `threat`); new test confirms missing `threat` → `successful: false`; renderer regression tests for BYPASSED/BLOCKED
- [x] GREEN: 685/685 tests pass
- [x] `pnpm lint` clean
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` 685 passed
- [x] `pnpm docs:check` clean

Closes #205