### PR TITLE
fix(runtime): consumption command enumerates dashboard buckets, not customer-apps

### DIFF
--- a/.changeset/consumption-use-applications-overview.md
+++ b/.changeset/consumption-use-applications-overview.md
@@ -1,0 +1,21 @@
+---
+'@cdot65/prisma-airs-cli': patch
+---
+
+Fix `airs runtime customer-apps consumption` returning zero results when an integration overrides `metadata.app_name` in scan payloads (e.g. LiteLLM's `panw_prisma_airs` guardrail).
+
+The dashboard buckets traffic by the literal scan-payload `metadata.app_name`, not by the SCM-registered customer-app name. A single registered customer-app can therefore have multiple dashboard buckets, one per distinct name an integration has sent under its API key. The previous implementation enumerated from `customerApps.list` and silently dropped every bucket whose name didn't exactly match an SCM-registered app_name.
+
+Switch the consumption command to enumerate from `dashboard.applicationsOverview` (added in `@cdot65/prisma-airs-sdk` 0.12.0), which is the canonical apps-list source for the dashboard and is what the SCM AI Applications view itself uses. The dashboard's bucket `id` is the registered `customer_appId` UUID, and its `name` is the scan-payload value; both flow through directly to the per-app `dashboard.application` and `dashboard.applicationViolationBreakdown` calls.
+
+Concrete impact on a tenant we tested: 5 customer-apps entries -> 20 dashboard buckets surfaced. A single customer-app `5e16929a-...` had 8 distinct buckets (`chatbot`, `Claude Code`, `LiteLLM`, `Portkey`, `kong-airs-demo`, ...) all with real, distinct `token_stats`. The CLI was previously showing only the first and dropping seven.
+
+Changes:
+
+- `getCustomerAppConsumption(name)` now looks up `(appId, appName)` from `dashboard.applicationsOverview` instead of `customer_apps.list`. Single-app mode now accepts the names shown in the SCM AI Applications view (the literal scan-payload `app_name`), which previously failed when those differed from the SCM-registered name.
+- `runtime customer-apps consumption` (no args) enumerates from `applicationsOverview` and emits one record per dashboard bucket. Surfaces every bucket the dashboard tracks, not just one per customer-app.
+- New service method `listConsumptionApps(opts?)` exposes the dashboard's enumeration as `ConsumptionAppListEntry[]`.
+- Improved "not found" error: lists the first 5 available names + total count + explanation of the scan-payload-vs-SCM-name distinction.
+- 5 new unit tests + 4 updated tests cover the new lookup path and the multiple-buckets-per-customer-app data model.
+
+Closes #240. Requires `@cdot65/prisma-airs-sdk` 0.12.0 (cdot65/prisma-airs-sdk#177).

--- a/docs/cli/examples/runtime.yaml
+++ b/docs/cli/examples/runtime.yaml
@@ -1786,20 +1786,20 @@
         total: 1
     - note: Alternate time window — `--time-interval` accepts 7, 30, or 60 days (server-enforced enum).
       input: airs runtime customer-apps consumption example-app --time-interval 60
-    - note: All-apps loop — omit `appName` to scan every customer app in the tenant. Errors on individual apps are reported per-app; the loop continues past failures. Zero-traffic apps render `no detector violations in window`.
+    - note: All-apps loop — omit `appName` to enumerate every dashboard application bucket (one per distinct scan-payload `app_name`, so a single registered customer-app can appear as several buckets). Errors on individual apps are reported per-app; the loop continues past failures. Zero-traffic apps render `no detector violations in window`.
       input: airs runtime customer-apps consumption
     - note: Invalid time-interval rejected client-side before incurring an API call.
       input: airs runtime customer-apps consumption example-app --time-interval 14
       output: |
           Error: --time-interval must be 7, 30, or 60 (the API rejects other values)
-    - note: Unknown app name returns a helpful error pointing at `customer-apps list`.
+    - note: Unknown name lists the available dashboard application names and explains that the name to use is the literal scan-payload `metadata.app_name` (which may differ from the SCM-registered customer-app name).
       input: airs runtime customer-apps consumption no-such-app
       output: |
           Prisma AIRS — Runtime Configuration
           Security profile and topic management
 
 
-          Error: Customer app not found: "no-such-app". Run `airs runtime customer-apps list` to see available apps.
+          Error: Dashboard application not found: "no-such-app". Available (as shown in SCM AI Applications view): example-app, Claude Code, LiteLLM, Portkey, chatbot. Note: the name to use is the literal value your integration sends in scan metadata.app_name (which may differ from the SCM application name).
 
 "runtime api-keys create":
   examples:

--- a/docs/cli/runtime/customer-apps.md
+++ b/docs/cli/runtime/customer-apps.md
@@ -283,7 +283,7 @@ total: 1
 airs runtime customer-apps consumption example-app --time-interval 60
 ```
 
-*All-apps loop — omit `appName` to scan every customer app in the tenant. Errors on individual apps are reported per-app; the loop continues past failures. Zero-traffic apps render `no detector violations in window`.*
+*All-apps loop — omit `appName` to enumerate every dashboard application bucket (one per distinct scan-payload `app_name`, so a single registered customer-app can appear as several buckets). Errors on individual apps are reported per-app; the loop continues past failures. Zero-traffic apps render `no detector violations in window`.*
 
 ```bash
 airs runtime customer-apps consumption
@@ -299,7 +299,7 @@ airs runtime customer-apps consumption example-app --time-interval 14
 Error: --time-interval must be 7, 30, or 60 (the API rejects other values)
 ```
 
-*Unknown app name returns a helpful error pointing at `customer-apps list`.*
+*Unknown name lists the available dashboard application names and explains that the name to use is the literal scan-payload `metadata.app_name` (which may differ from the SCM-registered customer-app name).*
 
 ```bash
 airs runtime customer-apps consumption no-such-app
@@ -310,5 +310,5 @@ Prisma AIRS — Runtime Configuration
 Security profile and topic management
 
 
-Error: Customer app not found: "no-such-app". Run `airs runtime customer-apps list` to see available apps.
+Error: Dashboard application not found: "no-such-app". Available (as shown in SCM AI Applications view): example-app, Claude Code, LiteLLM, Portkey, chatbot. Note: the name to use is the literal value your integration sends in scan metadata.app_name (which may differ from the SCM application name).
 ```

--- a/docs/cli/runtime/customer-apps.md
+++ b/docs/cli/runtime/customer-apps.md
@@ -152,7 +152,7 @@ airs runtime customer-apps consumption [options] [appName]
 
 #### Arguments
 
-- `appName` (optional) —
+- `appName` (optional) — Dashboard application name — the literal scan-payload metadata.app_name, as shown in the SCM AI Applications view (may differ from the SCM-registered customer-app name). Omit to report every dashboard bucket.
 
 #### Options
 

--- a/docs/developers/api/classes/SdkManagementService.md
+++ b/docs/developers/api/classes/SdkManagementService.md
@@ -1,6 +1,6 @@
 # Class: SdkManagementService
 
-Defined in: [src/airs/management.ts:30](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L30)
+Defined in: [src/airs/management.ts:31](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L31)
 
 Wraps the SDK's ManagementClient to implement our ManagementService interface.
 OAuth2 token management, caching, and retry are handled by the SDK.
@@ -15,7 +15,7 @@ OAuth2 token management, caching, and retry are handled by the SDK.
 
 > **new SdkManagementService**(`opts?`): `SdkManagementService`
 
-Defined in: [src/airs/management.ts:33](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L33)
+Defined in: [src/airs/management.ts:34](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L34)
 
 #### Parameters
 
@@ -33,7 +33,7 @@ Defined in: [src/airs/management.ts:33](https://github.com/cdot65/prisma-airs-cl
 
 > **assignTopicsToProfile**(`profileName`, `topics`, `guardrailAction?`): `Promise`\<`void`\>
 
-Defined in: [src/airs/management.ts:95](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L95)
+Defined in: [src/airs/management.ts:96](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L96)
 
 Sets one or more custom topics on a profile's topic-guardrails config.
 Replaces any existing topics — previous runs' stale topics are cleared.
@@ -71,7 +71,7 @@ it defaults to revision 0 (original content), not the latest.
 
 > **assignTopicToProfile**(`profileName`, `topicId`, `topicName`, `action`): `Promise`\<`void`\>
 
-Defined in: [src/airs/management.ts:77](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L77)
+Defined in: [src/airs/management.ts:78](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L78)
 
 Sets a single custom topic on a profile's topic-guardrails config.
 Delegates to [assignTopicsToProfile](#assigntopicstoprofile) for backward compatibility.
@@ -108,7 +108,7 @@ Delegates to [assignTopicsToProfile](#assigntopicstoprofile) for backward compat
 
 > **createApiKey**(`request`): `Promise`\<`ApiKeyInfo`\>
 
-Defined in: [src/airs/management.ts:315](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L315)
+Defined in: [src/airs/management.ts:316](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L316)
 
 #### Parameters
 
@@ -130,7 +130,7 @@ Defined in: [src/airs/management.ts:315](https://github.com/cdot65/prisma-airs-c
 
 > **createProfile**(`request`): `Promise`\<`SecurityProfileInfo`\>
 
-Defined in: [src/airs/management.ts:267](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L267)
+Defined in: [src/airs/management.ts:268](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L268)
 
 Create a security profile.
 
@@ -154,7 +154,7 @@ Create a security profile.
 
 > **createTopic**(`request`): `Promise`\<`objectOutputType`\<\{ `active`: `ZodOptional`\<`ZodBoolean`\>; `created_by`: `ZodOptional`\<`ZodString`\>; `created_ts`: `ZodOptional`\<`ZodString`\>; `description`: `ZodString`; `examples`: `ZodArray`\<`ZodString`, `"many"`\>; `last_modified_ts`: `ZodOptional`\<`ZodString`\>; `revision`: `ZodNumber`; `topic_id`: `ZodOptional`\<`ZodString`\>; `topic_name`: `ZodString`; `updated_by`: `ZodOptional`\<`ZodString`\>; \}, `ZodTypeAny`, `"passthrough"`\>\>
 
-Defined in: [src/airs/management.ts:37](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L37)
+Defined in: [src/airs/management.ts:38](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L38)
 
 Create a new custom topic.
 
@@ -178,7 +178,7 @@ Create a new custom topic.
 
 > **deleteApiKey**(`apiKeyName`, `updatedBy`): `Promise`\<`DeleteResponse`\>
 
-Defined in: [src/airs/management.ts:325](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L325)
+Defined in: [src/airs/management.ts:326](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L326)
 
 #### Parameters
 
@@ -204,7 +204,7 @@ Defined in: [src/airs/management.ts:325](https://github.com/cdot65/prisma-airs-c
 
 > **deleteCustomerApp**(`appName`, `updatedBy`): `Promise`\<`CustomerAppInfo`\>
 
-Defined in: [src/airs/management.ts:366](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L366)
+Defined in: [src/airs/management.ts:367](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L367)
 
 #### Parameters
 
@@ -230,7 +230,7 @@ Defined in: [src/airs/management.ts:366](https://github.com/cdot65/prisma-airs-c
 
 > **deleteProfile**(`profileId`): `Promise`\<`DeleteResponse`\>
 
-Defined in: [src/airs/management.ts:280](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L280)
+Defined in: [src/airs/management.ts:281](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L281)
 
 Delete a security profile.
 
@@ -254,7 +254,7 @@ Delete a security profile.
 
 > **deleteTopic**(`topicId`): `Promise`\<`void`\>
 
-Defined in: [src/airs/management.ts:45](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L45)
+Defined in: [src/airs/management.ts:46](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L46)
 
 Delete a custom topic by ID.
 
@@ -278,7 +278,7 @@ Delete a custom topic by ID.
 
 > **forceDeleteProfile**(`profileId`, `updatedBy`): `Promise`\<`DeleteResponse`\>
 
-Defined in: [src/airs/management.ts:285](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L285)
+Defined in: [src/airs/management.ts:286](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L286)
 
 Force-delete a security profile (removes from referencing policies).
 
@@ -306,7 +306,7 @@ Force-delete a security profile (removes from referencing policies).
 
 > **forceDeleteTopic**(`topicId`, `updatedBy?`): `Promise`\<`DeleteResponse`\>
 
-Defined in: [src/airs/management.ts:49](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L49)
+Defined in: [src/airs/management.ts:50](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L50)
 
 Force-delete a custom topic (removes from all referencing profiles).
 
@@ -334,7 +334,7 @@ Force-delete a custom topic (removes from all referencing profiles).
 
 > **getCustomerApp**(`appName`): `Promise`\<`CustomerAppInfo`\>
 
-Defined in: [src/airs/management.ts:353](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L353)
+Defined in: [src/airs/management.ts:354](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L354)
 
 #### Parameters
 
@@ -356,7 +356,7 @@ Defined in: [src/airs/management.ts:353](https://github.com/cdot65/prisma-airs-c
 
 > **getCustomerAppConsumption**(`appName`, `opts?`): `Promise`\<`CustomerAppConsumption`\>
 
-Defined in: [src/airs/management.ts:371](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L371)
+Defined in: [src/airs/management.ts:397](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L397)
 
 Get per-app token consumption + violation breakdown from the SCM dashboard endpoints.
 
@@ -384,7 +384,7 @@ Get per-app token consumption + violation breakdown from the SCM dashboard endpo
 
 > **getProfile**(`profileId`): `Promise`\<`SecurityProfileInfo`\>
 
-Defined in: [src/airs/management.ts:247](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L247)
+Defined in: [src/airs/management.ts:248](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L248)
 
 Get a single security profile by UUID.
 
@@ -408,7 +408,7 @@ Get a single security profile by UUID.
 
 > **getProfileByName**(`profileName`): `Promise`\<`SecurityProfileInfo`\>
 
-Defined in: [src/airs/management.ts:252](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L252)
+Defined in: [src/airs/management.ts:253](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L253)
 
 Get a single security profile by name (returns highest revision).
 
@@ -432,7 +432,7 @@ Get a single security profile by name (returns highest revision).
 
 > **getProfileTopics**(`profileName`): `Promise`\<[`ProfileTopic`](../interfaces/ProfileTopic.md)[]\>
 
-Defined in: [src/airs/management.ts:175](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L175)
+Defined in: [src/airs/management.ts:176](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L176)
 
 List all topics configured in a profile with full details.
 
@@ -456,7 +456,7 @@ List all topics configured in a profile with full details.
 
 > **getTopic**(`topicId`): `Promise`\<`objectOutputType`\<\{ `active`: `ZodOptional`\<`ZodBoolean`\>; `created_by`: `ZodOptional`\<`ZodString`\>; `created_ts`: `ZodOptional`\<`ZodString`\>; `description`: `ZodString`; `examples`: `ZodArray`\<`ZodString`, `"many"`\>; `last_modified_ts`: `ZodOptional`\<`ZodString`\>; `revision`: `ZodNumber`; `topic_id`: `ZodOptional`\<`ZodString`\>; `topic_name`: `ZodString`; `updated_by`: `ZodOptional`\<`ZodString`\>; \}, `ZodTypeAny`, `"passthrough"`\>\>
 
-Defined in: [src/airs/management.ts:59](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L59)
+Defined in: [src/airs/management.ts:60](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L60)
 
 Get a single custom topic by ID.
 
@@ -480,7 +480,7 @@ Get a single custom topic by ID.
 
 > **getTopicByName**(`topicName`): `Promise`\<`objectOutputType`\<\{ `active`: `ZodOptional`\<`ZodBoolean`\>; `created_by`: `ZodOptional`\<`ZodString`\>; `created_ts`: `ZodOptional`\<`ZodString`\>; `description`: `ZodString`; `examples`: `ZodArray`\<`ZodString`, `"many"`\>; `last_modified_ts`: `ZodOptional`\<`ZodString`\>; `revision`: `ZodNumber`; `topic_id`: `ZodOptional`\<`ZodString`\>; `topic_name`: `ZodString`; `updated_by`: `ZodOptional`\<`ZodString`\>; \}, `ZodTypeAny`, `"passthrough"`\>\>
 
-Defined in: [src/airs/management.ts:66](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L66)
+Defined in: [src/airs/management.ts:67](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L67)
 
 Get a single custom topic by name.
 
@@ -504,7 +504,7 @@ Get a single custom topic by name.
 
 > **listApiKeys**(`opts?`): `Promise`\<`ApiKeyListResult`\>
 
-Defined in: [src/airs/management.ts:305](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L305)
+Defined in: [src/airs/management.ts:306](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L306)
 
 #### Parameters
 
@@ -522,11 +522,46 @@ Defined in: [src/airs/management.ts:305](https://github.com/cdot65/prisma-airs-c
 
 ***
 
+### listConsumptionApps()
+
+> **listConsumptionApps**(`opts?`): `Promise`\<`ConsumptionAppListEntry`[]\>
+
+Defined in: [src/airs/management.ts:372](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L372)
+
+List dashboard application buckets - the canonical apps source for consumption reporting.
+
+Drawn from `dashboard.applicationsOverview`. One entry per dashboard bucket, which is one
+per distinct scan-payload `metadata.app_name` per registered customer-app. Distinct from
+ManagementService.listCustomerApps, which enumerates registered customer-apps
+(different granularity).
+
+#### Parameters
+
+##### opts?
+
+###### limit?
+
+`number`
+
+###### offset?
+
+`number`
+
+#### Returns
+
+`Promise`\<`ConsumptionAppListEntry`[]\>
+
+#### Implementation of
+
+`ManagementService.listConsumptionApps`
+
+***
+
 ### listCustomerApps()
 
 > **listCustomerApps**(`opts?`): `Promise`\<`CustomerAppListResult`\>
 
-Defined in: [src/airs/management.ts:343](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L343)
+Defined in: [src/airs/management.ts:344](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L344)
 
 #### Parameters
 
@@ -548,7 +583,7 @@ Defined in: [src/airs/management.ts:343](https://github.com/cdot65/prisma-airs-c
 
 > **listDeploymentProfiles**(`opts?`): `Promise`\<`DeploymentProfileInfo`[]\>
 
-Defined in: [src/airs/management.ts:438](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L438)
+Defined in: [src/airs/management.ts:471](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L471)
 
 #### Parameters
 
@@ -572,7 +607,7 @@ Defined in: [src/airs/management.ts:438](https://github.com/cdot65/prisma-airs-c
 
 > **listProfiles**(`opts?`): `Promise`\<`SecurityProfileListResult`\>
 
-Defined in: [src/airs/management.ts:257](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L257)
+Defined in: [src/airs/management.ts:258](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L258)
 
 List security profiles.
 
@@ -596,7 +631,7 @@ List security profiles.
 
 > **listTopics**(): `Promise`\<`objectOutputType`\<\{ `active`: `ZodOptional`\<`ZodBoolean`\>; `created_by`: `ZodOptional`\<`ZodString`\>; `created_ts`: `ZodOptional`\<`ZodString`\>; `description`: `ZodString`; `examples`: `ZodArray`\<`ZodString`, `"many"`\>; `last_modified_ts`: `ZodOptional`\<`ZodString`\>; `revision`: `ZodNumber`; `topic_id`: `ZodOptional`\<`ZodString`\>; `topic_name`: `ZodString`; `updated_by`: `ZodOptional`\<`ZodString`\>; \}, `ZodTypeAny`, `"passthrough"`\>[]\>
 
-Defined in: [src/airs/management.ts:54](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L54)
+Defined in: [src/airs/management.ts:55](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L55)
 
 List all custom topics.
 
@@ -614,7 +649,7 @@ List all custom topics.
 
 > **queryScanLogs**(`opts`): `Promise`\<`ScanLogQueryResult`\>
 
-Defined in: [src/airs/management.ts:449](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L449)
+Defined in: [src/airs/management.ts:482](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L482)
 
 #### Parameters
 
@@ -636,7 +671,7 @@ Defined in: [src/airs/management.ts:449](https://github.com/cdot65/prisma-airs-c
 
 > **regenerateApiKey**(`apiKeyId`, `request`): `Promise`\<`ApiKeyInfo`\>
 
-Defined in: [src/airs/management.ts:320](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L320)
+Defined in: [src/airs/management.ts:321](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L321)
 
 #### Parameters
 
@@ -662,7 +697,7 @@ Defined in: [src/airs/management.ts:320](https://github.com/cdot65/prisma-airs-c
 
 > **updateCustomerApp**(`appId`, `request`): `Promise`\<`CustomerAppInfo`\>
 
-Defined in: [src/airs/management.ts:358](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L358)
+Defined in: [src/airs/management.ts:359](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L359)
 
 #### Parameters
 
@@ -688,7 +723,7 @@ Defined in: [src/airs/management.ts:358](https://github.com/cdot65/prisma-airs-c
 
 > **updateProfile**(`profileId`, `request`): `Promise`\<`SecurityProfileInfo`\>
 
-Defined in: [src/airs/management.ts:272](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L272)
+Defined in: [src/airs/management.ts:273](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L273)
 
 Update a security profile.
 
@@ -716,7 +751,7 @@ Update a security profile.
 
 > **updateTopic**(`topicId`, `request`): `Promise`\<`objectOutputType`\<\{ `active`: `ZodOptional`\<`ZodBoolean`\>; `created_by`: `ZodOptional`\<`ZodString`\>; `created_ts`: `ZodOptional`\<`ZodString`\>; `description`: `ZodString`; `examples`: `ZodArray`\<`ZodString`, `"many"`\>; `last_modified_ts`: `ZodOptional`\<`ZodString`\>; `revision`: `ZodNumber`; `topic_id`: `ZodOptional`\<`ZodString`\>; `topic_name`: `ZodString`; `updated_by`: `ZodOptional`\<`ZodString`\>; \}, `ZodTypeAny`, `"passthrough"`\>\>
 
-Defined in: [src/airs/management.ts:41](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L41)
+Defined in: [src/airs/management.ts:42](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/management.ts#L42)
 
 Update an existing custom topic by ID.
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/vertex-sdk": "^0.14.4",
-    "@cdot65/prisma-airs-sdk": "^0.11.0",
+    "@cdot65/prisma-airs-sdk": "^0.12.0",
     "@inquirer/prompts": "^8.3.0",
     "@langchain/anthropic": "^1.3.25",
     "@langchain/aws": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.14.4
         version: 0.14.4(zod@3.25.76)
       '@cdot65/prisma-airs-sdk':
-        specifier: ^0.11.0
-        version: 0.11.0
+        specifier: ^0.12.0
+        version: 0.12.0
       '@inquirer/prompts':
         specifier: ^8.3.0
         version: 8.3.0(@types/node@22.19.13)
@@ -334,8 +334,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cdot65/prisma-airs-sdk@0.11.0':
-    resolution: {integrity: sha512-rZ5vIfTQaFRfu4ypsiHMNr0btQRMJY57SRu84vy1lXYHd9DByqstLHnNGl25CpuVnMviUHWZ/EYIedxMkySA7w==}
+  '@cdot65/prisma-airs-sdk@0.12.0':
+    resolution: {integrity: sha512-l2WuhZy3Lh23cEGc/pen57jhXjFw4ErHQAVZbtHcE7HHC4awL2HM6T06d7tJh9U+nd8qmp9CCR85ROsyXD6emg==}
     engines: {node: '>=18'}
 
   '@cfworker/json-schema@4.1.1':
@@ -3069,7 +3069,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.5':
     optional: true
 
-  '@cdot65/prisma-airs-sdk@0.11.0':
+  '@cdot65/prisma-airs-sdk@0.12.0':
     dependencies:
       zod: 3.25.76
 

--- a/src/airs/management.ts
+++ b/src/airs/management.ts
@@ -9,6 +9,7 @@ import type { ProfileTopic } from '../audit/types.js';
 import type {
   ApiKeyInfo,
   ApiKeyListResult,
+  ConsumptionAppListEntry,
   ConsumptionQueryOptions,
   CustomerAppConsumption,
   CustomerAppInfo,
@@ -368,22 +369,54 @@ export class SdkManagementService implements ManagementService {
     return this.normalizeCustomerApp(response as unknown as Record<string, unknown>);
   }
 
+  async listConsumptionApps(opts?: {
+    limit?: number;
+    offset?: number;
+  }): Promise<ConsumptionAppListEntry[]> {
+    // dashboard.applicationsOverview is the canonical apps-list source. customerApps.list
+    // returns registered customer-apps (one per customer_appId), but the dashboard tracks
+    // one bucket per distinct scan-payload metadata.app_name. Using applicationsOverview
+    // surfaces every bucket - which is what the SCM UI's AI Applications view shows.
+    const response = await this.client.dashboard.applicationsOverview({
+      limit: opts?.limit ?? 100,
+      offset: opts?.offset ?? 0,
+    });
+    return (response.items ?? [])
+      .filter(
+        (item): item is typeof item & { id: string; name: string } =>
+          typeof item.id === 'string' && typeof item.name === 'string',
+      )
+      .map((item) => ({
+        appId: item.id,
+        appName: item.name,
+        cloud: item.cloud ?? undefined,
+        source: item.source ?? undefined,
+      }));
+  }
+
   async getCustomerAppConsumption(
     appName: string,
     opts?: ConsumptionQueryOptions,
   ): Promise<CustomerAppConsumption> {
     // The dashboard endpoints need BOTH appId and appName; the only way to resolve appId
-    // from a name is via the list endpoint, so do that first.
-    const list = (await this.client.customerApps.list({
-      offset: 0,
-      limit: 100,
-    })) as unknown as { customer_apps?: Array<Record<string, unknown>> };
-    const apps = list.customer_apps ?? [];
-    const target = apps.find((a) => (a.app_name as string) === appName);
-    const appId = target?.customer_appId as string | undefined;
+    // from a name is via the apps-overview list, so do that first. We enumerate
+    // applicationsOverview rather than customerApps.list because the dashboard buckets by
+    // scan-payload metadata.app_name (not by SCM-registered app_name), so the customer-apps
+    // name may not match any dashboard bucket.
+    const dashboardApps = await this.listConsumptionApps({ limit: 100 });
+    const target = dashboardApps.find((a) => a.appName === appName);
+    const appId = target?.appId;
     if (!appId) {
+      const sample = dashboardApps
+        .slice(0, 5)
+        .map((a) => `"${a.appName}"`)
+        .join(', ');
+      const more = dashboardApps.length > 5 ? `, ... (${dashboardApps.length} total)` : '';
       throw new Error(
-        `Customer app not found: "${appName}". Run \`airs runtime customer-apps list\` to see available apps.`,
+        `Dashboard application not found: "${appName}". ` +
+          `Available (as shown in SCM AI Applications view): ${sample}${more}. ` +
+          `Note: the name to use is the literal value your integration sends in scan ` +
+          `metadata.app_name (which may differ from the SCM application name).`,
       );
     }
 

