### PR TITLE
docs(examples): post-v2.11.0 re-probe pass — DLP + Runtime

### DIFF
--- a/.changeset/docs-reprobe-dlp-runtime.md
+++ b/.changeset/docs-reprobe-dlp-runtime.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+docs(examples): land DLP examples for filtering-profiles get, patterns get/replace/patch, profiles get/create after v2.11.0 + SDK 0.10.0 unblocked them.

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -12,21 +12,9 @@ runtime customer-apps delete
 runtime profiles delete
 # Blocked by SDK — see https://github.com/cdot65/prisma-airs-sdk/issues/165
 runtime topics delete
-# Blocked by CLI bug — see https://github.com/cdot65/prisma-airs-cli/issues/105
-runtime dlp filtering-profiles get
-# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/80
-runtime dlp patterns get
-# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/98
-runtime dlp patterns replace
-# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/98
-runtime dlp patterns patch
-# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/101
-runtime dlp profiles create
-# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/80
-runtime dlp profiles get
-# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/101
+# Blocked by upstream API 500 (was 400; create now works) — see https://github.com/cdot65/prisma-airs-cli/issues/101
 runtime dlp profiles replace
-# Blocked by upstream API 400 — see https://github.com/cdot65/prisma-airs-cli/issues/101
+# Blocked by upstream API 500 (was 400; create now works) — see https://github.com/cdot65/prisma-airs-cli/issues/101
 runtime dlp profiles patch
 # Blocked by upstream — see https://github.com/cdot65/prisma-airs-cli/issues/99
 runtime dlp dictionaries create

--- a/docs/cli/examples/dlp/patterns/patch.json
+++ b/docs/cli/examples/dlp/patterns/patch.json
@@ -1,0 +1,1 @@
+{ "description": "Docs example pattern (patched description only)" }

--- a/docs/cli/examples/dlp/patterns/replace.json
+++ b/docs/cli/examples/dlp/patterns/replace.json
@@ -1,0 +1,13 @@
+{
+  "name": "docs-example-pattern",
+  "description": "Docs example pattern (replaced)",
+  "type": "custom",
+  "detection_config": {
+    "technique": "regex",
+    "supported_confidence_levels": ["high"]
+  },
+  "matching_rules": {
+    "regexes": [{ "regex": "\\bACME-V2-\\d{6}\\b", "weight": 1 }],
+    "proximity_distance": 200
+  }
+}

--- a/docs/cli/examples/dlp/profiles/create.json
+++ b/docs/cli/examples/dlp/profiles/create.json
@@ -1,0 +1,22 @@
+{
+  "name": "docs-example-profile",
+  "description": "Docs example profile",
+  "profile_type": "advanced",
+  "type": "custom",
+  "detection_rules": [
+    {
+      "rule_type": "expression_tree",
+      "expression_tree": {
+        "operator_type": "or",
+        "rule_item": {
+          "detection_technique": "regex",
+          "id": "000000000000000000000099",
+          "match_type": "include",
+          "confidence_level": "high",
+          "occurrence_count": 1,
+          "occurrence_operator_type": "more_than_equal_to"
+        }
+      }
+    }
+  ]
+}

--- a/docs/cli/examples/runtime.yaml
+++ b/docs/cli/examples/runtime.yaml
@@ -324,6 +324,88 @@
           "version": 1
         }
 
