### PR TITLE
docs: issue-audit window 3 remediations

### DIFF
--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -34,10 +34,6 @@ redteam devices delete
 # (CLI calls version-info unconditionally after detail fetch, so all three formats fail until either
 # upstream is fixed or CLI gains graceful degradation — see sub-issue #164 retry 2026-05-28)
 redteam prompt-sets get
-# Blocked by SDK empty-body response validation — see https://github.com/cdot65/prisma-airs-sdk/issues/168
-redteam prompts delete
 # Blocked by SDK wrong-schema-on-write — POST property-names returns 201 with {data: string[]} but SDK
 # declares BaseResponseSchema — see sub-issue #172 retry 2026-05-28
 redteam properties create
-# Blocked by SDK empty-body response validation — see https://github.com/cdot65/prisma-airs-sdk/issues/168
-redteam targets delete

--- a/docs/cli/examples/redteam.yaml
+++ b/docs/cli/examples/redteam.yaml
@@ -843,4 +843,24 @@
             Set UUID:   00000000-0000-0000-0000-000000000002
             Status:     active
             Prompt:     Echo 'AIRS test prompt updated'
+
+"redteam prompts delete":
+  examples:
+    - note: Delete a prompt from a set by set UUID + prompt UUID
+      input: airs redteam prompts delete 00000000-0000-0000-0000-000000000002 00000000-0000-0000-0000-000000000003
+      output: |
+          Prisma AIRS — AI Red Team
+          Adversarial scan operations
+
+          Prompt 00000000-0000-0000-0000-000000000003 deleted.
+
+"redteam targets delete":
+  examples:
+    - note: Delete a target by UUID (SDK now returns a clean confirmation on the empty-body 204)
+      input: airs redteam targets delete 00000000-0000-0000-0000-000000000001
+      output: |
+          Prisma AIRS — AI Red Team
+          Adversarial scan operations
+
+          Target 00000000-0000-0000-0000-000000000001 deleted.
             Goal:       Functional test

--- a/docs/cli/redteam/prompts.md
+++ b/docs/cli/redteam/prompts.md
@@ -158,7 +158,6 @@ Prompt Detail:
   Set UUID:   00000000-0000-0000-0000-000000000002
   Status:     active
   Prompt:     Echo 'AIRS test prompt updated'
-  Goal:       Functional test
 ```
 
 ---
@@ -178,5 +177,15 @@ airs redteam prompts delete [options] <setUuid> <promptUuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Delete a prompt from a set by set UUID + prompt UUID*
+
+```bash
+airs redteam prompts delete 00000000-0000-0000-0000-000000000002 00000000-0000-0000-0000-000000000003
+```
+
+```text
+Prisma AIRS — AI Red Team
+Adversarial scan operations
+
+Prompt 00000000-0000-0000-0000-000000000003 deleted.
+```

--- a/docs/cli/redteam/targets.md
+++ b/docs/cli/redteam/targets.md
@@ -241,8 +241,19 @@ airs redteam targets delete [options] <uuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Delete a target by UUID (SDK now returns a clean confirmation on the empty-body 204)*
+
+```bash
+airs redteam targets delete 00000000-0000-0000-0000-000000000001
+```
+
+```text
+Prisma AIRS — AI Red Team
+Adversarial scan operations
+
+Target 00000000-0000-0000-0000-000000000001 deleted.
+  Goal:       Functional test
+```
 
 ---
 


### PR DESCRIPTION
## Window 3 (red-team domain) doc-issue audit remediations

Re-verified the 17 assigned red-team documentation issues live against the tenant on 2026-06-05.

### Key finding
The tenant license is **no longer read-only** — the `License has expired. Only read-only access is allowed.` error behind #111 / #118 / #123 (and several sub-issues) is resolved tenant-wide. Remaining blocks are upstream-API or SDK, not license.

### Resolved (closed + documented)
| Command | Issue | Note |
|---|---|---|
| `redteam prompts delete` | #171 | SDK empty-body validation (sdk#168) fixed — clean delete, verified removed |
| `redteam targets delete` | #177 | same SDK fix; captured via a throwaway target (real targets untouched) |
| `redteam properties values` | #173 | works live; representative example already shipped |
| `redteam properties add-value` | #174 | works live (write succeeds); example already shipped |

### Changes
- `docs/cli/examples/redteam.yaml`: added sanitized examples for `prompts delete` + `targets delete`.
- `docs/cli/examples/.missing-allowlist`: removed those two lines (allowlist 22 → 20).
- Regenerated `docs/cli/redteam/{prompts,targets}.md` via `pnpm docs:gen`.
- `pnpm docs:gen` + `pnpm docs:check` pass.

### Still blocked (left open, root cause re-classified)
- `properties create` (#172): **SDK** response-schema mismatch (was license) — POST `201 {data:string[]}` vs `BaseResponseSchema`.
- `prompt-sets get` (#164): upstream `/version-info` 500 (#117).
- instances/devices CRUD (#156–#162): upstream API 403 (#124).
- `abort` (#111): now fixture-blocked (no running scan).

### ⚠️ Out-of-domain flag
`pnpm docs:build` fails on a **pre-existing** TS error unrelated to these doc changes: `src/airs/management.ts:380` calls `this.client.dashboard.applicationsOverview(...)`, which no longer exists on `DashboardClient` (SDK drift). Flagged for the orchestrator / runtime domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
