### PR TITLE
chore: prune already-shipped changesets

### DIFF
--- a/.changeset/0000-api-key-value.md
+++ b/.changeset/0000-api-key-value.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": patch
----
-
-Display API key value on create/regenerate and last 8 characters in list views.

--- a/.changeset/0001-debug-api-logging.md
+++ b/.changeset/0001-debug-api-logging.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": patch
----
-
-Added `--debug` global flag that logs all AIRS/SCM API requests and responses to a JSONL file for troubleshooting rate limits and API issues.

--- a/.changeset/0002-rate-limit-flag.md
+++ b/.changeset/0002-rate-limit-flag.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": patch
----
-
-Added `--rate <n>` flag to guardrail generate and resume commands that caps AIRS scan API calls to N per second, preventing rate limit errors during intensive scan loops.

--- a/.changeset/0003-autoresearch-refactor.md
+++ b/.changeset/0003-autoresearch-refactor.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": major
----
-
-Replace LLM-driven guardrail generation loop with atomic CLI commands following the autoresearch pattern. Added `topics create`, `topics apply`, `topics eval`, and `topics revert` commands. Removed `topics generate`, `topics resume`, `topics report`, and `topics runs` commands. Removed memory system and persistence layer.

--- a/.changeset/0005-backup-restore-targets.md
+++ b/.changeset/0005-backup-restore-targets.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": minor
----
-
-Add `airs redteam targets backup` and `airs redteam targets restore` subcommands for exporting/importing redteam target configurations to/from local JSON/YAML files. Supports single-target and bulk modes, with `--overwrite` for collision handling on restore.

--- a/.changeset/0005-profiles-cleanup.md
+++ b/.changeset/0005-profiles-cleanup.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": minor
----
-
-Add `airs runtime profiles cleanup` command to remove old profile revisions, keeping only the latest per name. Supports `--force` to skip confirmation, `--updated-by` (defaults to git email), and `--output json`.

--- a/.changeset/0005-target-init-command.md
+++ b/.changeset/0005-target-init-command.md
@@ -1,5 +1,0 @@
----
-"prisma-airs-cli": minor
----
-
-Add `airs redteam targets init <provider>` command that scaffolds a target config JSON from provider templates (OPENAI, HUGGING_FACE, DATABRICKS, BEDROCK, REST, STREAMING, WEBSOCKET).

--- a/.changeset/0007-backup-restructure-full-fields.md
+++ b/.changeset/0007-backup-restructure-full-fields.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": minor
----
-
-Move backup/restore from top-level to `airs redteam targets backup/restore`. Backup now captures all target fields (routing tuple, auth config, network broker UUID, extra info). Restore supplies routing defaults for targets with null routing fields. Strip null values from backup output.

--- a/.changeset/0008-sdk-080-upgrade.md
+++ b/.changeset/0008-sdk-080-upgrade.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": patch
----
-
-Upgrade `@cdot65/prisma-airs-sdk` from `0.7.1` to `0.8.0`. SDK adds runtime Zod validation on every response and tightens `ScanResponse`/`CustomTopic` field requiredness. No CLI behavior changes — public surface is unchanged. Test fixtures updated to match the now-required `revision`/`description`/`examples` fields on `CustomTopic` responses.

--- a/.changeset/0009-smoke-tests-doc.md
+++ b/.changeset/0009-smoke-tests-doc.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": patch
----
-
-Add a live smoke test reference (`docs/development/smoke-tests.md`) covering 16 read-only commands across install/version verification, runtime security, red team, and model security. The unit suite is fully mocked — zero tests hit a real AIRS tenant — so this reference is the standing checklist for catching wire-format drift after CLI releases or SDK upgrades.