+"runtime dlp patterns get":
+  examples:
+    - note: Pretty output (default — predefined pattern)
+      input: airs runtime dlp patterns get 000000000000000000000001
+      output: |
+          Data Pattern:
+
+            ID           000000000000000000000001
+            Name         API Credentials Client ID - Amazon Web Services AWS
+            Description  This pattern identifies an Amazon Web Services client ID.
+            Type         predefined
+            Status       disabled
+            Technique    regex
+            Confidence   high, low
+            Version      1
+            Updated      2026-05-25T15:50:58.037Z
+    - note: JSON output
+      input: airs runtime dlp patterns get 000000000000000000000001 --output json
+      output: |
+        {
+          "id": "000000000000000000000001",
+          "name": "API Credentials Client ID - Amazon Web Services AWS",
+          "description": "This pattern identifies an Amazon Web Services client ID.",
+          "type": "predefined",
+          "status": "disabled",
+          "technique": "regex",
+          "confidence": "high, low",
+          "version": 1,
+          "updated": "2026-05-25T15:50:58.037Z"
+        }
+    - note: YAML output
+      input: airs runtime dlp patterns get 000000000000000000000001 --output yaml
+      output: |
+        id: 000000000000000000000001
+        name: API Credentials Client ID - Amazon Web Services AWS
+        description: This pattern identifies an Amazon Web Services client ID.
+        type: predefined
+        status: disabled
+        technique: regex
+        confidence: high, low
+        version: 1
+        updated: '2026-05-25T15:50:58.037Z'
+
+"runtime dlp patterns replace":
+  examples:
+    - note: Full-replace a custom pattern from a body fixture (see docs/cli/examples/dlp/patterns/replace.json). API returns the new version.
+      input: airs runtime dlp patterns replace 000000000000000000000099 --body-file docs/cli/examples/dlp/patterns/replace.json --output json
+      output: |
+        {
+          "action": "replaced",
+          "id": "000000000000000000000099",
+          "name": "docs-example-pattern",
+          "type": "custom",
+          "status": "active",
+          "version": 2
+        }
+
+"runtime dlp patterns patch":
+  examples:
+    - note: Merge-patch a pattern's description from a body fixture (see docs/cli/examples/dlp/patterns/patch.json). Omitted fields are unchanged.
+      input: airs runtime dlp patterns patch 000000000000000000000099 --body-file docs/cli/examples/dlp/patterns/patch.json --output json
+      output: |
+        {
+          "action": "patched",
+          "id": "000000000000000000000099",
+          "name": "docs-example-pattern",
+          "type": "custom",
+          "status": "active",
+          "version": 2
+        }
+    - note: Merge-patch inline via --set (scalar fields only; quote regex/JSON literals as needed)
+      input: airs runtime dlp patterns patch 000000000000000000000099 --set description='docs example' --output json
+      output: |
+        {
+          "action": "patched",
+          "id": "000000000000000000000099",
+          "name": "docs-example-pattern",
+          "type": "custom",
+          "status": "active",
+          "version": 2
+        }
+
 "runtime dlp patterns delete":
   examples:
     - note: Soft-delete (archive) a data pattern by id
@@ -868,6 +950,60 @@
           last: false
           empty: false
 
+"runtime dlp profiles get":
+  examples:
+    - note: Pretty output (default — predefined profile)
+      input: airs runtime dlp profiles get 00000001
+      output: |
+          Data Profile:
+
+            ID            00000001
+            Name          Bulk CCN
+            Description   Default profile for Bulk CCN
+            Type          predefined
+            Profile Type  basic
+            Status        active
+            Version       1
+            Updated       2026-05-15T08:05:35.599Z
+    - note: JSON output
+      input: airs runtime dlp profiles get 00000001 --output json
+      output: |
+        {
+          "id": "00000001",
+          "name": "Bulk CCN",
+          "description": "Default profile for Bulk CCN",
+          "type": "predefined",
+          "profile_type": "basic",
+          "status": "active",
+          "version": 1,
+          "updated": "2026-05-15T08:05:35.599Z"
+        }
+    - note: YAML output
+      input: airs runtime dlp profiles get 00000001 --output yaml
+      output: |
+        id: '00000001'
+        name: Bulk CCN
+        description: Default profile for Bulk CCN
+        type: predefined
+        profile_type: basic
+        status: active
+        version: 1
+        updated: '2026-05-15T08:05:35.599Z'
+
+"runtime dlp profiles create":
+  examples:
+    - note: Create a custom advanced profile from a body fixture (see docs/cli/examples/dlp/profiles/create.json). Body uses the discriminated-union detection_rules shape (rule_type=expression_tree).
+      input: airs runtime dlp profiles create --body-file docs/cli/examples/dlp/profiles/create.json --output json
+      output: |
+        {
+          "action": "created",
+          "id": "00000099",
+          "name": "docs-example-profile",
+          "type": "custom",
+          "status": "active",
+          "version": 1
+        }
+
 "runtime dlp profiles delete":
   examples:
     - note: Stub — DLP data profiles have no DELETE endpoint; soft-delete via patch
