### PR TITLE
fix(model-security): groups delete reports real post-delete state

### DIFF
--- a/.changeset/fix-ms-groups-delete-verify-state.md
+++ b/.changeset/fix-ms-groups-delete-verify-state.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/prisma-airs-cli": patch
+---
+
+Fix `model-security groups delete` reporting unconditional success even though the API soft/async-deletes (the group often remains ACTIVE on a subsequent `get`). The command now re-verifies after deleting: it prints "deleted" only when the group is actually gone, otherwise reports that the delete was accepted but the group still reports its current state, pointing the user to re-check.

--- a/docs/developers/api/classes/SdkModelSecurityService.md
+++ b/docs/developers/api/classes/SdkModelSecurityService.md
@@ -33,7 +33,7 @@ Defined in: [src/airs/modelsecurity.ts:146](https://github.com/cdot65/prisma-air
 
 > **addLabels**(`scanUuid`, `labels`): `Promise`\<`void`\>
 
-Defined in: [src/airs/modelsecurity.ts:397](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L397)
+Defined in: [src/airs/modelsecurity.ts:415](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L415)
 
 #### Parameters
 
@@ -81,7 +81,7 @@ Defined in: [src/airs/modelsecurity.ts:182](https://github.com/cdot65/prisma-air
 
 > **createScan**(`request`): `Promise`\<[`ModelSecurityScan`](../interfaces/ModelSecurityScan.md)\>
 
-Defined in: [src/airs/modelsecurity.ts:294](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L294)
+Defined in: [src/airs/modelsecurity.ts:312](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L312)
 
 #### Parameters
 
@@ -121,11 +121,36 @@ Defined in: [src/airs/modelsecurity.ts:202](https://github.com/cdot65/prisma-air
 
 ***
 
+### deleteGroupAndVerify()
+
+> **deleteGroupAndVerify**(`uuid`): `Promise`\<\{ `confirmed`: `boolean`; `state?`: `string`; \}\>
+
+Defined in: [src/airs/modelsecurity.ts:214](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L214)
+
+Delete a group, then verify whether it is actually gone. The API soft/async-deletes
+security groups — a successful DELETE does not immediately remove the resource, so a
+follow-up `get` may still return it as ACTIVE (see prisma-airs-cli#239). The SDK delete
+returns void, so re-reading is the only way to report the real outcome rather than
+claiming an unconditional success. Returns `{ confirmed: true }` when the group no longer
+resolves, or `{ confirmed: false, state }` when it still does.
+
+#### Parameters
+
+##### uuid
+
+`string`
+
+#### Returns
+
+`Promise`\<\{ `confirmed`: `boolean`; `state?`: `string`; \}\>
+
+***
+
 ### deleteLabels()
 
 > **deleteLabels**(`scanUuid`, `keys`): `Promise`\<`void`\>
 
-Defined in: [src/airs/modelsecurity.ts:405](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L405)
+Defined in: [src/airs/modelsecurity.ts:423](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L423)
 
 #### Parameters
 
@@ -151,7 +176,7 @@ Defined in: [src/airs/modelsecurity.ts:405](https://github.com/cdot65/prisma-air
 
 > **getEvaluation**(`uuid`): `Promise`\<[`ModelSecurityEvaluation`](../interfaces/ModelSecurityEvaluation.md)\>
 
-Defined in: [src/airs/modelsecurity.ts:345](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L345)
+Defined in: [src/airs/modelsecurity.ts:363](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L363)
 
 #### Parameters
 
@@ -173,7 +198,7 @@ Defined in: [src/airs/modelsecurity.ts:345](https://github.com/cdot65/prisma-air
 
 > **getEvaluations**(`scanUuid`, `opts?`): `Promise`\<\{ `evaluations`: [`ModelSecurityEvaluation`](../interfaces/ModelSecurityEvaluation.md)[]; `totalItems`: `number`; \}\>
 
-Defined in: [src/airs/modelsecurity.ts:330](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L330)
+Defined in: [src/airs/modelsecurity.ts:348](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L348)
 
 #### Parameters
 
@@ -205,7 +230,7 @@ Defined in: [src/airs/modelsecurity.ts:330](https://github.com/cdot65/prisma-air
 
 > **getFiles**(`scanUuid`, `opts?`): `Promise`\<\{ `files`: [`ModelSecurityFile`](../interfaces/ModelSecurityFile.md)[]; `totalItems`: `number`; \}\>
 
-Defined in: [src/airs/modelsecurity.ts:378](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L378)
+Defined in: [src/airs/modelsecurity.ts:396](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L396)
 
 #### Parameters
 
@@ -253,7 +278,7 @@ Defined in: [src/airs/modelsecurity.ts:177](https://github.com/cdot65/prisma-air
 
 > **getLabelKeys**(`opts?`): `Promise`\<\{ `keys`: `string`[]; `totalItems`: `number`; \}\>
 
-Defined in: [src/airs/modelsecurity.ts:409](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L409)
+Defined in: [src/airs/modelsecurity.ts:427](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L427)
 
 #### Parameters
 
@@ -281,7 +306,7 @@ Defined in: [src/airs/modelsecurity.ts:409](https://github.com/cdot65/prisma-air
 
 > **getLabelValues**(`key`, `opts?`): `Promise`\<\{ `totalItems`: `number`; `values`: `string`[]; \}\>
 
-Defined in: [src/airs/modelsecurity.ts:424](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L424)
+Defined in: [src/airs/modelsecurity.ts:442](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L442)
 
 #### Parameters
 
@@ -313,7 +338,7 @@ Defined in: [src/airs/modelsecurity.ts:424](https://github.com/cdot65/prisma-air
 
 > **getPyPIAuth**(): `Promise`\<[`ModelSecurityPyPIAuth`](../interfaces/ModelSecurityPyPIAuth.md)\>
 
-Defined in: [src/airs/modelsecurity.ts:443](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L443)
+Defined in: [src/airs/modelsecurity.ts:461](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L461)
 
 #### Returns
 
@@ -329,7 +354,7 @@ Defined in: [src/airs/modelsecurity.ts:443](https://github.com/cdot65/prisma-air
 
 > **getRule**(`uuid`): `Promise`\<[`ModelSecurityRule`](../interfaces/ModelSecurityRule.md)\>
 
-Defined in: [src/airs/modelsecurity.ts:285](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L285)
+Defined in: [src/airs/modelsecurity.ts:303](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L303)
 
 #### Parameters
 
@@ -351,7 +376,7 @@ Defined in: [src/airs/modelsecurity.ts:285](https://github.com/cdot65/prisma-air
 
 > **getRuleInstance**(`groupUuid`, `instanceUuid`): `Promise`\<[`ModelSecurityRuleInstance`](../interfaces/ModelSecurityRuleInstance.md)\>
 
-Defined in: [src/airs/modelsecurity.ts:234](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L234)
+Defined in: [src/airs/modelsecurity.ts:252](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L252)
 
 #### Parameters
 
@@ -377,7 +402,7 @@ Defined in: [src/airs/modelsecurity.ts:234](https://github.com/cdot65/prisma-air
 
 > **getScan**(`uuid`): `Promise`\<[`ModelSecurityScan`](../interfaces/ModelSecurityScan.md)\>
 
-Defined in: [src/airs/modelsecurity.ts:321](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L321)
+Defined in: [src/airs/modelsecurity.ts:339](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L339)
 
 #### Parameters
 
@@ -399,7 +424,7 @@ Defined in: [src/airs/modelsecurity.ts:321](https://github.com/cdot65/prisma-air
 
 > **getViolation**(`uuid`): `Promise`\<[`ModelSecurityViolation`](../interfaces/ModelSecurityViolation.md)\>
 
-Defined in: [src/airs/modelsecurity.ts:369](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L369)
+Defined in: [src/airs/modelsecurity.ts:387](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L387)
 
 #### Parameters
 
@@ -421,7 +446,7 @@ Defined in: [src/airs/modelsecurity.ts:369](https://github.com/cdot65/prisma-air
 
 > **getViolations**(`scanUuid`, `opts?`): `Promise`\<\{ `totalItems`: `number`; `violations`: [`ModelSecurityViolation`](../interfaces/ModelSecurityViolation.md)[]; \}\>
 
-Defined in: [src/airs/modelsecurity.ts:354](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L354)
+Defined in: [src/airs/modelsecurity.ts:372](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L372)
 
 #### Parameters
 
@@ -475,7 +500,7 @@ Defined in: [src/airs/modelsecurity.ts:154](https://github.com/cdot65/prisma-air
 
 > **listRuleInstances**(`groupUuid`, `opts?`): `Promise`\<\{ `ruleInstances`: [`ModelSecurityRuleInstance`](../interfaces/ModelSecurityRuleInstance.md)[]; `totalItems`: `number`; \}\>
 
-Defined in: [src/airs/modelsecurity.ts:210](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L210)
+Defined in: [src/airs/modelsecurity.ts:228](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L228)
 
 #### Parameters
 
@@ -501,7 +526,7 @@ Defined in: [src/airs/modelsecurity.ts:210](https://github.com/cdot65/prisma-air
 
 > **listRules**(`opts?`): `Promise`\<\{ `rules`: [`ModelSecurityRule`](../interfaces/ModelSecurityRule.md)[]; `totalItems`: `number`; \}\>
 
-Defined in: [src/airs/modelsecurity.ts:265](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L265)
+Defined in: [src/airs/modelsecurity.ts:283](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L283)
 
 #### Parameters
 
@@ -523,7 +548,7 @@ Defined in: [src/airs/modelsecurity.ts:265](https://github.com/cdot65/prisma-air
 
 > **listScans**(`opts?`): `Promise`\<\{ `scans`: [`ModelSecurityScan`](../interfaces/ModelSecurityScan.md)[]; `totalItems`: `number`; \}\>
 
-Defined in: [src/airs/modelsecurity.ts:299](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L299)
+Defined in: [src/airs/modelsecurity.ts:317](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L317)
 
 #### Parameters
 
@@ -545,7 +570,7 @@ Defined in: [src/airs/modelsecurity.ts:299](https://github.com/cdot65/prisma-air
 
 > **setLabels**(`scanUuid`, `labels`): `Promise`\<`void`\>
 
-Defined in: [src/airs/modelsecurity.ts:401](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L401)
+Defined in: [src/airs/modelsecurity.ts:419](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L419)
 
 #### Parameters
 
@@ -597,7 +622,7 @@ Defined in: [src/airs/modelsecurity.ts:194](https://github.com/cdot65/prisma-air
 
 > **updateRuleInstance**(`groupUuid`, `instanceUuid`, `request`): `Promise`\<[`ModelSecurityRuleInstance`](../interfaces/ModelSecurityRuleInstance.md)\>
 
-Defined in: [src/airs/modelsecurity.ts:242](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L242)
+Defined in: [src/airs/modelsecurity.ts:260](https://github.com/cdot65/prisma-airs-cli/blob/main/src/airs/modelsecurity.ts#L260)
 
 #### Parameters
 

--- a/src/airs/modelsecurity.ts
+++ b/src/airs/modelsecurity.ts
@@ -203,6 +203,24 @@ export class SdkModelSecurityService implements ModelSecurityService {
     await this.client.securityGroups.delete(uuid);
   }
 
+  /**
+   * Delete a group, then verify whether it is actually gone. The API soft/async-deletes
+   * security groups — a successful DELETE does not immediately remove the resource, so a
+   * follow-up `get` may still return it as ACTIVE (see prisma-airs-cli#239). The SDK delete
+   * returns void, so re-reading is the only way to report the real outcome rather than
+   * claiming an unconditional success. Returns `{ confirmed: true }` when the group no longer
+   * resolves, or `{ confirmed: false, state }` when it still does.
+   */
+  async deleteGroupAndVerify(uuid: string): Promise<{ confirmed: boolean; state?: string }> {
+    await this.deleteGroup(uuid);
+    try {
+      const group = await this.getGroup(uuid);
+      return { confirmed: false, state: group.state };
+    } catch {
+      return { confirmed: true };
+    }
+  }
+
   // -----------------------------------------------------------------------
   // Rule Instances
   // -----------------------------------------------------------------------

--- a/src/cli/commands/modelsecurity.ts
+++ b/src/cli/commands/modelsecurity.ts
@@ -173,8 +173,15 @@ export function registerModelSecurityCommand(program: Command): void {
       try {
         renderModelSecurityHeader();
         const service = await createService();
-        await service.deleteGroup(uuid);
-        console.log(`  Group ${uuid} deleted.\n`);
+        const { confirmed, state } = await service.deleteGroupAndVerify(uuid);
+        if (confirmed) {
+          console.log(`  Group ${uuid} deleted.\n`);
+        } else {
+          console.log(
+            `  Delete request accepted, but group ${uuid} still reports state '${state}'.\n` +
+              `  Deletion is asynchronous (soft-delete) — re-check with \`model-security groups get ${uuid}\`.\n`,
+          );
+        }
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);

--- a/tests/unit/airs/modelsecurity.spec.ts
+++ b/tests/unit/airs/modelsecurity.spec.ts
@@ -258,6 +258,35 @@ describe('SdkModelSecurityService', () => {
     });
   });
 
+  describe('deleteGroupAndVerify', () => {
+    it('confirmed when the group is gone after delete (get 404s)', async () => {
+      mockGroupsDelete.mockResolvedValue(undefined);
+      mockGroupsGet.mockRejectedValue(new Error('AISEC_CLIENT_SIDE_ERROR:not found'));
+      const result = await service.deleteGroupAndVerify('g-1');
+      expect(mockGroupsDelete).toHaveBeenCalledWith('g-1');
+      expect(result).toEqual({ confirmed: true });
+    });
+
+    it('NOT confirmed when the group still resolves (soft/async delete) — reports its state', async () => {
+      mockGroupsDelete.mockResolvedValue(undefined);
+      mockGroupsGet.mockResolvedValue({
+        uuid: 'g-1',
+        name: 'still-here',
+        state: 'ACTIVE',
+        sourceType: 'LOCAL',
+        createdAt: 'x',
+        updatedAt: 'y',
+      });
+      const result = await service.deleteGroupAndVerify('g-1');
+      expect(result).toEqual({ confirmed: false, state: 'ACTIVE' });
+    });
+
+    it('propagates a failure of the delete call itself', async () => {
+      mockGroupsDelete.mockRejectedValue(new Error('boom'));
+      await expect(service.deleteGroupAndVerify('g-1')).rejects.toThrow('boom');
+    });
+  });
+
   // -----------------------------------------------------------------------
   // Rule Instances
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`model-security groups delete` printed `Group <uuid> deleted.` unconditionally, but the API soft/async-deletes security groups — a follow-up `groups get` often still returns the group as `ACTIVE`. The success message was misleading (#239).

## Fix

New service method `deleteGroupAndVerify(uuid)` deletes, then re-reads (the SDK `delete` returns `void`, so re-reading is the only way to know the real outcome):
- group no longer resolves → `{ confirmed: true }` → command prints "deleted"
- group still resolves → `{ confirmed: false, state }` → command reports the delete was *accepted* but the group still reports `state`, and points the user to `groups get` to re-check

## Tests

3 new service tests (confirmed-gone, still-present-soft-delete, delete-error-propagates). 745 pass. typecheck / docs:build green.

> Not exercised against a live group — delete is destructive and there's no scratch tenant (consistent with the #126 safety-defer policy). Logic is covered by unit tests.

Root cause: upstream soft/async-delete (no transitional state) surfaced honestly by the CLI. Closes #239.