### PR TITLE
fix(redteam): footnote when --attacks count diverges from summary

### DIFF
--- a/.changeset/fix-redteam-attacks-divergence-footnote.md
+++ b/.changeset/fix-redteam-attacks-divergence-footnote.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+`airs redteam report <jobId> --attacks --severity X` now prints a footnote when the `list-attacks` endpoint returns fewer items than the summary severity breakdown promised for that severity, so operators know the discrepancy is upstream (server-side aggregator divergence) rather than a CLI bug. `service.listAttacks()` return shape changes from `RedTeamAttack[]` to `{ attacks: RedTeamAttack[]; totalItems?: number }` to surface pagination — only internal callers affected.

--- a/src/airs/redteam.ts
+++ b/src/airs/redteam.ts
@@ -454,10 +454,15 @@ export class SdkRedTeamService implements RedTeamService {
   async listAttacks(
     jobId: string,
     opts?: { severity?: string; limit?: number },
-  ): Promise<RedTeamAttack[]> {
-    const response = await this.client.reports.listAttacks(jobId, opts);
-    return ((response as Record<string, unknown>).data as Array<Record<string, unknown>>).map(
-      (a) => ({
+  ): Promise<{ attacks: RedTeamAttack[]; totalItems?: number }> {
+    const response = (await this.client.reports.listAttacks(jobId, opts)) as Record<
+      string,
+      unknown
+    >;
+    const data = (response.data ?? []) as Array<Record<string, unknown>>;
+    const pagination = response.pagination as { total_items?: number } | undefined;
+    return {
+      attacks: data.map((a) => ({
         id: a.uuid as string,
         name: a.attack_name as string,
         severity: a.severity as string | undefined,
@@ -465,8 +470,9 @@ export class SdkRedTeamService implements RedTeamService {
         subCategory: a.sub_category as string | undefined,
         subCategoryDisplayName: a.sub_category_display_name as string | undefined,
         successful: (a.threat ?? false) as boolean,
-      }),
-    );
+      })),
+      totalItems: pagination?.total_items,
+    };
   }
 
   async listCustomAttacks(

--- a/src/airs/types.ts
+++ b/src/airs/types.ts
@@ -497,7 +497,7 @@ export interface RedTeamService {
   listAttacks(
     jobId: string,
     opts?: { severity?: string; limit?: number },
-  ): Promise<RedTeamAttack[]>;
+  ): Promise<{ attacks: RedTeamAttack[]; totalItems?: number }>;
 
   /** List attacks from a custom prompt set scan. */
   listCustomAttacks(jobId: string, opts?: { limit?: number }): Promise<RedTeamCustomAttack[]>;

--- a/src/cli/commands/redteam.ts
+++ b/src/cli/commands/redteam.ts
@@ -8,6 +8,7 @@ import { resolveOutputDir } from '../../backup/io.js';
 import type { BackupFormat } from '../../backup/types.js';
 import { loadConfig } from '../../config/loader.js';
 import {
+  buildAttackListFootnote,
   type OutputFormat,
   renderAttackList,
   renderAuthValidation,
@@ -725,23 +726,26 @@ export function registerRedteamCommand(program: Command): void {
         if (job.jobType === 'CUSTOM') {
           const report = await service.getCustomReport(jobId);
           renderCustomReport(report);
-        } else {
-          const report = await service.getStaticReport(jobId);
-          renderStaticReport(report);
-        }
-
-        if (opts.attacks) {
-          if (job.jobType === 'CUSTOM') {
+          if (opts.attacks) {
             const attacks = await service.listCustomAttacks(jobId, {
               limit: Number.parseInt(opts.limit, 10),
             });
             renderCustomAttackList(attacks);
-          } else {
-            const attacks = await service.listAttacks(jobId, {
+          }
+        } else {
+          const report = await service.getStaticReport(jobId);
+          renderStaticReport(report);
+          if (opts.attacks) {
+            const { attacks, totalItems } = await service.listAttacks(jobId, {
               severity: opts.severity,
               limit: Number.parseInt(opts.limit, 10),
             });
-            renderAttackList(attacks);
+            const footnote = buildAttackListFootnote({
+              severity: opts.severity,
+              totalItems,
+              severityBreakdown: report.severityBreakdown,
+            });
+            renderAttackList(attacks, { footnote });
           }
         }
       } catch (err) {

--- a/src/cli/renderer/redteam.ts
+++ b/src/cli/renderer/redteam.ts
@@ -209,9 +209,11 @@ export function renderAttackList(
     subCategoryDisplayName?: string;
     successful: boolean;
   }>,
+  options?: { footnote?: string },
 ): void {
   if (attacks.length === 0) {
     console.log(chalk.dim('  No attacks found.\n'));
+    if (options?.footnote) console.log(chalk.dim(`  ${options.footnote}\n`));
     return;
   }
   console.log(chalk.bold('\n  Attacks:\n'));
@@ -223,7 +225,26 @@ export function renderAttackList(
     const label = a.subCategoryDisplayName ?? a.subCategory ?? '—';
     console.log(`    ${sev} ${result}  ${label}${a.category ? chalk.dim(` [${a.category}]`) : ''}`);
   }
+  if (options?.footnote) console.log(chalk.dim(`  ${options.footnote}`));
   console.log();
+}
+
+/**
+ * Build a footnote for `report --attacks --severity X` when the list-attacks
+ * endpoint returns fewer items than the summary breakdown expects. Returns
+ * undefined when no footnote is warranted.
+ */
+export function buildAttackListFootnote(args: {
+  severity?: string;
+  totalItems?: number;
+  severityBreakdown: Array<{ severity: string; successful: number; failed: number }>;
+}): string | undefined {
+  if (!args.severity || args.totalItems == null) return undefined;
+  const row = args.severityBreakdown.find((s) => s.severity === args.severity);
+  if (!row) return undefined;
+  const expected = row.successful + row.failed;
+  if (args.totalItems >= expected) return undefined;
+  return `(showing ${args.totalItems} of ${expected} expected for severity ${args.severity} — list-attacks endpoint excludes some variants; tracking upstream divergence at #206)`;
 }
 
 /** Render custom attack list (prompt-level results). */

--- a/tests/unit/airs/redteam.spec.ts
+++ b/tests/unit/airs/redteam.spec.ts
@@ -533,8 +533,8 @@ describe('SdkRedTeamService', () => {
       });
 
       const result = await service.listAttacks('job-1', { severity: 'HIGH', limit: 10 });
-      expect(result).toHaveLength(2);
-      expect(result[0]).toEqual({
+      expect(result.attacks).toHaveLength(2);
+      expect(result.attacks[0]).toEqual({
         id: 'atk-1',
         name: 'Prompt Injection Basic',
         severity: 'HIGH',
@@ -542,14 +542,14 @@ describe('SdkRedTeamService', () => {
         subCategory: 'Prompt Injection',
         successful: true,
       });
-      expect(result[1].successful).toBe(false);
+      expect(result.attacks[1].successful).toBe(false);
       expect(mockReportsListAttacks).toHaveBeenCalledWith('job-1', { severity: 'HIGH', limit: 10 });
     });
 
     it('returns empty array when no attacks', async () => {
       mockReportsListAttacks.mockResolvedValue({ data: [] });
       const result = await service.listAttacks('job-1');
-      expect(result).toEqual([]);
+      expect(result.attacks).toEqual([]);
     });
 
     it('lifts sub_category_display_name into subCategoryDisplayName', async () => {
@@ -567,8 +567,8 @@ describe('SdkRedTeamService', () => {
         ],
       });
       const result = await service.listAttacks('job-1');
-      expect(result[0].subCategoryDisplayName).toBe('Jailbreak');
-      expect(result[0].subCategory).toBe('JAILBREAK');
+      expect(result.attacks[0].subCategoryDisplayName).toBe('Jailbreak');
+      expect(result.attacks[0].subCategory).toBe('JAILBREAK');
     });
 
     it('treats missing threat as not successful (BLOCKED default)', async () => {
@@ -584,7 +584,7 @@ describe('SdkRedTeamService', () => {
         ],
       });
       const result = await service.listAttacks('job-1');
-      expect(result[0].successful).toBe(false);
+      expect(result.attacks[0].successful).toBe(false);
     });
 
     it('leaves subCategoryDisplayName undefined when API omits it', async () => {
@@ -600,8 +600,23 @@ describe('SdkRedTeamService', () => {
         ],
       });
       const result = await service.listAttacks('job-1');
-      expect(result[0].subCategoryDisplayName).toBeUndefined();
-      expect(result[0].subCategory).toBe('JAILBREAK');
+      expect(result.attacks[0].subCategoryDisplayName).toBeUndefined();
+      expect(result.attacks[0].subCategory).toBe('JAILBREAK');
+    });
+
+    it('lifts pagination.total_items into totalItems', async () => {
+      mockReportsListAttacks.mockResolvedValue({
+        data: [],
+        pagination: { total_items: 109 },
+      });
+      const result = await service.listAttacks('job-1');
+      expect(result.totalItems).toBe(109);
+    });
+
+    it('leaves totalItems undefined when pagination missing', async () => {
+      mockReportsListAttacks.mockResolvedValue({ data: [] });
+      const result = await service.listAttacks('job-1');
+      expect(result.totalItems).toBeUndefined();
     });
   });
 

--- a/tests/unit/cli/redteam-attacks-renderer.spec.ts
+++ b/tests/unit/cli/redteam-attacks-renderer.spec.ts
@@ -82,6 +82,26 @@ describe('renderAttackList', () => {
     expect(text).not.toContain('BYPASSED');
   });
 
+  it('prints footnote when passed via options', async () => {
+    const { renderAttackList } = await import('../../../src/cli/renderer/redteam.js');
+    renderAttackList(
+      [
+        {
+          id: 'atk-1',
+          name: undefined as unknown as string,
+          severity: 'CRITICAL',
+          category: 'SECURITY',
+          subCategory: 'JAILBREAK',
+          successful: false,
+        },
+      ],
+      { footnote: '(showing 19 of 109 expected for severity CRITICAL — #206)' },
+    );
+    const text = output.join('\n');
+    expect(text).toContain('19 of 109');
+    expect(text).toContain('CRITICAL');
+  });
+
   it('prints em-dash when neither subcategory field is present', async () => {
     const { renderAttackList } = await import('../../../src/cli/renderer/redteam.js');
     renderAttackList([

--- a/tests/unit/cli/redteam-footnote.spec.ts
+++ b/tests/unit/cli/redteam-footnote.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { buildAttackListFootnote } from '../../../src/cli/renderer/redteam.js';
+
+describe('buildAttackListFootnote', () => {
+  const breakdown = [
+    { severity: 'CRITICAL', successful: 97, failed: 12 },
+    { severity: 'HIGH', successful: 503, failed: 98 },
+  ];
+
+  it('returns footnote when totalItems < expected for filtered severity', () => {
+    const footnote = buildAttackListFootnote({
+      severity: 'CRITICAL',
+      totalItems: 19,
+      severityBreakdown: breakdown,
+    });
+    expect(footnote).toBeDefined();
+    expect(footnote).toContain('19');
+    expect(footnote).toContain('109');
+    expect(footnote).toContain('CRITICAL');
+  });
+
+  it('returns undefined when totalItems matches expected', () => {
+    const footnote = buildAttackListFootnote({
+      severity: 'CRITICAL',
+      totalItems: 109,
+      severityBreakdown: breakdown,
+    });
+    expect(footnote).toBeUndefined();
+  });
+
+  it('returns undefined when no severity filter set', () => {
+    const footnote = buildAttackListFootnote({
+      severity: undefined,
+      totalItems: 19,
+      severityBreakdown: breakdown,
+    });
+    expect(footnote).toBeUndefined();
+  });
+
+  it('returns undefined when no matching breakdown row', () => {
+    const footnote = buildAttackListFootnote({
+      severity: 'INFORMATIONAL',
+      totalItems: 5,
+      severityBreakdown: breakdown,
+    });
+    expect(footnote).toBeUndefined();
+  });
+
+  it('returns undefined when totalItems is unknown', () => {
+    const footnote = buildAttackListFootnote({
+      severity: 'CRITICAL',
+      totalItems: undefined,
+      severityBreakdown: breakdown,
+    });
+    expect(footnote).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

CLI footnote workaround for upstream aggregator divergence — **not** a server-side reconciliation.

- `airs redteam report <jobId> --attacks --severity X` now prints a dimmed one-line footnote when `list-attacks` returns fewer items than the summary severity breakdown promised for X. Example: summary says 109 CRITICAL, list returns 19 → footnote `(showing 19 of 109 expected for severity CRITICAL — list-attacks endpoint excludes some variants; tracking upstream divergence at #206)`.
- No extra API calls: `getStaticReport(jobId)` already runs above the `--attacks` branch, so `severityBreakdown` is free.
- Reshapes internal `service.listAttacks()` from `Promise<RedTeamAttack[]>` to `Promise<{ attacks; totalItems? }>` to surface `pagination.total_items`. Only internal caller (the report command) updated.
- New pure helper `buildAttackListFootnote()` exported from the renderer module — unit-testable in isolation.
- No footnote when: no `--severity` filter, no matching breakdown row, totalItems unknown, or counts agree.
- CUSTOM jobs unaffected (different code path).

## Test plan

- [x] RED: 12 new/updated failing tests across `buildAttackListFootnote` (5), `listAttacks` normalizer shape (5 reshape + 2 pagination), renderer footnote (1)
- [x] GREEN: 693/693 tests pass
- [x] `pnpm lint` clean
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` 693 passed
- [x] `pnpm docs:check` clean

Closes #206