@@ -1322,6 +1458,58 @@
           size: 2
           total: 29
           returned: 2
+
+"runtime dlp filtering-profiles get":
+  examples:
+    - note: Pretty output (default — predefined filtering profile)
+      input: airs runtime dlp filtering-profiles get 000000000000000000000001
+      output: |
+          Data Filtering Profile:
+
+            ID              000000000000000000000001
+            Name            Bulk CCN
+            Type            predefined
+            Data Profile    00000001
+            Direction       c2s
+            Severity        low
+            Scan Type       include
+            File Based      yes
+            Non-File Based  no
+            Version         1
+            File Types      35
+            Updated         2026-05-15T08:05:35.599Z
+    - note: JSON output
+      input: airs runtime dlp filtering-profiles get 000000000000000000000001 --output json
+      output: |
+        {
+          "id": "000000000000000000000001",
+          "name": "Bulk CCN",
+          "type": "predefined",
+          "data_profile": 1,
+          "direction": "c2s",
+          "severity": "low",
+          "scan_type": "include",
+          "file_based": "yes",
+          "non_file_based": "no",
+          "version": 1,
+          "file_types": 35,
+          "updated": "2026-05-15T08:05:35.599Z"
+        }
+    - note: YAML output
+      input: airs runtime dlp filtering-profiles get 000000000000000000000001 --output yaml
+      output: |
+        id: 000000000000000000000001
+        name: Bulk CCN
+        type: predefined
+        data_profile: 1
+        direction: c2s
+        severity: low
+        scan_type: include
+        file_based: 'yes'
+        non_file_based: 'no'
+        version: 1
+        file_types: 35
+        updated: '2026-05-15T08:05:35.599Z'
 
 "runtime dlp filtering-profiles replace":
   examples:

--- a/docs/cli/runtime/dlp/filtering-profiles.md
+++ b/docs/cli/runtime/dlp/filtering-profiles.md
@@ -120,8 +120,72 @@ airs runtime dlp filtering-profiles get [options] <id>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default — predefined filtering profile)*
+
+```bash
+airs runtime dlp filtering-profiles get 000000000000000000000001
+```
+
+```text
+Data Filtering Profile:
+
+  ID              000000000000000000000001
+  Name            Bulk CCN
+  Type            predefined
+  Data Profile    00000001
+  Direction       c2s
+  Severity        low
+  Scan Type       include
+  File Based      yes
+  Non-File Based  no
+  Version         1
+  File Types      35
+  Updated         2026-05-15T08:05:35.599Z
+```
+
+*JSON output*
+
+```bash
+airs runtime dlp filtering-profiles get 000000000000000000000001 --output json
+```
+
+```text
+{
+  "id": "000000000000000000000001",
+  "name": "Bulk CCN",
+  "type": "predefined",
+  "data_profile": 1,
+  "direction": "c2s",
+  "severity": "low",
+  "scan_type": "include",
+  "file_based": "yes",
+  "non_file_based": "no",
+  "version": 1,
+  "file_types": 35,
+  "updated": "2026-05-15T08:05:35.599Z"
+}
+```
+
+*YAML output*
+
+```bash
+airs runtime dlp filtering-profiles get 000000000000000000000001 --output yaml
+```
+
+```text
+id: 000000000000000000000001
+name: Bulk CCN
+type: predefined
+data_profile: 1
+direction: c2s
+severity: low
+scan_type: include
+file_based: 'yes'
+non_file_based: 'no'
+version: 1
+file_types: 35
+updated: '2026-05-15T08:05:35.599Z'
+```
 
 ---
 