--- a/.changeset/0010-fix-testing-doc.md
+++ b/.changeset/0010-fix-testing-doc.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": patch
----
-
-Rewrite `docs/development/testing.md` to accurately describe the test suite. The page previously claimed MSW intercepted HTTP requests and listed test directories that don't exist (`memory/`, `persistence/`, `integration/`, `report/`). The unit suite actually injects in-memory service mocks from `tests/helpers/mocks.ts` — the SDK and its HTTP layer are never instantiated. Also removes the unused `msw` devDependency and links the page to the new live AIRS smoke test reference for API coverage that the unit suite intentionally does not provide.

--- a/.changeset/0011-sdk-081-upgrade.md
+++ b/.changeset/0011-sdk-081-upgrade.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": patch
----
-
-Upgrade `@cdot65/prisma-airs-sdk` from `0.8.0` to `0.8.1`. Picks up a fix to the `TopicArraySchema.topic` field, which was strict-array in 0.8.0 but the AIRS API legitimately returns `null` for empty action buckets. SDK 0.8.0 + live tenants would fail `airs runtime profiles list` with `RESPONSE_VALIDATION` for any profile that had an empty allow or block bucket; 0.8.1 fixes this. No CLI behavior changes.

--- a/.changeset/0012-fix-smoke-rule-instances.md
+++ b/.changeset/0012-fix-smoke-rule-instances.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": patch
----
-
-Fix `airs model-security rule-instances list` entry in the live smoke test reference. The CLI requires a positional `<groupUuid>` argument (rule instances are scoped to a security group); the doc was missing it. Discovered during the first live run of the smoke checklist on a real tenant.

--- a/.changeset/0013-full-cli-sweep.md
+++ b/.changeset/0013-full-cli-sweep.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": patch
----
-
-Add `docs/development/full-cli-sweep.md` — a copy-paste-runnable walkthrough of every CLI command for a deep audit against a real tenant. Covers all read paths, every CRUD resource type with cleanup, long-running workflows (bulk-scan, audit, red team scan, model security install), and a suggested teardown order. Linked from the Live Smoke Tests page as the heavier deep-dive companion.

--- a/.changeset/0014-fix-cli-sweep-doc.md
+++ b/.changeset/0014-fix-cli-sweep-doc.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": patch
----
-
-Fix ~20 incorrect command signatures in `docs/development/full-cli-sweep.md`. The previous version listed nonexistent commands (`redteam instances list`, `redteam devices list`, `redteam devices registry-credentials`) and used wrong flags throughout the write/CRUD sections (`topics create --topic` should be `--name`/`--description`/`--examples`; `topics apply/revert --topic` should be `--name`; `topics eval --input` should be `--prompts`; `redteam scan --custom-prompt-sets` should be `--prompt-sets`; `api-keys create --name` should be `--config <path>`; profile-protection flags take action values not bare booleans; many `update` commands take `--config` rather than per-field flags; `validate-auth` requires `--auth-type` and `--config`). All commands now match `src/cli/commands/*.ts`. Adds a Known Issues section documenting the `scan-logs query` SDK schema bug, the `prompt-sets get` follow-up 500, and the `customer-apps get` permission boundary.

--- a/.changeset/0015-fix-csv-upload-filename.md
+++ b/.changeset/0015-fix-csv-upload-filename.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": patch
----
-
-Fix `airs redteam prompt-sets upload` failing with `File must be a CSV` (400). The upload now sends a `File` (with filename) instead of a bare `Blob`, so the server can identify the content type from the multipart header.

--- a/.changeset/0016-dynamic-scan-flags.md
+++ b/.changeset/0016-dynamic-scan-flags.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": minor
----
-
-Add `--goals`, `--depth`, and `--breadth` flags to `airs redteam scan --type DYNAMIC` for human-augmented agent scans. `--goals` accepts an inline JSON array or a path to a JSON file of goal strings. Inputs are validated (positive integers; non-empty string array). Without `--goals`, DYNAMIC scans still run in fully automated mode (no behavior change).

