### PR TITLE
fix(redteam): prompt-sets get degrades gracefully when version-info 500s

### DIFF
--- a/.changeset/fix-prompt-sets-get-graceful-version-info.md
+++ b/.changeset/fix-prompt-sets-get-graceful-version-info.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Fix `redteam prompt-sets get` aborting when the upstream `/version-info` endpoint returns 500. The set detail now renders regardless; Version Info degrades to an "unavailable" note (pretty) or is omitted (json/yaml) instead of failing the whole command.

--- a/docs/cli/examples/.missing-allowlist
+++ b/docs/cli/examples/.missing-allowlist
@@ -30,10 +30,6 @@ redteam instances delete
 redteam devices create
 redteam devices update
 redteam devices delete
-# Blocked by upstream API 500 on /version-info — see https://github.com/cdot65/prisma-airs-cli/issues/117
-# (CLI calls version-info unconditionally after detail fetch, so all three formats fail until either
-# upstream is fixed or CLI gains graceful degradation — see sub-issue #164 retry 2026-05-28)
-redteam prompt-sets get
 # Blocked by SDK wrong-schema-on-write — POST property-names returns 201 with {data: string[]} but SDK
 # declares BaseResponseSchema — see sub-issue #172 retry 2026-05-28
 redteam properties create

--- a/docs/cli/examples/redteam.yaml
+++ b/docs/cli/examples/redteam.yaml
@@ -54,6 +54,33 @@
         d68a14f5-cea3-4047-bedb-ae5726ba20d2
           Saffron  inactive
 
+"redteam prompt-sets get":
+  examples:
+    - note: |
+        Get a prompt set's details. The version-info section degrades gracefully — if the
+        upstream `/version-info` endpoint errors, the set detail still renders and Version
+        Info shows as unavailable rather than failing the whole command.
+      input: airs redteam prompt-sets get 00000000-0000-0000-0000-000000000002
+      output: |
+          Prisma AIRS — AI Red Team
+          Adversarial scan operations
+
+
+          Prompt Set Detail:
+
+            UUID:        00000000-0000-0000-0000-000000000002
+            Name:        redteam-demo-set
+            Status:      active
+            Archived:    no
+            Description: Red team prompt set with sample adversarial prompts
+            Created:     2026-06-05T13:46:08.274350Z
+            Updated:     2026-06-05T13:48:09.423595Z
+
+
+          Version Info:
+
+            unavailable (version-info endpoint returned an error)
+
 "redteam categories":
   examples:
     - note: |

--- a/docs/cli/redteam/prompt-sets.md
+++ b/docs/cli/redteam/prompt-sets.md
@@ -55,8 +55,35 @@ airs redteam prompt-sets get [options] <uuid>
 
 #### Examples
 
-!!! warning "Example needed"
-    No curated input/output example for this command yet.
+*Get a prompt set's details. The version-info section degrades gracefully — if the
+upstream `/version-info` endpoint errors, the set detail still renders and Version
+Info shows as unavailable rather than failing the whole command.
+*
+
+```bash
+airs redteam prompt-sets get 00000000-0000-0000-0000-000000000002
+```
+
+```text
+Prisma AIRS — AI Red Team
+Adversarial scan operations
+
+
+Prompt Set Detail:
+
+  UUID:        00000000-0000-0000-0000-000000000002
+  Name:        redteam-demo-set
+  Status:      active
+  Archived:    no
+  Description: Red team prompt set with sample adversarial prompts
+  Created:     2026-06-05T13:46:08.274350Z
+  Updated:     2026-06-05T13:48:09.423595Z
+
+
+Version Info:
+
+  unavailable (version-info endpoint returned an error)
+```
 
 ---
 

--- a/docs/developers/api/classes/SdkPromptSetService.md
+++ b/docs/developers/api/classes/SdkPromptSetService.md
@@ -121,7 +121,7 @@ Create a new custom prompt set.
 
 > **createPropertyName**(`name`): `Promise`\<[`MutationResponse`](../interfaces/MutationResponse.md)\>
 
-Defined in: [src/airs/promptsets.ts:153](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L153)
+Defined in: [src/airs/promptsets.ts:173](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L173)
 
 Create a property name.
 
@@ -145,7 +145,7 @@ Create a property name.
 
 > **createPropertyValue**(`name`, `value`): `Promise`\<[`MutationResponse`](../interfaces/MutationResponse.md)\>
 
-Defined in: [src/airs/promptsets.ts:164](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L164)
+Defined in: [src/airs/promptsets.ts:184](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L184)
 
 Create a property value.
 
@@ -173,7 +173,7 @@ Create a property value.
 
 > **deletePrompt**(`setUuid`, `promptUuid`): `Promise`\<`void`\>
 
-Defined in: [src/airs/promptsets.ts:143](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L143)
+Defined in: [src/airs/promptsets.ts:163](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L163)
 
 Delete a prompt.
 