--- a/docs/cli/runtime/dlp/patterns.md
+++ b/docs/cli/runtime/dlp/patterns.md
@@ -168,8 +168,63 @@ airs runtime dlp patterns get [options] <id>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default — predefined pattern)*
+
+```bash
+airs runtime dlp patterns get 000000000000000000000001
+```
+
+```text
+Data Pattern:
+
+  ID           000000000000000000000001
+  Name         API Credentials Client ID - Amazon Web Services AWS
+  Description  This pattern identifies an Amazon Web Services client ID.
+  Type         predefined
+  Status       disabled
+  Technique    regex
+  Confidence   high, low
+  Version      1
+  Updated      2026-05-25T15:50:58.037Z
+```
+
+*JSON output*
+
+```bash
+airs runtime dlp patterns get 000000000000000000000001 --output json
+```
+
+```text
+{
+  "id": "000000000000000000000001",
+  "name": "API Credentials Client ID - Amazon Web Services AWS",
+  "description": "This pattern identifies an Amazon Web Services client ID.",
+  "type": "predefined",
+  "status": "disabled",
+  "technique": "regex",
+  "confidence": "high, low",
+  "version": 1,
+  "updated": "2026-05-25T15:50:58.037Z"
+}
+```
+
+*YAML output*
+
+```bash
+airs runtime dlp patterns get 000000000000000000000001 --output yaml
+```
+
+```text
+id: 000000000000000000000001
+name: API Credentials Client ID - Amazon Web Services AWS
+description: This pattern identifies an Amazon Web Services client ID.
+type: predefined
+status: disabled
+technique: regex
+confidence: high, low
+version: 1
+updated: '2026-05-25T15:50:58.037Z'
+```
 
 ---
 
@@ -206,8 +261,22 @@ airs runtime dlp patterns replace [options] <id>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Full-replace a custom pattern from a body fixture (see docs/cli/examples/dlp/patterns/replace.json). API returns the new version.*
+
+```bash
+airs runtime dlp patterns replace 000000000000000000000099 --body-file docs/cli/examples/dlp/patterns/replace.json --output json
+```
+
+```text
+{
+  "action": "replaced",
+  "id": "000000000000000000000099",
+  "name": "docs-example-pattern",
+  "type": "custom",
+  "status": "active",
+  "version": 2
+}
+```
 
 ---
 
@@ -234,8 +303,39 @@ airs runtime dlp patterns patch [options] <id>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Merge-patch a pattern's description from a body fixture (see docs/cli/examples/dlp/patterns/patch.json). Omitted fields are unchanged.*
+
+```bash
+airs runtime dlp patterns patch 000000000000000000000099 --body-file docs/cli/examples/dlp/patterns/patch.json --output json
+```
+
+```text
+{
+  "action": "patched",
+  "id": "000000000000000000000099",
+  "name": "docs-example-pattern",
+  "type": "custom",
+  "status": "active",
+  "version": 2
+}
+```
+
+*Merge-patch inline via --set (scalar fields only; quote regex/JSON literals as needed)*
+
+```bash
+airs runtime dlp patterns patch 000000000000000000000099 --set description='docs example' --output json
+```
+
+```text
+{
+  "action": "patched",
+  "id": "000000000000000000000099",
+  "name": "docs-example-pattern",
+  "type": "custom",
+  "status": "active",
+  "version": 2
+}
+```
 
 ---
 

--- a/docs/cli/runtime/dlp/profiles.md
+++ b/docs/cli/runtime/dlp/profiles.md
@@ -234,8 +234,22 @@ airs runtime dlp profiles create [options]
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Create a custom advanced profile from a body fixture (see docs/cli/examples/dlp/profiles/create.json). Body uses the discriminated-union detection_rules shape (rule_type=expression_tree).*
+
+```bash
+airs runtime dlp profiles create --body-file docs/cli/examples/dlp/profiles/create.json --output json
+```
+
+```text
+{
+  "action": "created",
+  "id": "00000099",
+  "name": "docs-example-profile",
+  "type": "custom",
+  "status": "active",
+  "version": 1
+}
+```
 
 ---
 
