### PR TITLE
feat(model-security): add --output json|yaml to groups get

### DIFF
--- a/.changeset/feat-ms-groups-get-output.md
+++ b/.changeset/feat-ms-groups-get-output.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": minor
+---
+
+Add `--output json|yaml` to `model-security groups get` (default `pretty`), matching its sibling `groups list`. Previously the command only printed the human layout, so its detail couldn't be piped into scripts.

--- a/docs/cli/model-security/groups.md
+++ b/docs/cli/model-security/groups.md
@@ -57,6 +57,12 @@ airs model-security groups get [options] <uuid>
 
 - `uuid` (required) —
 
+#### Options
+
+| Flag | Required | Default | Description |
+|------|:--------:|---------|-------------|
+| `--output <format>` | No | `pretty` | Output format: pretty, json, yaml |
+
 #### Examples
 
 *Pretty output (default; no --output flag on this command)*

--- a/src/cli/commands/modelsecurity.ts
+++ b/src/cli/commands/modelsecurity.ts
@@ -108,12 +108,14 @@ export function registerModelSecurityCommand(program: Command): void {
   groups
     .command('get <uuid>')
     .description('Get security group details')
-    .action(async (uuid: string) => {
+    .option('--output <format>', 'Output format: pretty, json, yaml', 'pretty')
+    .action(async (uuid: string, opts) => {
       try {
-        renderModelSecurityHeader();
+        const fmt = opts.output as OutputFormat;
+        if (fmt === 'pretty') renderModelSecurityHeader();
         const service = await createService();
         const group = await service.getGroup(uuid);
-        renderGroupDetail(group);
+        renderGroupDetail(group, fmt);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);

--- a/src/cli/renderer/modelsecurity.ts
+++ b/src/cli/renderer/modelsecurity.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { dump as yamlDump } from 'js-yaml';
 import type {
   ModelSecurityEvaluation,
   ModelSecurityFile,
@@ -56,7 +57,18 @@ export function renderGroupList(
 }
 
 /** Render security group detail. */
-export function renderGroupDetail(group: ModelSecurityGroup): void {
+export function renderGroupDetail(
+  group: ModelSecurityGroup,
+  format: OutputFormat = 'pretty',
+): void {
+  if (format === 'json') {
+    console.log(JSON.stringify(group, null, 2));
+    return;
+  }
+  if (format === 'yaml') {
+    console.log(yamlDump(group));
+    return;
+  }
   console.log(chalk.bold('\n  Security Group Detail:\n'));
   console.log(`    UUID:        ${chalk.dim(group.uuid)}`);
   console.log(`    Name:        ${group.name}`);

--- a/tests/unit/cli/modelsecurity-groupdetail-output.spec.ts
+++ b/tests/unit/cli/modelsecurity-groupdetail-output.spec.ts
@@ -1,0 +1,44 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: test payloads use arbitrary SDK shapes
+import { describe, expect, it, vi } from 'vitest';
+import { renderGroupDetail } from '../../../src/cli/renderer/modelsecurity.js';
+
+const group: any = {
+  uuid: '00000000-0000-0000-0000-000000000001',
+  name: 'demo-group',
+  description: 'a demo group',
+  sourceType: 'HUGGING_FACE',
+  state: 'ACTIVE',
+  createdAt: '2026-06-05T00:00:00Z',
+  updatedAt: '2026-06-05T00:00:00Z',
+};
+
+describe('renderGroupDetail --output (#238)', () => {
+  it('json: emits the full group object as parseable JSON', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    renderGroupDetail(group, 'json');
+    const out = spy.mock.calls.map((c) => c[0]).join('\n');
+    spy.mockRestore();
+    const parsed = JSON.parse(out);
+    expect(parsed.uuid).toBe(group.uuid);
+    expect(parsed.name).toBe('demo-group');
+    expect(parsed.state).toBe('ACTIVE');
+  });
+
+  it('yaml: emits the group as YAML', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    renderGroupDetail(group, 'yaml');
+    const out = spy.mock.calls.map((c) => c[0]).join('\n');
+    spy.mockRestore();
+    expect(out).toMatch(/uuid:\s*00000000-0000-0000-0000-000000000001/);
+    expect(out).toMatch(/name:\s*demo-group/);
+  });
+
+  it('pretty (default): unchanged human layout', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    renderGroupDetail(group);
+    const out = spy.mock.calls.map((c) => c[0]).join('\n');
+    spy.mockRestore();
+    expect(out).toContain('Security Group Detail');
+    expect(out).toContain('demo-group');
+  });
+});


### PR DESCRIPTION
## Summary

`model-security groups get` only printed the human-readable layout — no `--output` flag, unlike its sibling `groups list` and the other `get` commands. Its detail couldn't be piped into scripts.

## Fix

`renderGroupDetail(group, format?)` gains a format param: `json` → full object via `JSON.stringify`, `yaml` → `js-yaml` dump, `pretty` (default) unchanged. The `get` command adds `--output <format>` and suppresses the banner in non-pretty modes. `create`/`update` callers are unaffected (default pretty).

## Verified live

`groups get <uuid> --output json|yaml|pretty` all render correctly against the tenant.

## Tests

3 new renderer tests (json parseable, yaml shape, pretty unchanged). 742 pass. docs regenerated (options table now lists `--output`).

Closes #238.

> Note: window-5 triage found `scans get` and `rule-instances get` have the same gap — intentionally out of scope here; can file a follow-up.