@@ -201,7 +201,7 @@ Delete a prompt.
 
 > **downloadTemplate**(`uuid`): `Promise`\<`string`\>
 
-Defined in: [src/airs/promptsets.ts:106](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L106)
+Defined in: [src/airs/promptsets.ts:126](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L126)
 
 Download CSV template for a prompt set.
 
@@ -225,7 +225,7 @@ Download CSV template for a prompt set.
 
 > **getPrompt**(`setUuid`, `promptUuid`): `Promise`\<[`PromptDetail`](../interfaces/PromptDetail.md)\>
 
-Defined in: [src/airs/promptsets.ts:125](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L125)
+Defined in: [src/airs/promptsets.ts:145](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L145)
 
 Get a single prompt.
 
@@ -297,11 +297,35 @@ Get prompt set version info with stats.
 
 ***
 
+### getPromptSetWithVersionInfo()
+
+> **getPromptSetWithVersionInfo**(`uuid`): `Promise`\<\{ `set`: [`PromptSetDetail`](../interfaces/PromptSetDetail.md); `versionInfo?`: [`PromptSetVersionInfo`](../interfaces/PromptSetVersionInfo.md); \}\>
+
+Defined in: [src/airs/promptsets.ts:113](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L113)
+
+Fetch a prompt set and its version info in one call, degrading gracefully when the
+version-info endpoint is unavailable. The upstream `/version-info` route currently
+returns 500 for every prompt set (see prisma-airs-cli#117); without this, a 500 there
+would abort the whole `prompt-sets get` command even though the set itself fetched fine.
+The set is always returned; `versionInfo` is `undefined` when that lookup fails.
+
+#### Parameters
+
+##### uuid
+
+`string`
+
+#### Returns
+
+`Promise`\<\{ `set`: [`PromptSetDetail`](../interfaces/PromptSetDetail.md); `versionInfo?`: [`PromptSetVersionInfo`](../interfaces/PromptSetVersionInfo.md); \}\>
+
+***
+
 ### getPropertyNames()
 
 > **getPropertyNames**(): `Promise`\<`string`[]\>
 
-Defined in: [src/airs/promptsets.ts:147](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L147)
+Defined in: [src/airs/promptsets.ts:167](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L167)
 
 List property names.
 
@@ -319,7 +343,7 @@ List property names.
 
 > **getPropertyValues**(`name`): `Promise`\<[`PropertyValueList`](../interfaces/PropertyValueList.md)\>
 
-Defined in: [src/airs/promptsets.ts:158](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L158)
+Defined in: [src/airs/promptsets.ts:178](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L178)
 
 Get values for a property.
 
@@ -343,7 +367,7 @@ Get values for a property.
 
 > **listPrompts**(`setUuid`, `opts?`): `Promise`\<[`PromptDetail`](../interfaces/PromptDetail.md)[]\>
 
-Defined in: [src/airs/promptsets.ts:115](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L115)
+Defined in: [src/airs/promptsets.ts:135](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L135)
 
 List prompts in a prompt set.
 
@@ -395,7 +419,7 @@ List all custom prompt sets.
 
 > **updatePrompt**(`setUuid`, `promptUuid`, `request`): `Promise`\<[`PromptDetail`](../interfaces/PromptDetail.md)\>
 
-Defined in: [src/airs/promptsets.ts:130](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L130)
+Defined in: [src/airs/promptsets.ts:150](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L150)
 
 Update a prompt.
 
@@ -467,7 +491,7 @@ Update prompt set name/description.
 
 > **uploadPromptsCsv**(`uuid`, `file`): `Promise`\<\{ `message`: `string`; `status`: `number`; \}\>
 
-Defined in: [src/airs/promptsets.ts:110](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L110)
+Defined in: [src/airs/promptsets.ts:130](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/promptsets.ts#L130)
 
 Upload CSV file to a prompt set.
 

--- a/src/airs/promptsets.ts
+++ b/src/airs/promptsets.ts
@@ -103,6 +103,26 @@ export class SdkPromptSetService implements PromptSetService {
     };
   }
 
+  /**
+   * Fetch a prompt set and its version info in one call, degrading gracefully when the
+   * version-info endpoint is unavailable. The upstream `/version-info` route currently
+   * returns 500 for every prompt set (see prisma-airs-cli#117); without this, a 500 there
+   * would abort the whole `prompt-sets get` command even though the set itself fetched fine.
+   * The set is always returned; `versionInfo` is `undefined` when that lookup fails.
+   */
+  async getPromptSetWithVersionInfo(
+    uuid: string,
+  ): Promise<{ set: PromptSetDetail; versionInfo?: PromptSetVersionInfo }> {
+    const set = await this.getPromptSet(uuid);
+    let versionInfo: PromptSetVersionInfo | undefined;
+    try {
+      versionInfo = await this.getPromptSetVersionInfo(uuid);
+    } catch {
+      versionInfo = undefined;
+    }
+    return { set, versionInfo };
+  }
+
   async downloadTemplate(uuid: string): Promise<string> {
     return this.client.customAttacks.downloadTemplate(uuid);
   }

--- a/src/cli/commands/redteam.ts
+++ b/src/cli/commands/redteam.ts
@@ -40,6 +40,7 @@ import {
   renderTargetList,
   renderTargetTemplates,
   renderVersionInfo,
+  renderVersionInfoUnavailable,
 } from '../renderer/index.js';
 import { backupTargets } from './backup.js';
 import { restoreTargets } from './restore.js';
@@ -441,11 +442,11 @@ export function registerRedteamCommand(program: Command): void {
         const fmt = opts.output as OutputFormat;
         if (fmt === 'pretty') renderRedteamHeader();
         const service = await createPromptSetService();
-        const ps = await service.getPromptSet(uuid);
-        const info = await service.getPromptSetVersionInfo(uuid);
+        const { set: ps, versionInfo: info } = await service.getPromptSetWithVersionInfo(uuid);
         if (fmt === 'pretty') {
           renderPromptSetDetail(ps);
-          renderVersionInfo(info);
+          if (info) renderVersionInfo(info);
+          else renderVersionInfoUnavailable();
         } else {
           renderPromptSetDetail(ps, fmt, info);
         }

--- a/src/cli/renderer/redteam.ts
+++ b/src/cli/renderer/redteam.ts
@@ -524,6 +524,13 @@ export function renderVersionInfo(info: {
   console.log();
 }
 
+/** Render a placeholder when the version-info endpoint is unavailable (upstream 500). */
+export function renderVersionInfoUnavailable(): void {
+  console.log(chalk.bold('\n  Version Info:\n'));
+  console.log(chalk.dim('    unavailable (version-info endpoint returned an error)'));
+  console.log();
+}
+
 /** Render a list of prompts. */
 export function renderPromptList(
   prompts: Array<{

--- a/tests/unit/airs/promptsets.spec.ts
+++ b/tests/unit/airs/promptsets.spec.ts
@@ -258,6 +258,51 @@ describe('SdkPromptSetService', () => {
     });
   });
 
+  describe('getPromptSetWithVersionInfo', () => {
+    it('returns the set plus version info when both succeed', async () => {
+      mockGetPromptSet.mockResolvedValue({
+        uuid: 'ps-1',
+        name: 'set-a',
+        active: true,
+        archive: false,
+      });
+      mockGetPromptSetVersionInfo.mockResolvedValue({
+        uuid: 'ps-1',
+        version: 3,
+        stats: { total: 50, active: 45, inactive: 5 },
+      });
+
+      const result = await service.getPromptSetWithVersionInfo('ps-1');
+      expect(result.set.uuid).toBe('ps-1');
+      expect(result.versionInfo).toEqual({
+        uuid: 'ps-1',
+        version: 3,
+        stats: { total: 50, active: 45, inactive: 5 },
+      });
+    });
+
+    it('degrades gracefully when version-info fails (upstream 500) — set still returned, versionInfo undefined', async () => {
+      mockGetPromptSet.mockResolvedValue({
+        uuid: 'ps-1',
+        name: 'set-a',
+        active: true,
+        archive: false,
+      });
+      mockGetPromptSetVersionInfo.mockRejectedValue(
+        new Error('AISEC_CLIENT_SIDE_ERROR:API error 500'),
+      );
+
+      const result = await service.getPromptSetWithVersionInfo('ps-1');
+      expect(result.set.uuid).toBe('ps-1');
+      expect(result.versionInfo).toBeUndefined();
+    });
+
+    it('still propagates a failure of the primary getPromptSet call', async () => {
+      mockGetPromptSet.mockRejectedValue(new Error('not found'));
+      await expect(service.getPromptSetWithVersionInfo('ps-x')).rejects.toThrow('not found');
+    });
+  });
+
   describe('downloadTemplate', () => {
     it('delegates to SDK and returns CSV string', async () => {
       mockDownloadTemplate.mockResolvedValue('prompt,goal\n"test","test goal"');


### PR DESCRIPTION
## Summary

`airs redteam prompt-sets get` aborted entirely when the upstream `/version-info` endpoint returned 500 (#117) — even though the prompt set itself fetched fine. The unconditional `getPromptSetVersionInfo` call threw and the command's catch killed all output in every format.

## Fix

New service method `getPromptSetWithVersionInfo(uuid)` fetches the set, then attempts version-info and swallows its failure — returning `{ set, versionInfo? }`. The command renders the set detail regardless; pretty mode shows `Version Info: unavailable …`, json/yaml omit it.

## Verified live

Against a real prompt set (`/version-info` still 500s upstream): pretty + json now render the set detail instead of erroring. Example captured, `redteam prompt-sets get` removed from `.missing-allowlist` (20 → 19).

## Tests

3 new service tests (both-succeed, version-info-fails-degrades, primary-failure-propagates). 739 pass. docs:check / docs:build --strict green.

Closes #164.