### PR TITLE
docs: rename runtime dlp-gen references to runtime dlp generate

### DIFF
--- a/.changeset/docs-rename-dlp-gen-to-dlp-generate.md
+++ b/.changeset/docs-rename-dlp-gen-to-dlp-generate.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Renamed the DLP test-file generator user guide from `docs/runtime/dlp-gen.md` to `docs/runtime/dlp/generate.md` and updated all `airs runtime dlp-gen` references to `airs runtime dlp generate` (matches the command move shipped in the prior code release). Top-level nav now lists "Test-File Generation" under the DLP namespace alongside Filtering Profiles, Patterns, Profiles, and Dictionaries. Companion to the code PR that moved the command.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,7 +8,6 @@
     * Runtime Security
         * [Overview](runtime/overview.md)
         * [Prompt Scanning](runtime/scanning.md)
-        * [DLP Test-File Generation](runtime/dlp-gen.md)
         * [Configuration Management](runtime/config-management.md)
         * [Profile Audits](runtime/profile-audits.md)
         * Guardrail Optimization
@@ -22,6 +21,7 @@
             * [Patterns](runtime/dlp/patterns.md)
             * [Profiles](runtime/dlp/profiles.md)
             * [Dictionaries](runtime/dlp/dictionaries.md)
+            * [Test-File Generation](runtime/dlp/generate.md)
     * AI Red Teaming
         * [Overview](redteam/overview.md)
         * [End-to-End Walkthrough](redteam/end-to-end-walkthrough.md)

--- a/docs/development/full-cli-sweep.md
+++ b/docs/development/full-cli-sweep.md
@@ -202,13 +202,13 @@ multiple techniques. Local only — no AIRS API calls, safe to run anywhere.
 
 ```bash
 # Full corpus (all formats + techniques) into ./temp, reproducible with a seed
-airs runtime dlp-gen --types all --count 1 --out ./temp --seed 1
+airs runtime dlp generate --types all --count 1 --out ./temp --seed 1
 
 # Images only, JSON summary
-airs runtime dlp-gen --types png,jpeg,svg --techniques all --output json
+airs runtime dlp generate --types png,jpeg,svg --techniques all --output json
 
 # Just the PNG steganography variant
-airs runtime dlp-gen --types png --techniques stego-lsb --out ./temp
+airs runtime dlp generate --types png --techniques stego-lsb --out ./temp
 ```
 
 Expected output (pretty):

--- a/docs/runtime/dlp/generate.md
+++ b/docs/runtime/dlp/generate.md
@@ -1,6 +1,6 @@
 # DLP Test-File Generation
 
-`airs runtime dlp-gen` generates **DLP test corpora** — clean carrier files plus "dirty"
+`airs runtime dlp generate` generates **DLP test corpora** — clean carrier files plus "dirty"
 copies with **synthetic** sensitive data embedded via multiple hiding techniques. Use it to
 measure how well a content scanner detects sensitive data across file formats and channels.
 
@@ -12,7 +12,7 @@ measure how well a content scanner detects sensitive data across file formats an
 ## Usage
 
 ```bash
-airs runtime dlp-gen [options]
+airs runtime dlp generate [options]
 ```
 
 | Option | Default | Meaning |
@@ -52,11 +52,11 @@ the exact synthetic values embedded.
 
 ```bash
 # Full corpus into ./temp
-airs runtime dlp-gen
+airs runtime dlp generate
 
 # Images only, 3 each, reproducible
-airs runtime dlp-gen --types png,jpeg,svg --count 3 --seed 42
+airs runtime dlp generate --types png,jpeg,svg --count 3 --seed 42
 
 # Just PNG LSB steganography, JSON summary
-airs runtime dlp-gen --types png --techniques stego-lsb --output json
+airs runtime dlp generate --types png --techniques stego-lsb --output json
 ```


### PR DESCRIPTION
Companion to #229 (code rename: `runtime dlp-gen` → `runtime dlp generate`).

## Summary
- `git mv docs/runtime/dlp-gen.md` → `docs/runtime/dlp/generate.md` (file now lives under the DLP namespace alongside its siblings)
- Updated all in-file `airs runtime dlp-gen` mentions to `airs runtime dlp generate`
- `docs/SUMMARY.md`: removed top-level "DLP Test-File Generation" entry, added "Test-File Generation" under the existing DLP section
- `docs/development/full-cli-sweep.md`: 3 example commands updated

Note: `docs/cli/examples/runtime.yaml`, `docs/about/release-notes.md`, and auto-gen `docs/cli/**` pages were already updated by #229 — not touched here.

The historical mention in `docs/about/release-notes.md` is intentional (migration note tells users what to migrate FROM).

## Test plan
- [x] `pnpm docs:check` — 123 commands, 30 allowlist
- [x] `pnpm docs:build` — mkdocs strict green, no broken cross-refs after rename
- [ ] Visual skim of renamed page via `pnpm docs:serve`