### PR TITLE
fix(dlp): emit snake_case JSON keys, stop dropping uppercase letters

### DIFF
--- a/.changeset/fix-dlp-tokey-strips-uppercase.md
+++ b/.changeset/fix-dlp-tokey-strips-uppercase.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+`airs runtime dlp filtering-profiles get`, `profiles get`, `patterns get`, and `dictionaries get` no longer mangle JSON/YAML keys for multi-word fields. The label→key transformer used by the detail renderers tried to produce camelCase but stripped uppercase letters in its final pass, yielding `datarofile`/`scanype`/`fileased`/`nonileased`/`fileypes`/`profileype`. It now emits snake_case directly: `data_profile`, `scan_type`, `file_based`, `non_file_based`, `file_types`, `profile_type`. `pretty` output was unaffected.

--- a/docs/runtime/dlp/filtering-profiles.md
+++ b/docs/runtime/dlp/filtering-profiles.md
@@ -75,44 +75,22 @@ airs runtime dlp filtering-profiles get 6a146fe17e175b786523c03a --output json
     Updated         2026-05-25T17:06:36.032Z
 ```
 
-!!! warning "Snake-case mangling on JSON/YAML (issue #105)"
-    The JSON shape below is the **intended** SDK contract. The current CLI snake_case transformer drops the character after each camelCase boundary, so the actual live output renders `datarofile` / `scanype` / `fileased` / `nonileased` / `fileypes` instead of `data_profile` / `scan_type` / `file_based` / `non_file_based` / `file_types`. Use `pretty` until [#105](https://github.com/cdot65/prisma-airs-cli/issues/105) lands.
-
-**JSON output (target shape):**
+**JSON output:**
 
 ```json
 {
   "id": "6a10...",
   "name": "asdfafdsadsa",
-  "description": null,
-  "tenant_id": "<TENANT_ID>",
   "type": "custom",
-  "data_profile_id": 1234567890,
+  "data_profile": 1234567890,
   "direction": "c2s",
-  "file_based": true,
-  "non_file_based": false,
-  "log_severity": "low",
+  "severity": "low",
   "scan_type": "include",
+  "file_based": "yes",
+  "non_file_based": "no",
   "version": 1,
-  "audit_metadata": {
-    "created_at": 1779473698140,
-    "created_by": null,
-    "updated_at": 1779473698140,
-    "updated_by": "Strata Cloud Manager"
-  },
-  "criteria_details": [],
-  "exception_rules": [],
-  "exclusions": {
-    "app_exclusion_list": [],
-    "url_exclusion_list": [],
-    "exclusion_list": {}
-  },
-  "rule1": {
-    "action": "alert",
-    "response_page": "This file has dlp issues",
-    "show_rsp_page": "no"
-  },
-  "rule2": null
+  "file_types": 35,
+  "updated": "2026-05-25T17:06:36.032Z"
 }
 ```
 

--- a/docs/runtime/dlp/profiles.md
+++ b/docs/runtime/dlp/profiles.md
@@ -170,15 +170,12 @@ airs runtime dlp profiles get 11995028 --output json
   "name": "U.K. PIOCP",
   "description": "Default profile for U.K. PIOCP",
   "type": "predefined",
-  "profileype": "basic",
+  "profile_type": "basic",
   "status": "active",
   "version": 1,
   "updated": "2026-05-15T08:05:35.633Z"
 }
 ```
-
-!!! warning "Snake-case mangling on JSON/YAML (issue #105)"
-    The JSON output above shows `profileype` instead of `profile_type` — the CLI's camelCase→snake_case transformer drops the character after each boundary. Use `pretty` until [#105](https://github.com/cdot65/prisma-airs-cli/issues/105) lands.
 
 ## replace
 

--- a/src/cli/renderer/dlp.ts
+++ b/src/cli/renderer/dlp.ts
@@ -92,11 +92,11 @@ function fieldsToObject(
   return obj;
 }
 