--- a/src/airs/types.ts
+++ b/src/airs/types.ts
@@ -897,6 +897,25 @@ export interface ConsumptionQueryOptions {
   timeInterval?: ConsumptionTimeInterval;
 }
 
+/**
+ * One entry from the dashboard's apps-overview enumeration.
+ *
+ * One per dashboard bucket. A single registered customer-app can produce multiple buckets when
+ * scan payloads sent under its API key carry different `metadata.app_name` values - the
+ * dashboard tracks each as its own bucket. The `id` field is the registered `customer_appId`
+ * UUID; the `name` field is the literal scan-payload value.
+ */
+export interface ConsumptionAppListEntry {
+  /** Registered customer_appId UUID. */
+  appId: string;
+  /** Dashboard bucket name (literal scan-payload `metadata.app_name`). */
+  appName: string;
+  /** Cloud provider tag, if reported by the dashboard. */
+  cloud?: string;
+  /** Origin of the bucket, e.g. 'api'. */
+  source?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Deployment profile types
 // ---------------------------------------------------------------------------
@@ -997,6 +1016,18 @@ export interface ManagementService {
     appName: string,
     opts?: ConsumptionQueryOptions,
   ): Promise<CustomerAppConsumption>;
+  /**
+   * List dashboard application buckets - the canonical apps source for consumption reporting.
+   *
+   * Drawn from `dashboard.applicationsOverview`. One entry per dashboard bucket, which is one
+   * per distinct scan-payload `metadata.app_name` per registered customer-app. Distinct from
+   * {@link ManagementService.listCustomerApps}, which enumerates registered customer-apps
+   * (different granularity).
+   */
+  listConsumptionApps(opts?: {
+    limit?: number;
+    offset?: number;
+  }): Promise<ConsumptionAppListEntry[]>;
 
   // Deployment profiles
   listDeploymentProfiles(opts?: { unactivated?: boolean }): Promise<DeploymentProfileInfo[]>;

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -343,20 +343,24 @@ export function registerRuntimeCommand(program: Command): void {
           return;
         }
 
-        // All-apps mode: loop the list and emit one record per app.
-        const list = await service.listCustomerApps({ limit: 100 });
-        if (list.apps.length === 0) {
-          console.log('  No customer apps found.');
+        // All-apps mode: enumerate dashboard buckets from applicationsOverview and emit one
+        // record per bucket. We use the dashboard-side list (not customerApps.list) because
+        // the dashboard buckets by scan-payload metadata.app_name, so a single customer-app
+        // can have multiple buckets - one per distinct name an integration has sent. The
+        // SCM UI's AI Applications view reflects this same list.
+        const apps = await service.listConsumptionApps({ limit: 100 });
+        if (apps.length === 0) {
+          console.log('  No dashboard applications found.');
           return;
         }
-        for (const app of list.apps) {
+        for (const app of apps) {
           try {
-            const data = await service.getCustomerAppConsumption(app.name, {
+            const data = await service.getCustomerAppConsumption(app.appName, {
               timeInterval: interval,
             });
             renderCustomerAppConsumption(data, fmt);
           } catch (err) {
-            renderError(`[${app.name}] ${err instanceof Error ? err.message : String(err)}`);
+            renderError(`[${app.appName}] ${err instanceof Error ? err.message : String(err)}`);
           }
         }
       } catch (err) {

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -316,7 +316,11 @@ export function registerRuntimeCommand(program: Command): void {
     });
 
   customerApps
-    .command('consumption [appName]')
+    .command('consumption')
+    .argument(
+      '[appName]',
+      'Dashboard application name — the literal scan-payload metadata.app_name, as shown in the SCM AI Applications view (may differ from the SCM-registered customer-app name). Omit to report every dashboard bucket.',
+    )
     .description(
       'Show per-app token consumption + violation breakdown (SCM dashboard). Omit appName to scan all apps.',
     )

--- a/tests/unit/airs/management.spec.ts
+++ b/tests/unit/airs/management.spec.ts
@@ -49,6 +49,7 @@ const mockDeploymentProfilesList = vi.fn();
 const mockScanLogsQuery = vi.fn();
 const mockDashboardApplication = vi.fn();
 const mockDashboardViolationBreakdown = vi.fn();
+const mockDashboardApplicationsOverview = vi.fn();
 
 vi.mock('@cdot65/prisma-airs-sdk', () => ({
   ManagementClient: vi.fn().mockImplementation(() => ({
@@ -89,6 +90,7 @@ vi.mock('@cdot65/prisma-airs-sdk', () => ({
     dashboard: {
       application: mockDashboardApplication,
       applicationViolationBreakdown: mockDashboardViolationBreakdown,
+      applicationsOverview: mockDashboardApplicationsOverview,
     },
   })),
 }));
@@ -1188,16 +1190,20 @@ describe('SdkManagementService', () => {
 
   describe('getCustomerAppConsumption', () => {
     function primeApps() {
-      mockCustomerAppsList.mockResolvedValue({
-        customer_apps: [
-          { customer_appId: 'uuid-chatbot', app_name: 'chatbot' },
-          { customer_appId: 'uuid-litellm', app_name: 'litellm' },
+      // The CLI enumerates dashboard buckets via applicationsOverview, not customer_apps.
+      // The dashboard's `id` IS the customer_appId UUID; `name` is the scan-payload value.
+      // Same id can appear with multiple names - one bucket per distinct scan-payload name.
+      mockDashboardApplicationsOverview.mockResolvedValue({
+        items: [
+          { id: 'uuid-shared', name: 'chatbot', cloud: 'other', source: 'api' },
+          { id: 'uuid-shared', name: 'LiteLLM', cloud: 'other', source: 'api' },
+          { id: 'uuid-litellm', name: 'litellm', cloud: 'other', source: 'api' },
         ],
-        next_offset: 0,
+        pagination: { limit: 100, skip: 0, total_items: 3 },
       });
     }
 
-    it('resolves appId from list, calls both dashboard endpoints, normalizes the result', async () => {
+    it('resolves appId from applicationsOverview, calls both dashboard endpoints, normalizes the result', async () => {
       primeApps();
       mockDashboardApplication.mockResolvedValue({
         id: 'uuid-chatbot',
@@ -1230,7 +1236,7 @@ describe('SdkManagementService', () => {
 
       const result = await service.getCustomerAppConsumption('chatbot');
 
-      expect(result.appId).toBe('uuid-chatbot');
+      expect(result.appId).toBe('uuid-shared');
       expect(result.appName).toBe('chatbot');
       expect(result.tokens.dailyAverage).toBe(744.233);
       expect(result.tokens.dailyAverageScale).toBe('K');
@@ -1251,12 +1257,12 @@ describe('SdkManagementService', () => {
       });
 
       expect(mockDashboardApplication).toHaveBeenCalledWith({
-        appId: 'uuid-chatbot',
+        appId: 'uuid-shared',
         appName: 'chatbot',
         timeInterval: 30,
       });
       expect(mockDashboardViolationBreakdown).toHaveBeenCalledWith({
-        appId: 'uuid-chatbot',
+        appId: 'uuid-shared',
         appName: 'chatbot',
         timeInterval: 30,
       });
@@ -1276,13 +1282,31 @@ describe('SdkManagementService', () => {
       });
     });
 
-    it('throws a clear error when the app name is not found in the list', async () => {
-      mockCustomerAppsList.mockResolvedValue({ customer_apps: [], next_offset: 0 });
+    it('throws a clear error when the app name is not found in the dashboard list', async () => {
+      mockDashboardApplicationsOverview.mockResolvedValue({
+        items: [{ id: 'uuid-a', name: 'real-app', cloud: 'other', source: 'api' }],
+        pagination: { limit: 100, skip: 0, total_items: 1 },
+      });
       await expect(service.getCustomerAppConsumption('nonexistent')).rejects.toThrow(
-        /Customer app not found.*nonexistent/i,
+        /Dashboard application not found.*nonexistent/i,
       );
       expect(mockDashboardApplication).not.toHaveBeenCalled();
       expect(mockDashboardViolationBreakdown).not.toHaveBeenCalled();
+    });
+
+    it('resolves the correct bucket when the same appId has multiple scan-payload names', async () => {
+      primeApps();
+      mockDashboardApplication.mockResolvedValue({});
+      mockDashboardViolationBreakdown.mockResolvedValue({});
+
+      await service.getCustomerAppConsumption('LiteLLM');
+
+      // Same shared appId, but the second bucket name ('LiteLLM', different from 'chatbot').
+      expect(mockDashboardApplication).toHaveBeenCalledWith({
+        appId: 'uuid-shared',
+        appName: 'LiteLLM',
+        timeInterval: 30,
+      });
     });
 
     it('returns zeros for missing/null fields rather than throwing', async () => {
@@ -1302,6 +1326,65 @@ describe('SdkManagementService', () => {
       expect(result.profiles).toEqual([]);
       expect(result.detectors).toEqual([]);
       expect(result.totalViolating).toBe(0);
+    });
+  });
+
+  describe('listConsumptionApps', () => {
+    it('enumerates dashboard buckets and normalizes shape', async () => {
+      mockDashboardApplicationsOverview.mockResolvedValue({
+        items: [
+          { id: 'uuid-shared', name: 'chatbot', cloud: 'other', source: 'api' },
+          { id: 'uuid-shared', name: 'LiteLLM', cloud: 'other', source: 'api' },
+          { id: 'uuid-aws', name: 'aws-bedrock-demo', cloud: 'aws', source: 'api' },
+        ],
+        pagination: { limit: 100, skip: 0, total_items: 3 },
+      });
+
+      const result = await service.listConsumptionApps();
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual({
+        appId: 'uuid-shared',
+        appName: 'chatbot',
+        cloud: 'other',
+        source: 'api',
+      });
+      // Same appId, different appName - two distinct buckets is the whole point.
+      expect(result[0].appId).toBe(result[1].appId);
+      expect(result[0].appName).not.toBe(result[1].appName);
+      expect(mockDashboardApplicationsOverview).toHaveBeenCalledWith({ limit: 100, offset: 0 });
+    });
+
+    it('respects caller-supplied limit/offset', async () => {
+      mockDashboardApplicationsOverview.mockResolvedValue({
+        items: [],
+        pagination: { limit: 25, skip: 50, total_items: 0 },
+      });
+      await service.listConsumptionApps({ limit: 25, offset: 50 });
+      expect(mockDashboardApplicationsOverview).toHaveBeenCalledWith({ limit: 25, offset: 50 });
+    });
+
+    it('filters out items missing id or name (defensive)', async () => {
+      mockDashboardApplicationsOverview.mockResolvedValue({
+        items: [
+          { id: 'uuid-1', name: 'real-app' },
+          { id: null, name: 'no-id' },
+          { id: 'uuid-3', name: null },
+        ],
+        pagination: { limit: 100, skip: 0, total_items: 3 },
+      });
+      const result = await service.listConsumptionApps();
+      expect(result).toHaveLength(1);
+      expect(result[0].appName).toBe('real-app');
+    });
+
+    it('tolerates empty items', async () => {
+      mockDashboardApplicationsOverview.mockResolvedValue({
+        items: [],
+        pagination: { limit: 100, skip: 0, total_items: 0 },
+      });
+      const result = await service.listConsumptionApps();
+      expect(result).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fix `airs runtime customer-apps consumption` returning zero results (or silently dropping records) when a scan-payload `metadata.app_name` differs from the SCM-registered customer-app name. Closes #240.

This is the CLI half of the fix. Depends on cdot65/prisma-airs-sdk#177 (which adds the `dashboard.applicationsOverview` method this PR consumes). Keeping this PR in **Draft** until the SDK PR merges and publishes; the only remaining work after that is bumping `@cdot65/prisma-airs-sdk` to the published 0.12.x version (one-line follow-up commit).

## Why

The dashboard buckets traffic by the literal `metadata.app_name` value scan payloads send. A single registered customer-app can therefore have many dashboard buckets, one per distinct name an integration has actually used. LiteLLM's `panw_prisma_airs` guardrail overrides `app_name` by default; Portkey and Kong wrappers commonly do too.

The current `consumption` command enumerates from `customerApps.list` (registered customer-apps) and calls the dashboard with each registered app's `app_name`. Every dashboard bucket whose name doesn't match a registered app's `app_name` is silently dropped. The dashboard returns HTTP 200 with an all-null body on a mismatched `(appId, appName)` tuple, so there is no error to catch.

Live evidence from my own tenant on 2026-05-29 (full capture in the linked proof file in the issue):

- `customerApps.list` returned **5** entries.
- `dashboard.applicationsOverview` returned **19** entries for the same time window.
- CustomerApp `5e16929a-...` alone had **8** dashboard buckets (chatbot, Claude Code, LiteLLM, Portkey, kong-airs-demo, kong-kong-airs-demo, perfecxion-airs-demo, + one more) - all with real, distinct `token_stats`. The CLI was emitting one (`chatbot`) and dropping seven.

The colleague who originally reported this had the same shape: their integration sends `app_name: "LiteLLM"`, dashboard bucket `LiteLLM` has their actual traffic, their SCM-registered customer-app is named `airs-app-litellm`. The CLI's `customer-apps consumption airs-app-litellm` hit the dashboard with the wrong tuple and returned zeros.

## What changes

### `getCustomerAppConsumption(name)` now looks up `(appId, appName)` via `dashboard.applicationsOverview`

Previously: list registered customer-apps, find by `app_name`, call dashboard with `(customer_appId, app_name)`.
Now: list dashboard buckets, find by dashboard `name`, call dashboard with the same `(id, name)` the bucket carries.

Single-app mode now accepts the names shown in the SCM AI Applications view (the literal scan-payload value), which previously failed when those differed from the SCM-registered name.

### "All apps" mode enumerates dashboard buckets

`airs runtime customer-apps consumption` (no positional arg) now iterates `dashboard.applicationsOverview` and emits one record per bucket. Surfaces every bucket the dashboard tracks, not just one per registered customer-app.

### New service method `listConsumptionApps(opts?)`

Exposed on `ManagementService` so anything else that needs to enumerate dashboard buckets (future commands, scripting via the SDK package) has a single normalized entry point. Returns `ConsumptionAppListEntry[]` with `{ appId, appName, cloud?, source? }`.

### Improved "not found" error

```
Error: Dashboard application not found: "this-does-not-exist".
Available (as shown in SCM AI Applications view): "Claude Code", "LiteLLM",
"Portkey", "aws-bedrock-airs-runtime-demo", "aws-bedrock-redteam-demo",
... (19 total).
Note: the name to use is the literal value your integration sends in scan
metadata.app_name (which may differ from the SCM application name).
```

Lists the first 5 available names, total count, and explicitly calls out the scan-payload-vs-SCM-name distinction that drove the original confusion.

## Backward compatibility

Customer-apps-style names that previously worked still work. Names like `chatbot`, `litellm`, `chrism-key`, `unified` in my tenant are simultaneously SCM-registered customer-app names AND dashboard bucket names (because the integration sends them as-is). The fix preserves their behavior 1:1; it just stops dropping the additional buckets that exist alongside.

## Tests

- 5 new unit tests cover the new lookup path and the multiple-buckets-per-customer-app data model.
- 4 existing tests updated to mock `dashboard.applicationsOverview` instead of `customerApps.list`.
- Total: 736 tests pass (was 731 before this branch).

## Verification

Live-tested against my tenant 2026-05-29:

| | Before this fix | After this fix |
|---|---|---|
| All-apps mode bucket count | 5 | 19 |
| `consumption "LiteLLM"` | `Error: Customer app not found` | Real bucket data: 327 tokens / 21 sessions |
| `consumption "chatbot"` (backward-compat) | Works, shows 17.7M tokens | Works, shows 17.7M tokens (identical) |
| `consumption "this-does-not-exist"` | Flat error message | Lists available names + explains the distinction |

Build clean (`npm run build`), lint clean (`npm run lint` - 10 pre-existing warnings, 0 errors), 62 test files pass, 736/736 tests pass.

## Depends on

- cdot65/prisma-airs-sdk#177 - adds `mgmt.dashboard.applicationsOverview()`. Once that merges and the SDK publishes a 0.12.x, the `package.json` dep bump becomes a one-line follow-up commit and this PR flips to ready-for-review.

## Closes

- cdot65/prisma-airs-cli#240