@@ -259,8 +273,60 @@ airs runtime dlp profiles get [options] <id>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Pretty output (default — predefined profile)*
+
+```bash
+airs runtime dlp profiles get 00000001
+```
+
+```text
+Data Profile:
+
+  ID            00000001
+  Name          Bulk CCN
+  Description   Default profile for Bulk CCN
+  Type          predefined
+  Profile Type  basic
+  Status        active
+  Version       1
+  Updated       2026-05-15T08:05:35.599Z
+```
+
+*JSON output*
+
+```bash
+airs runtime dlp profiles get 00000001 --output json
+```
+
+```text
+{
+  "id": "00000001",
+  "name": "Bulk CCN",
+  "description": "Default profile for Bulk CCN",
+  "type": "predefined",
+  "profile_type": "basic",
+  "status": "active",
+  "version": 1,
+  "updated": "2026-05-15T08:05:35.599Z"
+}
+```
+
+*YAML output*
+
+```bash
+airs runtime dlp profiles get 00000001 --output yaml
+```
+
+```text
+id: '00000001'
+name: Bulk CCN
+description: Default profile for Bulk CCN
+type: predefined
+profile_type: basic
+status: active
+version: 1
+updated: '2026-05-15T08:05:35.599Z'
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Re-probe of `.missing-allowlist` entries after v2.11.0 (CLI #105 JSON-key fix) + SDK 0.10.0 (DLP get-by-id schema fix). Lands curated examples for 6 commands that now work; updates trackers for the rest.

Refs epic #127.

## DLP — wins (6, removed from allowlist)

| Command | Tracker | Status |
|---|---|---|
| `runtime dlp filtering-profiles get` | #105 | ✅ landed (already closed) |
| `runtime dlp patterns get` | #80 | ✅ landed (already closed) |
| `runtime dlp patterns replace` | #98 | ✅ landed — closed #98 |
| `runtime dlp patterns patch` | #98 | ✅ landed — closed #98 |
| `runtime dlp profiles get` | #80 | ✅ landed (already closed) |
| `runtime dlp profiles create` | #101 | ✅ landed (replace+patch still blocked) |

Fixture bodies live under `docs/cli/examples/dlp/patterns/{replace,patch}.json` and `docs/cli/examples/dlp/profiles/create.json`. All inputs/outputs redacted per `docs/cli/examples/REDACTION.md`.

## DLP — still blocked (5)

| Command | Tracker | Status |
|---|---|---|
| `runtime dlp profiles replace` | #101 | ⏸️ now 500 (was 400) |
| `runtime dlp profiles patch` | #101 | ⏸️ now 500 (was 400) |
| `runtime dlp dictionaries create` | #99 | ⏸️ unchanged 400 |
| `runtime dlp dictionaries replace` | #99 | ⏸️ unchanged 400 |
| `runtime dlp dictionaries patch` | #99 | ⏸️ unchanged 400 |

## Runtime — still blocked (6)

| Command | Tracker | Status |
|---|---|---|
| `runtime api-keys delete` | SDK #166 | ⏸️ SDK string-body parse error |
| `runtime customer-apps get` | #115 | ⏸️ unchanged 403 |
| `runtime customer-apps update` | #193 | ⏸️ unchanged 503 |
| `runtime customer-apps delete` | SDK #167 | ⏸️ SDK string-body parse error |
| `runtime profiles delete` | SDK #164 | ⏸️ SDK string-body parse error |
| `runtime topics delete` | SDK #165 | ⏸️ SDK string-body parse error |

## Notes

- `patterns replace` / `patterns patch` needed snake_case nested body shape (`detection_config`, `matching_rules.regexes`) — different from OpenAPI / older examples. Documented in fixture.
- `profiles create` needs the SDK `DetectionRuleSchema` discriminated-union shape (`rule_type: "expression_tree"` with `expression_tree.rule_item`).
- All 4 SDK delete-validation issues (#164–#167) confirmed still open; commented retry notes on each.

## Test plan

- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm tsc --noEmit`
- [x] `pnpm test` (708 passing)
- [x] `pnpm docs:check` (123 commands, 24 on allowlist)
- [x] `pnpm docs:build` (clean)