-function toKey(label: string): string {
+export function toKey(label: string): string {
   return label
     .toLowerCase()
-    .replace(/[^a-z0-9]+(.)/g, (_, c) => c.toUpperCase())
-    .replace(/[^a-z0-9]/g, '');
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
 }
 
 function emitDetail(

--- a/tests/unit/cli/dlp-renderer.spec.ts
+++ b/tests/unit/cli/dlp-renderer.spec.ts
@@ -5,7 +5,78 @@ import {
   dlpFilteringProfiles,
   dlpPatterns,
   dlpProfiles,
+  toKey,
 } from '../../../src/cli/renderer/dlp.js';
+
+describe('toKey (snake_case label transformer)', () => {
+  it('multi-word labels become snake_case', () => {
+    expect(toKey('Data Profile')).toBe('data_profile');
+    expect(toKey('Scan Type')).toBe('scan_type');
+    expect(toKey('File Based')).toBe('file_based');
+    expect(toKey('File Types')).toBe('file_types');
+    expect(toKey('Profile Type')).toBe('profile_type');
+  });
+
+  it('hyphens become underscores', () => {
+    expect(toKey('Non-File Based')).toBe('non_file_based');
+  });
+
+  it('single-word labels lowercased unchanged', () => {
+    expect(toKey('ID')).toBe('id');
+    expect(toKey('Name')).toBe('name');
+    expect(toKey('Version')).toBe('version');
+  });
+
+  it('empty string returns empty', () => {
+    expect(toKey('')).toBe('');
+  });
+});
+
+describe('dlp renderGet json keys are snake_case (regression #105)', () => {
+  it('filtering-profiles get json uses snake_case keys, not mangled camelCase', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    dlpFilteringProfiles.renderGet(
+      {
+        id: 'a',
+        name: 'p',
+        type: 'custom',
+        data_profile_id: 11995047,
+        direction: 'c2s',
+        log_severity: 'low',
+        scan_type: 'include',
+        file_based: true,
+        non_file_based: false,
+        version: 1,
+        file_type: new Array(35).fill('txt'),
+      } as any,
+      'json',
+    );
+    const out = String(spy.mock.calls[0]?.[0]);
+    expect(out).toContain('"data_profile"');
+    expect(out).toContain('"scan_type"');
+    expect(out).toContain('"file_based"');
+    expect(out).toContain('"non_file_based"');
+    expect(out).toContain('"file_types"');
+    expect(out).not.toContain('datarofile');
+    expect(out).not.toContain('scanype');
+    expect(out).not.toContain('fileased');
+    expect(out).not.toContain('nonileased');
+    expect(out).not.toContain('fileypes');
+    spy.mockRestore();
+  });
+
+  it('profiles get json uses profile_type, not profileype', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    dlpProfiles.renderGet(
+      { id: 'dp', name: 'n', type: 'advanced', profile_type: 'predefined', version: 2 } as any,
+      'json',
+    );
+    const out = String(spy.mock.calls[0]?.[0]);
+    expect(out).toContain('"profile_type"');
+    expect(out).not.toContain('profileype');
+    spy.mockRestore();
+  });
+});
 
 describe('dlpFilteringProfiles renderer', () => {
   it('renderList json emits curated items + page meta (not raw SDK envelope)', () => {


### PR DESCRIPTION
## Summary

- `toKey()` in `src/cli/renderer/dlp.ts` produced camelCase via `[^a-z0-9]+(.)` → `c.toUpperCase()`, then a final `/[^a-z0-9]/g` pass stripped the just-uppercased letter — so `Data Profile` → `dataProfile` → `datarofile`. Fixed by emitting snake_case directly: `.replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')`.
- All 4 DLP `renderGet` renderers (filtering-profiles, profiles, patterns, dictionaries) now emit correct keys: `data_profile`, `scan_type`, `file_based`, `non_file_based`, `file_types`, `profile_type`.
- Removed `#105` warnings from `docs/runtime/dlp/profiles.md` and `filtering-profiles.md`; updated the JSON examples to match actual CLI output.

Closes #105
Unblocks #188

## Test plan

- [x] RED unit tests on `toKey` for the 6 mangled labels + edge cases
- [x] RED integration tests on `dlpFilteringProfiles.renderGet` (5 keys) and `dlpProfiles.renderGet` (profile_type) — fail with mangled keys, pass after fix
- [x] `pnpm lint` clean
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` 699/699
- [x] `pnpm docs:check` clean
- [ ] CI green