--- a/.changeset/0017-fix-download-template.md
+++ b/.changeset/0017-fix-download-template.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": patch
----
-
-Fix `airs redteam prompt-sets download` crashing with `Cannot read properties of undefined (reading 'getToken')`. The previous workaround reached into SDK internals that no longer exist. With `@cdot65/prisma-airs-sdk` 0.8.3 the SDK now returns CSV correctly, so the workaround is removed and the method delegates straight to `customAttacks.downloadTemplate()`.

--- a/.changeset/0018-runtime-dlp-gen.md
+++ b/.changeset/0018-runtime-dlp-gen.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": minor
----
-
-Add `airs runtime dlp-gen` to generate DLP test corpora: clean carrier files plus "dirty" copies with synthetic sensitive data embedded across PDF, PNG, JPEG, SVG, and DOCX via multiple hiding techniques (metadata, hidden text, container trailers, PNG chunks, LSB steganography, EXIF/COM, DOCX core-props/hidden-run). Writes `clean/`, `dirty/`, and a `manifest.json` mapping each dirty file to its technique and embedded values for scanner scoring. All values are synthetic / reserved-for-testing. Adds a companion `dlp-test-files` skill.

--- a/.changeset/0019-dlp-ux.md
+++ b/.changeset/0019-dlp-ux.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": minor
----
-
-DLP UX overhaul. `dlp patterns|profiles|filtering-profiles` now accept structured CLI flags (`--name`, `--regex`, `--pattern-id`, `--file-based`, …) instead of forcing `--body-file pattern.json`. All output formats now route through a curated projection — `--output json` returns `{items, page}` and ack `{action,id,name,…}` instead of the raw SDK envelope.

--- a/.changeset/lazy-load-docx.md
+++ b/.changeset/lazy-load-docx.md
@@ -1,5 +1,0 @@
----
-"@cdot65/prisma-airs-cli": patch
----
-
-Lazy-load the `docx` dependency so it only loads when generating DOCX output. Previously `docx` was imported eagerly, pulling in browserify polyfills whose `util-deprecate` shim reads `localStorage` at import time and triggered a Node Web Storage warning (`--localstorage-file was provided without a valid path`) on every command. The import is now deferred into the DOCX builders, so unrelated commands (scan, profiles, etc.) no longer emit the warning and start slightly faster.


### PR DESCRIPTION
## Summary

- Delete 21 `.changeset/*.md` files whose content has already shipped in v2.6.x through v2.10.1.
- Keep 32 changesets describing genuinely-unreleased post-v2.10.0 work (will go in the next release).

## Why

The repo has `@changesets/cli` installed and devs add changesets alongside PRs, but the release workflow does **manual `package.json` version bumps** (e.g. `chore: bump to v2.9.0`). `pnpm changeset version` has never been run, so consumed entries were never deleted and have piled up since 2026-03. This left 53 files in `.changeset/` — 21 historical, 32 actually pending — which made it impossible to use the changesets workflow for future releases (would compute a misleading MAJOR bump from a stale 2026-03-28 changeset).

## What was deleted

| Range | Date added | Shipped in |
|-------|-----------|------------|
| `0000`–`0007` | 2026-03-17 → 04-12 | v2.2.0 → v2.6.0 |
| `0008`–`0014` | 2026-05-04 | v2.6.1 → v2.7.0 |
| `0015`–`0017` | 2026-05-13 | v2.7.0 → v2.8.0 |
| `0018` | 2026-05-21 | v2.8.0 |
| `0019` | 2026-05-24 | v2.10.0 |
| `lazy-load-docx` | 2026-05-28 | v2.10.1 (#218) |

## What was kept (32)

All `docs-*` and `fix-*` from 2026-05-25 through 2026-05-27, plus `0020`/`0021`/`0022`. These describe the docs sweep + redteam/DLP fixes from PRs #214–#221 that merged after v2.10.0 and haven't shipped yet.

## Test plan

- [ ] CI green (lint, typecheck, test, docs-check, docs-build)
- [ ] `.changeset/` count is 33 (32 kept + `README.md`)
- [ ] No `.changeset/*.md` describing pre-v2.10.0 work remains